### PR TITLE
Fix createNote function URL construction: use plural resource names and avoid duplicate /api/v4

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -583,9 +583,9 @@ async function createNote(
 ): Promise<any> {
   // ⚙️ 응답 타입은 GitLab API 문서에 따라 조정 가능
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
-    )}/${noteableType}/${noteableIid}/notes`
+    )}/${noteableType}s/${noteableIid}/notes` // Using plural form (issues/merge_requests) as per GitLab API documentation
   );
 
   const response = await fetch(url.toString(), {


### PR DESCRIPTION
   This pull request fixes two issues in the createNote function:

   1. Uses plural form for resource types (issues, merge_requests) in the URL path
   2. Removes duplicate /api/v4 in URL construction, which caused 404 errors

   These changes align with the GitLab API documentation and fix 404 errors when adding notes to issues or merge requests.

   The fix has been tested and confirmed to work with both numeric project IDs and project path formats, and for both issues and merge requests.