### PR TITLE
Authentication Header Consistency Fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1612,23 +1612,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "list_projects": {
         const args = ListProjectsSchema.parse(request.params.arguments);
-        const url = new URL(`${GITLAB_API_URL}/projects`);
-
-        // Add query parameters for filtering
-        Object.entries(args).forEach(([key, value]) => {
-          if (value !== undefined) {
-            url.searchParams.append(key, value.toString());
-          }
-        });
-
-        const response = await fetch(url.toString(), {
-          headers: DEFAULT_HEADERS,
-        });
-
-        await handleGitLabError(response);
-        const data = await response.json();
-        const projects = z.array(GitLabProjectSchema).parse(data);
-
+        const projects = await listProjects(args);
         return {
           content: [{ type: "text", text: JSON.stringify(projects, null, 2) }],
         };


### PR DESCRIPTION
# Authentication Header Consistency Fix

This PR addresses an issue with authentication header usage in the GitLab MCP server:

## Authentication Fixes

- Ensures consistent use of DEFAULT_HEADERS across all API calls
- Refactors the list_projects function to use a properly implemented helper function
- Improves maintainability by removing duplicate code

## Implementation Details

The PR focuses on ensuring that all API calls use the predefined DEFAULT_HEADERS constant, which contains the proper authentication headers for GitLab API requests. Specifically:

- The `list_projects` handler has been refactored to use the existing `listProjects` helper function
- This eliminates duplicate code and ensures consistent authentication header usage
- The implementation follows the pattern used by other API functions in the codebase

## Testing

The changes have been tested against a GitLab instance and work correctly. 