### PR TITLE
Fix URL construction with smart API URL normalization

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -345,8 +345,11 @@ async function updateMergeRequest(projectId, mergeRequestIid, options) {
 async function createNote(projectId, noteableType, // 'issue' 또는 'merge_request' 타입 명시
 noteableIid, body) {
     // ⚙️ 응답 타입은 GitLab API 문서에 따라 조정 가능
+    // Don't add /api/v4 again since it's already included in GITLAB_API_URL
     const url = new URL(`${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/${noteableType}s/${noteableIid}/notes` // Using plural form (issues/merge_requests) as per GitLab API documentation
     );
+    // Add some debug logging
+    console.log(`DEBUG - createNote function called`);
     console.log(`DEBUG - createNote - URL: ${url.toString()}`);
     console.log(`DEBUG - createNote - projectId: ${projectId}, noteableType: ${noteableType}, noteableIid: ${noteableIid}`);
     console.log(`DEBUG - createNote - GITLAB_API_URL: ${GITLAB_API_URL}`);

--- a/build/index.js
+++ b/build/index.js
@@ -541,10 +541,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 try {
                     const args = CreateNoteSchema.parse(request.params.arguments);
                     const { project_id, noteable_type, noteable_iid, body } = args;
-                    const note = await createNote(project_id, noteable_type, noteable_iid, body);
-                    return {
-                        content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+                    // Debug info that will be included in the response
+                    const debugInfo = {
+                        gitlab_api_url: GITLAB_API_URL,
+                        project_id,
+                        noteable_type,
+                        noteable_iid,
+                        constructed_url: `${GITLAB_API_URL}/projects/${encodeURIComponent(project_id)}/${noteable_type}s/${noteable_iid}/notes`
                     };
+                    try {
+                        const note = await createNote(project_id, noteable_type, noteable_iid, body);
+                        return {
+                            content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+                        };
+                    }
+                    catch (error) {
+                        // Include debug info in the error message
+                        throw new Error(`Error with debug info: ${JSON.stringify(debugInfo)}\n${error instanceof Error ? error.message : String(error)}`);
+                    }
                 }
                 catch (error) {
                     if (error instanceof z.ZodError) {

--- a/build/index.js
+++ b/build/index.js
@@ -8,7 +8,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { GitLabForkSchema, GitLabReferenceSchema, GitLabRepositorySchema, GitLabIssueSchema, GitLabMergeRequestSchema, GitLabContentSchema, GitLabCreateUpdateFileResponseSchema, GitLabSearchResponseSchema, GitLabTreeSchema, GitLabCommitSchema, CreateOrUpdateFileSchema, SearchRepositoriesSchema, CreateRepositorySchema, GetFileContentsSchema, PushFilesSchema, CreateIssueSchema, CreateMergeRequestSchema, ForkRepositorySchema, CreateBranchSchema, GitLabMergeRequestDiffSchema, GetMergeRequestSchema, GetMergeRequestDiffsSchema, UpdateMergeRequestSchema, CreateNoteSchema, } from "./schemas.js";
 const server = new Server({
     name: "better-gitlab-mcp-server",
-    version: "0.0.1",
+    version: "1.0.7-fix",
 }, {
     capabilities: {
         tools: {},
@@ -345,7 +345,11 @@ async function updateMergeRequest(projectId, mergeRequestIid, options) {
 async function createNote(projectId, noteableType, // 'issue' 또는 'merge_request' 타입 명시
 noteableIid, body) {
     // ⚙️ 응답 타입은 GitLab API 문서에 따라 조정 가능
-    const url = new URL(`${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/${noteableType}/${noteableIid}/notes`);
+    const url = new URL(`${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/${noteableType}s/${noteableIid}/notes` // Using plural form (issues/merge_requests) as per GitLab API documentation
+    );
+    console.log(`DEBUG - createNote - URL: ${url.toString()}`);
+    console.log(`DEBUG - createNote - projectId: ${projectId}, noteableType: ${noteableType}, noteableIid: ${noteableIid}`);
+    console.log(`DEBUG - createNote - GITLAB_API_URL: ${GITLAB_API_URL}`);
     const response = await fetch(url.toString(), {
         method: "POST",
         headers: DEFAULT_HEADERS,

--- a/index.ts
+++ b/index.ts
@@ -588,6 +588,10 @@ async function createNote(
     )}/${noteableType}s/${noteableIid}/notes` // Using plural form (issues/merge_requests) as per GitLab API documentation
   );
 
+  console.log(`DEBUG - createNote - URL: ${url.toString()}`);
+  console.log(`DEBUG - createNote - projectId: ${projectId}, noteableType: ${noteableType}, noteableIid: ${noteableIid}`);
+  console.log(`DEBUG - createNote - GITLAB_API_URL: ${GITLAB_API_URL}`);
+
   const response = await fetch(url.toString(), {
     method: "POST",
     headers: DEFAULT_HEADERS,

--- a/index.ts
+++ b/index.ts
@@ -582,12 +582,15 @@ async function createNote(
   body: string
 ): Promise<any> {
   // ⚙️ 응답 타입은 GitLab API 문서에 따라 조정 가능
+  // Don't add /api/v4 again since it's already included in GITLAB_API_URL
   const url = new URL(
     `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/${noteableType}s/${noteableIid}/notes` // Using plural form (issues/merge_requests) as per GitLab API documentation
   );
 
+  // Add some debug logging
+  console.log(`DEBUG - createNote function called`);
   console.log(`DEBUG - createNote - URL: ${url.toString()}`);
   console.log(`DEBUG - createNote - projectId: ${projectId}, noteableType: ${noteableType}, noteableIid: ${noteableIid}`);
   console.log(`DEBUG - createNote - GITLAB_API_URL: ${GITLAB_API_URL}`);

--- a/index.ts
+++ b/index.ts
@@ -583,6 +583,9 @@ async function createNote(
 ): Promise<any> {
   // ⚙️ 응답 타입은 GitLab API 문서에 따라 조정 가능
   // Don't add /api/v4 again since it's already included in GITLAB_API_URL
+  console.error("DEBUG - createNote - GITLAB_API_URL from env: " + process.env.GITLAB_API_URL);
+  console.error("DEBUG - createNote - GITLAB_API_URL in code: " + GITLAB_API_URL);
+
   const url = new URL(
     `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
@@ -590,19 +593,31 @@ async function createNote(
   );
 
   // Add some debug logging
-  console.log(`DEBUG - createNote function called`);
-  console.log(`DEBUG - createNote - URL: ${url.toString()}`);
-  console.log(`DEBUG - createNote - projectId: ${projectId}, noteableType: ${noteableType}, noteableIid: ${noteableIid}`);
-  console.log(`DEBUG - createNote - GITLAB_API_URL: ${GITLAB_API_URL}`);
+  console.error("DEBUG - createNote function called");
+  console.error(`DEBUG - createNote - URL: ${url.toString()}`);
+  console.error(`DEBUG - createNote - projectId: ${projectId}, noteableType: ${noteableType}, noteableIid: ${noteableIid}`);
 
-  const response = await fetch(url.toString(), {
-    method: "POST",
-    headers: DEFAULT_HEADERS,
-    body: JSON.stringify({ body }),
-  });
+  try {
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: DEFAULT_HEADERS,
+      body: JSON.stringify({ body }),
+    });
 
-  await handleGitLabError(response);
-  return await response.json(); // ⚙️ 응답 타입은 GitLab API 문서에 따라 조정 가능, 필요하면 스키마 정의
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`DEBUG - createNote - Error response: ${response.status} ${response.statusText}`);
+      console.error(`DEBUG - createNote - Error body: ${errorText}`);
+      throw new Error(
+        `GitLab API error: ${response.status} ${response.statusText}\n${errorText}`
+      );
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error(`DEBUG - createNote - Exception: ${error instanceof Error ? error.message : String(error)}`);
+    throw error;
+  }
 }
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -892,6 +907,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function runServer() {
+  console.error("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+  console.error("!!! RUNNING VERSION 1.0.7-fix WITH URL DEBUGGING FIX !!!");
+  console.error("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("GitLab MCP Server running on stdio");

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,8 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
+import fs from "fs";
+import path from "path";
 import {
   GitLabForkSchema,
   GitLabReferenceSchema,
@@ -54,10 +56,24 @@ import {
   CreateNoteSchema,
 } from "./schemas.js";
 
+// Read version from package.json
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJsonPath = path.resolve(__dirname, '../package.json');
+let SERVER_VERSION = "unknown";
+try {
+  if (fs.existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    SERVER_VERSION = packageJson.version || SERVER_VERSION;
+  }
+} catch (error) {
+  console.error("Warning: Could not read version from package.json:", error);
+}
+
 const server = new Server(
   {
     name: "better-gitlab-mcp-server",
-    version: "1.0.7-fix",
+    version: SERVER_VERSION,
   },
   {
     capabilities: {
@@ -67,8 +83,34 @@ const server = new Server(
 );
 
 const GITLAB_PERSONAL_ACCESS_TOKEN = process.env.GITLAB_PERSONAL_ACCESS_TOKEN;
-const GITLAB_API_URL =
-  process.env.GITLAB_API_URL || "https://gitlab.com/api/v4";
+
+// Smart URL handling for GitLab API
+function normalizeGitLabApiUrl(url?: string): string {
+  if (!url) {
+    return "https://gitlab.com/api/v4";
+  }
+
+  // Remove trailing slash if present
+  let normalizedUrl = url.endsWith('/') ? url.slice(0, -1) : url;
+
+  // Check if URL already has /api/v4
+  if (!normalizedUrl.endsWith('/api/v4') && !normalizedUrl.endsWith('/api/v4/')) {
+    // Append /api/v4 if not already present
+    normalizedUrl = `${normalizedUrl}/api/v4`;
+  }
+
+  return normalizedUrl;
+}
+
+// Use the normalizeGitLabApiUrl function to handle various URL formats
+const GITLAB_API_URL = normalizeGitLabApiUrl(process.env.GITLAB_API_URL || "");
+
+// Add debug logging for API URL construction
+console.log("=== MCP Server Configuration ===");
+console.log(`GITLAB_API_URL = "${GITLAB_API_URL}"`);
+console.log(`Example project API URL = "${GITLAB_API_URL}/projects/123"`);
+console.log(`Example Notes API URL = "${GITLAB_API_URL}/projects/123/issues/1/notes"`);
+console.log("===============================");
 
 if (!GITLAB_PERSONAL_ACCESS_TOKEN) {
   console.error("GITLAB_PERSONAL_ACCESS_TOKEN environment variable is not set");
@@ -101,7 +143,7 @@ async function forkProject(
 ): Promise<GitLabFork> {
   // API 엔드포인트 URL 생성
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(projectId)}/fork`
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/fork`
   );
 
   if (namespace) {
@@ -129,7 +171,7 @@ async function createBranch(
   options: z.infer<typeof CreateBranchOptionsSchema>
 ): Promise<GitLabReference> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/repository/branches`
   );
@@ -150,7 +192,7 @@ async function createBranch(
 // 프로젝트의 기본 브랜치 조회
 async function getDefaultBranchRef(projectId: string): Promise<string> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(projectId)}`
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}`
   );
 
   const response = await fetch(url.toString(), {
@@ -176,7 +218,7 @@ async function getFileContents(
   }
 
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/repository/files/${encodedPath}`
   );
@@ -213,7 +255,7 @@ async function createIssue(
   options: z.infer<typeof CreateIssueOptionsSchema>
 ): Promise<GitLabIssue> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(projectId)}/issues`
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/issues`
   );
 
   const response = await fetch(url.toString(), {
@@ -244,7 +286,7 @@ async function createMergeRequest(
   options: z.infer<typeof CreateMergeRequestOptionsSchema>
 ): Promise<GitLabMergeRequest> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/merge_requests`
   );
@@ -292,7 +334,7 @@ async function createOrUpdateFile(
 ): Promise<GitLabCreateUpdateFileResponse> {
   const encodedPath = encodeURIComponent(filePath);
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/repository/files/${encodedPath}`
   );
@@ -344,7 +386,7 @@ async function createTree(
   ref?: string
 ): Promise<GitLabTree> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/repository/tree`
   );
@@ -392,7 +434,7 @@ async function createCommit(
   actions: FileOperation[]
 ): Promise<GitLabCommit> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/repository/commits`
   );
@@ -437,7 +479,7 @@ async function searchProjects(
   page: number = 1,
   perPage: number = 20
 ): Promise<GitLabSearchResponse> {
-  const url = new URL(`${GITLAB_API_URL}/api/v4/projects`);
+  const url = new URL(`${GITLAB_API_URL}/projects`);
   url.searchParams.append("search", query);
   url.searchParams.append("page", page.toString());
   url.searchParams.append("per_page", perPage.toString());
@@ -477,7 +519,7 @@ async function searchProjects(
 async function createRepository(
   options: z.infer<typeof CreateRepositoryOptionsSchema>
 ): Promise<GitLabRepository> {
-  const response = await fetch(`${GITLAB_API_URL}/api/v4/projects`, {
+  const response = await fetch(`${GITLAB_API_URL}/projects`, {
     method: "POST",
     headers: {
       Accept: "application/json",
@@ -511,7 +553,7 @@ async function getMergeRequest(
   mergeRequestIid: number
 ): Promise<GitLabMergeRequest> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/merge_requests/${mergeRequestIid}`
   );
@@ -531,7 +573,7 @@ async function getMergeRequestDiffs(
   view?: "inline" | "parallel"
 ): Promise<GitLabMergeRequestDiff[]> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/merge_requests/${mergeRequestIid}/changes`
   );
@@ -559,7 +601,7 @@ async function updateMergeRequest(
   >
 ): Promise<GitLabMergeRequest> {
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/merge_requests/${mergeRequestIid}`
   );
@@ -582,42 +624,26 @@ async function createNote(
   body: string
 ): Promise<any> {
   // ⚙️ 응답 타입은 GitLab API 문서에 따라 조정 가능
-  // Don't add /api/v4 again since it's already included in GITLAB_API_URL
-  console.error("DEBUG - createNote - GITLAB_API_URL from env: " + process.env.GITLAB_API_URL);
-  console.error("DEBUG - createNote - GITLAB_API_URL in code: " + GITLAB_API_URL);
-
   const url = new URL(
     `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/${noteableType}s/${noteableIid}/notes` // Using plural form (issues/merge_requests) as per GitLab API documentation
   );
 
-  // Add some debug logging
-  console.error("DEBUG - createNote function called");
-  console.error(`DEBUG - createNote - URL: ${url.toString()}`);
-  console.error(`DEBUG - createNote - projectId: ${projectId}, noteableType: ${noteableType}, noteableIid: ${noteableIid}`);
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: DEFAULT_HEADERS,
+    body: JSON.stringify({ body }),
+  });
 
-  try {
-    const response = await fetch(url.toString(), {
-      method: "POST",
-      headers: DEFAULT_HEADERS,
-      body: JSON.stringify({ body }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(`DEBUG - createNote - Error response: ${response.status} ${response.statusText}`);
-      console.error(`DEBUG - createNote - Error body: ${errorText}`);
-      throw new Error(
-        `GitLab API error: ${response.status} ${response.statusText}\n${errorText}`
-      );
-    }
-
-    return await response.json();
-  } catch (error) {
-    console.error(`DEBUG - createNote - Exception: ${error instanceof Error ? error.message : String(error)}`);
-    throw error;
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `GitLab API error: ${response.status} ${response.statusText}\n${errorText}`
+    );
   }
+
+  return await response.json();
 }
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -850,45 +876,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "create_note": {
-        try {
-          const args = CreateNoteSchema.parse(request.params.arguments);
-          const { project_id, noteable_type, noteable_iid, body } = args;
+        const args = CreateNoteSchema.parse(request.params.arguments);
+        const { project_id, noteable_type, noteable_iid, body } = args;
 
-          // Debug info that will be included in the response
-          const debugInfo = {
-            gitlab_api_url: GITLAB_API_URL,
-            project_id,
-            noteable_type,
-            noteable_iid,
-            constructed_url: `${GITLAB_API_URL}/projects/${encodeURIComponent(project_id)}/${noteable_type}s/${noteable_iid}/notes`
-          };
-
-          try {
-            const note = await createNote(
-              project_id,
-              noteable_type,
-              noteable_iid,
-              body
-            );
-            return {
-              content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
-            };
-          } catch (error) {
-            // Include debug info in the error message
-            throw new Error(
-              `Error with debug info: ${JSON.stringify(debugInfo)}\n${error instanceof Error ? error.message : String(error)}`
-            );
-          }
-        } catch (error) {
-          if (error instanceof z.ZodError) {
-            throw new Error(
-              `Invalid arguments: ${error.errors
-                .map((e) => `${e.path.join(".")}: ${e.message}`)
-                .join(", ")}`
-            );
-          }
-          throw error;
-        }
+        const note = await createNote(
+          project_id,
+          noteable_type,
+          noteable_iid,
+          body
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+        };
       }
 
       default:
@@ -907,13 +906,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function runServer() {
-  console.error("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-  console.error("!!! RUNNING VERSION 1.0.7-fix WITH URL DEBUGGING FIX !!!");
-  console.error("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+  try {
+    console.error("========================");
+    console.error(`GitLab MCP Server v${SERVER_VERSION}`);
+    console.error(`API URL: ${GITLAB_API_URL}`);
+    console.error("========================");
 
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error("GitLab MCP Server running on stdio");
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error("GitLab MCP Server running on stdio");
+  } catch (error) {
+    console.error("Error initializing server:", error);
+    process.exit(1);
+  }
 }
 
 runServer().catch((error) => {

--- a/index.ts
+++ b/index.ts
@@ -583,7 +583,7 @@ async function createNote(
 ): Promise<any> {
   // ⚙️ 응답 타입은 GitLab API 문서에 따라 조정 가능
   const url = new URL(
-    `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(
       projectId
     )}/${noteableType}s/${noteableIid}/notes` // Using plural form (issues/merge_requests) as per GitLab API documentation
   );

--- a/index.ts
+++ b/index.ts
@@ -57,7 +57,7 @@ import {
 const server = new Server(
   {
     name: "better-gitlab-mcp-server",
-    version: "0.0.1",
+    version: "1.0.7-fix",
   },
   {
     capabilities: {

--- a/index.ts
+++ b/index.ts
@@ -585,7 +585,7 @@ async function createNote(
   const url = new URL(
     `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
       projectId
-    )}/${noteableType}/${noteableIid}/notes`
+    )}/${noteableType}s/${noteableIid}/notes` // Using plural form (issues/merge_requests) as per GitLab API documentation
   );
 
   const response = await fetch(url.toString(), {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zereight/mcp-gitlab",
-  "version": "1.0.6",
+  "version": "1.0.7-fix",
   "description": "MCP server for using the GitLab API",
   "license": "MIT",
   "author": "zereight",
@@ -27,6 +27,8 @@
     "zod-to-json-schema": "^3.23.5"
   },
   "devDependencies": {
-    "typescript": "^5.6.2"
+    "@types/node": "^22.13.10",
+    "typescript": "^5.8.2",
+    "zod": "3.21.4"
   }
 }

--- a/test-note.ts
+++ b/test-note.ts
@@ -1,0 +1,66 @@
+/**
+ * This test file verifies that the createNote function works correctly
+ * with the fixed endpoint URL construction that uses plural resource names
+ * (issues instead of issue, merge_requests instead of merge_request).
+ */
+
+import fetch from "node-fetch";
+
+// GitLab API configuration (replace with actual values when testing)
+const GITLAB_API_URL = process.env.GITLAB_API_URL || "https://gitlab.com";
+const GITLAB_PERSONAL_ACCESS_TOKEN = process.env.GITLAB_TOKEN || "";
+const PROJECT_ID = process.env.PROJECT_ID || "your/project";
+const ISSUE_IID = Number(process.env.ISSUE_IID || "1");
+
+async function testCreateIssueNote() {
+  try {
+    // Using plural form "issues" in the URL
+    const url = new URL(
+      `${GITLAB_API_URL}/api/v4/projects/${encodeURIComponent(
+        PROJECT_ID
+      )}/issues/${ISSUE_IID}/notes`
+    );
+
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+      },
+      body: JSON.stringify({ body: "Test note from API - with plural endpoint" }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `GitLab API error: ${response.status} ${response.statusText}\n${errorBody}`
+      );
+    }
+
+    const data = await response.json();
+    console.log("Successfully created note:");
+    console.log(JSON.stringify(data, null, 2));
+    return true;
+  } catch (error) {
+    console.error("Error creating note:", error);
+    return false;
+  }
+}
+
+// Only run the test if executed directly
+if (require.main === module) {
+  console.log("Testing note creation with plural 'issues' endpoint...");
+  testCreateIssueNote().then(success => {
+    if (success) {
+      console.log("✅ Test successful!");
+      process.exit(0);
+    } else {
+      console.log("❌ Test failed!");
+      process.exit(1);
+    }
+  });
+}
+
+// Export for use in other tests
+export { testCreateIssueNote };


### PR DESCRIPTION
This PR fixes the issues described in #9.\n\nChanges in this PR:\n\n1. Added a robust normalizeGitLabApiUrl function to handle various URL formats\n2. Normalizing API URLs to have /api/v4 exactly once\n3. Ensuring all URL constructions use consistent paths\n4. Added version reading from package.json\n\nThis supersedes PR #7 with a more comprehensive fix including proper version handling from package.json. The fix has been tested with both numeric project IDs and path formats for issues and merge requests.