### PR TITLE
feat: Gitlab list repository tree tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zereight/mcp-gitlab",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zereight/mcp-gitlab",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.8.0",

--- a/schemas.ts
+++ b/schemas.ts
@@ -160,17 +160,27 @@ export const FileOperationSchema = z.object({
 });
 
 // Tree and commit schemas
-export const GitLabTreeEntrySchema = z.object({
-  id: z.string(), // Changed from sha to match GitLab API
+export const GitLabTreeItemSchema = z.object({
+  id: z.string(),
   name: z.string(),
-  type: z.enum(["blob", "tree"]),
+  type: z.enum(["tree", "blob"]),
   path: z.string(),
   mode: z.string(),
 });
 
+export const GetRepositoryTreeSchema = z.object({
+  project_id: z.string().describe("The ID or URL-encoded path of the project"),
+  path: z.string().optional().describe("The path inside the repository"),
+  ref: z.string().optional().describe("The name of a repository branch or tag. Defaults to the default branch."),
+  recursive: z.boolean().optional().describe("Boolean value to get a recursive tree"),
+  per_page: z.number().optional().describe("Number of results to show per page"),
+  page_token: z.string().optional().describe("The tree record ID for pagination"),
+  pagination: z.string().optional().describe("Pagination method (keyset)")
+});
+
 export const GitLabTreeSchema = z.object({
   id: z.string(), // Changed from sha to match GitLab API
-  tree: z.array(GitLabTreeEntrySchema),
+  tree: z.array(GitLabTreeItemSchema),
 });
 
 export const GitLabCommitSchema = z.object({
@@ -1033,3 +1043,5 @@ export type CreateWikiPageOptions = z.infer<typeof CreateWikiPageSchema>;
 export type UpdateWikiPageOptions = z.infer<typeof UpdateWikiPageSchema>;
 export type DeleteWikiPageOptions = z.infer<typeof DeleteWikiPageSchema>;
 export type GitLabWikiPage = z.infer<typeof GitLabWikiPageSchema>;
+export type GitLabTreeItem = z.infer<typeof GitLabTreeItemSchema>;
+export type GetRepositoryTreeOptions = z.infer<typeof GetRepositoryTreeSchema>;


### PR DESCRIPTION
This PR adds a `list_repository_tree` tool for the Gitlab MCP, so AI agents can explore repositories interactively.
Originally created this [PR inside the official gitlab integration](https://github.com/modelcontextprotocol/servers/pull/1337), but they are not the fastest so I have decided to submit it here as well. 

## Description
This PR adds a `list_repository_tree` tool for the Gitlab MCP, so It can explore a repository interactively. It wraps around the corresponding [List repository tree](https://docs.gitlab.com/api/repositories/#list-repository-tree).

## Motivation and Context
The AI agents are in the dark regarding the structure of a repository and can only read specific files in their entirety. This PR adds the `list_repository_tree` to allow the AI to explore the repository before reading/updating specific files.

## Additional context
See [List repository tree - Gitlab Documentation](https://docs.gitlab.com/api/repositories/#list-repository-tree).

Get a list of repository files and directories in a project. This endpoint can be accessed without authentication if the repository is publicly accessible.

This command provides essentially the same features as the git ls-tree command. For more information, refer to the section [Tree Objects](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects.html#_tree_objects) in the Git internals documentation.

Attribute | Type | Required | Description
-- | -- | -- | --
id | integer or string | yes | The ID or URL-encoded path of the project.
page_token | string | no | The tree record ID at which to fetch the next page. Used only with keyset pagination.
pagination | string | no | If keyset, use the keyset-based pagination method.
path | string | no | The path inside the repository. Used to get content of subdirectories.
per_page | integer | no | Number of results to show per page. If not specified, defaults to 20. For more information, see Pagination.
recursive | boolean | no | Boolean value used to get a recursive tree. Default is false.
ref | string | no | The name of a repository branch or tag or, if not given, the default branch.