### PR TITLE
Fix GitLab API fork repository parameter handling

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -729,11 +729,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     switch (request.params.name) {
       case "fork_repository": {
-        const args = ForkRepositorySchema.parse(request.params.arguments);
-        const fork = await forkProject(args.project_id, args.namespace);
-        return {
-          content: [{ type: "text", text: JSON.stringify(fork, null, 2) }],
-        };
+        const forkArgs = ForkRepositorySchema.parse(request.params.arguments);
+        try {
+          const forkedProject = await forkProject(forkArgs.project_id, forkArgs.namespace);
+          return {
+            content: [{ type: "text", text: JSON.stringify(forkedProject, null, 2) }],
+          };
+        } catch (forkError) {
+          console.error("Error forking repository:", forkError);
+          let forkErrorMessage = "Failed to fork repository";
+          if (forkError instanceof Error) {
+            forkErrorMessage = `${forkErrorMessage}: ${forkError.message}`;
+          }
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: forkErrorMessage }, null, 2) }],
+          };
+        }
       }
 
       case "create_branch": {

--- a/schemas.ts
+++ b/schemas.ts
@@ -157,12 +157,12 @@ export const GitLabForkParentSchema = z.object({
     username: z.string(), // Changed from login to match GitLab API
     id: z.number(),
     avatar_url: z.string(),
-  }),
+  }).optional(), // Made optional to handle cases where GitLab API doesn't include it
   web_url: z.string(), // Changed from html_url to match GitLab API
 });
 
 export const GitLabForkSchema = GitLabRepositorySchema.extend({
-  forked_from_project: GitLabForkParentSchema, // Changed from parent to match GitLab API
+  forked_from_project: GitLabForkParentSchema.optional(), // Made optional to handle cases where GitLab API doesn't include it
 });
 
 // Issue related schemas


### PR DESCRIPTION
## Summary

This PR addresses issues reported in #12 by fixing the parameter handling in the fork_repository function.

## Changes

- Made the owner property optional in GitLabForkParentSchema
- Made the forked_from_project property optional in GitLabForkSchema
- Improved error handling in the fork_repository MCP handler

## Issue Reference

Resolves #12

## Testing

Manually tested and verified that the fork_repository function now works correctly with the GitLab API, even when optional fields are missing from the response.
