### PR TITLE
Add GitLab Projects API support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -894,11 +894,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     switch (request.params.name) {
       case "fork_repository": {
-        const args = ForkRepositorySchema.parse(request.params.arguments);
-        const fork = await forkProject(args.project_id, args.namespace);
-        return {
-          content: [{ type: "text", text: JSON.stringify(fork, null, 2) }],
-        };
+        const forkArgs = ForkRepositorySchema.parse(request.params.arguments);
+        try {
+          const forkedProject = await forkProject(forkArgs.project_id, forkArgs.namespace);
+          return {
+            content: [{ type: "text", text: JSON.stringify(forkedProject, null, 2) }],
+          };
+        } catch (forkError) {
+          console.error("Error forking repository:", forkError);
+          let forkErrorMessage = "Failed to fork repository";
+          if (forkError instanceof Error) {
+            forkErrorMessage = `${forkErrorMessage}: ${forkError.message}`;
+          }
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: forkErrorMessage }, null, 2) }],
+          };
+        }
       }
 
       case "create_branch": {

--- a/schemas.ts
+++ b/schemas.ts
@@ -58,6 +58,48 @@ export const GitLabRepositorySchema = z.object({
   created_at: z.string().optional(),
   last_activity_at: z.string().optional(),
   default_branch: z.string().optional(),
+  namespace: z.object({
+    id: z.number(),
+    name: z.string(),
+    path: z.string(),
+    kind: z.string(),
+    full_path: z.string(),
+    avatar_url: z.string().nullable().optional(),
+    web_url: z.string().optional(),
+  }).optional(),
+  readme_url: z.string().optional().nullable(),
+  topics: z.array(z.string()).optional(),
+  tag_list: z.array(z.string()).optional(), // deprecated but still present
+  open_issues_count: z.number().optional(),
+  archived: z.boolean().optional(),
+  forks_count: z.number().optional(),
+  star_count: z.number().optional(),
+  permissions: z.object({
+    project_access: z.object({
+      access_level: z.number(),
+      notification_level: z.number().optional(),
+    }).optional().nullable(),
+    group_access: z.object({
+      access_level: z.number(),
+      notification_level: z.number().optional(),
+    }).optional().nullable(),
+  }).optional(),
+  container_registry_enabled: z.boolean().optional(),
+  container_registry_access_level: z.string().optional(),
+  issues_enabled: z.boolean().optional(),
+  merge_requests_enabled: z.boolean().optional(),
+  wiki_enabled: z.boolean().optional(),
+  jobs_enabled: z.boolean().optional(),
+  snippets_enabled: z.boolean().optional(),
+  can_create_merge_request_in: z.boolean().optional(),
+  resolve_outdated_diff_discussions: z.boolean().optional(),
+  shared_runners_enabled: z.boolean().optional(),
+  shared_with_groups: z.array(z.object({
+    group_id: z.number(),
+    group_name: z.string(),
+    group_full_path: z.string(),
+    group_access_level: z.number(),
+  })).optional(),
 });
 
 // File content schemas
@@ -450,6 +492,36 @@ export const VerifyNamespaceSchema = z.object({
   parent_id: z.number().optional().describe("ID of the parent namespace. If unspecified, only returns top-level namespaces"),
 });
 
+// Project API operation schemas
+export const GetProjectSchema = z.object({
+  id: z.string().describe("ID or URL-encoded path of the project"),
+  license: z.boolean().optional().describe("Include project license data"),
+  statistics: z.boolean().optional().describe("Include project statistics"),
+  with_custom_attributes: z.boolean().optional().describe("Include custom attributes in response"),
+});
+
+export const ListProjectsSchema = z.object({
+  archived: z.boolean().optional().describe("Limit by archived status"),
+  id_after: z.number().optional().describe("Limit results to projects with IDs greater than the specified ID"),
+  id_before: z.number().optional().describe("Limit results to projects with IDs less than the specified ID"),
+  membership: z.boolean().optional().describe("Limit by projects that the current user is a member of"),
+  min_access_level: z.number().optional().describe("Limit by minimum access level"),
+  order_by: z.enum(['id', 'name', 'path', 'created_at', 'updated_at', 'last_activity_at']).optional().describe("Return projects ordered by field"),
+  owned: z.boolean().optional().describe("Limit by projects explicitly owned by the current user"),
+  search: z.string().optional().describe("Return list of projects matching the search criteria"),
+  simple: z.boolean().optional().describe("Return only limited fields for each project"),
+  sort: z.enum(['asc', 'desc']).optional().describe("Return projects sorted in ascending or descending order"),
+  starred: z.boolean().optional().describe("Limit by projects starred by the current user"),
+  visibility: z.enum(['public', 'internal', 'private']).optional().describe("Limit by visibility"),
+  with_custom_attributes: z.boolean().optional().describe("Include custom attributes in response"),
+  with_issues_enabled: z.boolean().optional().describe("Limit by enabled issues feature"),
+  with_merge_requests_enabled: z.boolean().optional().describe("Limit by enabled merge requests feature"),
+  with_programming_language: z.string().optional().describe("Limit by projects which use the given programming language"),
+  with_shared: z.boolean().optional().describe("Include projects shared to this group"),
+  page: z.number().optional().describe("Page number for pagination"),
+  per_page: z.number().optional().describe("Number of items per page"),
+});
+
 // Export types
 export type GitLabAuthor = z.infer<typeof GitLabAuthorSchema>;
 export type GitLabFork = z.infer<typeof GitLabForkSchema>;
@@ -483,3 +555,4 @@ export type GitLabMergeRequestDiff = z.infer<
 export type CreateNoteOptions = z.infer<typeof CreateNoteSchema>;
 export type GitLabNamespace = z.infer<typeof GitLabNamespaceSchema>;
 export type GitLabNamespaceExistsResponse = z.infer<typeof GitLabNamespaceExistsResponseSchema>;
+export type GitLabProject = z.infer<typeof GitLabRepositorySchema>;

--- a/schemas.ts
+++ b/schemas.ts
@@ -7,6 +7,33 @@ export const GitLabAuthorSchema = z.object({
   date: z.string(),
 });
 
+// Namespace related schemas
+export const GitLabNamespaceSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  path: z.string(),
+  kind: z.enum(["user", "group"]),
+  full_path: z.string(),
+  parent_id: z.number().nullable(),
+  avatar_url: z.string().nullable(),
+  web_url: z.string(),
+  members_count_with_descendants: z.number().optional(),
+  billable_members_count: z.number().optional(),
+  max_seats_used: z.number().optional(),
+  seats_in_use: z.number().optional(),
+  plan: z.string().optional(),
+  end_date: z.string().nullable().optional(),
+  trial_ends_on: z.string().nullable().optional(),
+  trial: z.boolean().optional(),
+  root_repository_size: z.number().optional(),
+  projects_count: z.number().optional(),
+});
+
+export const GitLabNamespaceExistsResponseSchema = z.object({
+  exists: z.boolean(),
+  suggests: z.array(z.string()).optional(),
+});
+
 // Repository related schemas
 export const GitLabOwnerSchema = z.object({
   username: z.string(), // Changed from login to match GitLab API
@@ -407,6 +434,22 @@ export const CreateNoteSchema = z.object({
   body: z.string().describe("Note content"),
 });
 
+// Add namespace-related operation schemas
+export const ListNamespacesSchema = z.object({
+  search: z.string().optional().describe("Only returns namespaces accessible by the current user"),
+  owned_only: z.boolean().optional().describe("If true, only returns namespaces by the current user"),
+  top_level_only: z.boolean().optional().describe("In GitLab 16.8 and later, if true, only returns top-level namespaces"),
+});
+
+export const GetNamespaceSchema = z.object({
+  id: z.string().describe("ID or URL-encoded path of the namespace"),
+});
+
+export const VerifyNamespaceSchema = z.object({
+  namespace: z.string().describe("Path of the namespace"),
+  parent_id: z.number().optional().describe("ID of the parent namespace. If unspecified, only returns top-level namespaces"),
+});
+
 // Export types
 export type GitLabAuthor = z.infer<typeof GitLabAuthorSchema>;
 export type GitLabFork = z.infer<typeof GitLabForkSchema>;
@@ -438,3 +481,5 @@ export type GitLabMergeRequestDiff = z.infer<
   typeof GitLabMergeRequestDiffSchema
 >;
 export type CreateNoteOptions = z.infer<typeof CreateNoteSchema>;
+export type GitLabNamespace = z.infer<typeof GitLabNamespaceSchema>;
+export type GitLabNamespaceExistsResponse = z.infer<typeof GitLabNamespaceExistsResponseSchema>;

--- a/schemas.ts
+++ b/schemas.ts
@@ -159,12 +159,12 @@ export const GitLabForkParentSchema = z.object({
     username: z.string(), // Changed from login to match GitLab API
     id: z.number(),
     avatar_url: z.string(),
-  }),
+  }).optional(), // Made optional to handle cases where GitLab API doesn't include it
   web_url: z.string(), // Changed from html_url to match GitLab API
 });
 
 export const GitLabForkSchema = GitLabRepositorySchema.extend({
-  forked_from_project: GitLabForkParentSchema, // Changed from parent to match GitLab API
+  forked_from_project: GitLabForkParentSchema.optional(), // Made optional to handle cases where GitLab API doesn't include it
 });
 
 // Issue related schemas


### PR DESCRIPTION
This PR adds support for the GitLab Projects API as documented at https://docs.gitlab.com/api/projects/

Features:
- Enhanced GitLabRepositorySchema with additional project fields
- Added comprehensive GET and LIST operations for projects
- Implemented two project-related functions:
  - get_project: Get details on a specified project
  - list_projects: List projects accessible by the current user

These functions are useful for AI assistants that need to:
- List and filter available projects
- Get detailed information about specific projects
- Access project metadata for GitLab operations

This PR builds on top of the Namespaces API support (#15)
