### PR TITLE
Support resolving merge request discussion notes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1027,7 +1027,7 @@ async function updateMergeRequestNote(
   mergeRequestIid: number,
   discussionId: string,
   noteId: number,
-  body: string,
+  body?: string,
   resolved?: boolean
 ): Promise<GitLabDiscussionNote> {
   projectId = decodeURIComponent(projectId); // Decode project ID
@@ -1037,8 +1037,11 @@ async function updateMergeRequestNote(
     )}/merge_requests/${mergeRequestIid}/discussions/${discussionId}/notes/${noteId}`
   );
 
-  const payload: { body: string; resolved?: boolean } = { body };
-  if (resolved !== undefined) {
+  // Only one of body or resolved can be sent according to GitLab API
+  const payload: { body?: string; resolved?: boolean } = {};
+  if (body !== undefined) {
+    payload.body = body;
+  } else if (resolved !== undefined) {
     payload.resolved = resolved;
   }
 
@@ -2270,8 +2273,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args.merge_request_iid,
           args.discussion_id,
           args.note_id,
-          args.body,
-          args.resolved // Pass resolved if provided
+          args.body, // Now optional
+          args.resolved // Now one of body or resolved must be provided, not both
         );
         return {
           content: [{ type: "text", text: JSON.stringify(note, null, 2) }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zereight/mcp-gitlab",
-  "version": "1.0.33",
+  "version": "1.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zereight/mcp-gitlab",
-      "version": "1.0.33",
+      "version": "1.0.36",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.8.0",

--- a/schemas.ts
+++ b/schemas.ts
@@ -475,8 +475,12 @@ export const UpdateMergeRequestNoteSchema = ProjectParamsSchema.extend({
   merge_request_iid: z.number().describe("The IID of a merge request"),
   discussion_id: z.string().describe("The ID of a thread"),
   note_id: z.number().describe("The ID of a thread note"),
-  body: z.string().describe("The content of the note or reply"),
-  resolved: z.boolean().optional().describe("Resolve or unresolve the note"), // Optional based on API docs
+  body: z.string().optional().describe("The content of the note or reply"),
+  resolved: z.boolean().optional().describe("Resolve or unresolve the note"),
+}).refine(data => data.body !== undefined || data.resolved !== undefined, {
+  message: "At least one of 'body' or 'resolved' must be provided"
+}).refine(data => !(data.body !== undefined && data.resolved !== undefined), {
+  message: "Only one of 'body' or 'resolved' can be provided, not both"
 });
 
 // API Operation Parameter Schemas


### PR DESCRIPTION
Allow the ability to resolve/unresolve notes in merge request discussions through the MCP API. Basically, the Gitlab API expects either `body` or `resolved`, but not both. The existing code here required `body` to be provided. I simply made that field optional.

Here is a reference to where this is called out in the API docs: https://docs.gitlab.com/api/discussions/#modify-an-existing-merge-request-thread-note