### PR TITLE
Adds threaded comment support for merge requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ When using with the Claude App, you need to set up your API key and URLs directl
 14. `create_merge_request_thread` - Create a new thread on a merge request
 15. `mr_discussions` - List discussion items for a merge request
 16. `update_merge_request_note` - Modify an existing merge request thread note
-17. `add_merge_request_thread_note` - Add a new note to an existing merge request thread
+17. `create_merge_request_note` - Add a new note to an existing merge request thread
 18. `list_issues` - List issues in a GitLab project with filtering options
 19. `get_issue` - Get details of a specific issue in a GitLab project
 20. `update_issue` - Update an issue in a GitLab project

--- a/README.md
+++ b/README.md
@@ -58,29 +58,30 @@ When using with the Claude App, you need to set up your API key and URLs directl
 14. `create_merge_request_thread` - Create a new thread on a merge request
 15. `mr_discussions` - List discussion items for a merge request
 16. `update_merge_request_note` - Modify an existing merge request thread note
-17. `list_issues` - List issues in a GitLab project with filtering options
-18. `get_issue` - Get details of a specific issue in a GitLab project
-19. `update_issue` - Update an issue in a GitLab project
-20. `delete_issue` - Delete an issue from a GitLab project
-21. `list_issue_links` - List all issue links for a specific issue
-22. `get_issue_link` - Get a specific issue link
-23. `create_issue_link` - Create an issue link between two issues
-24. `delete_issue_link` - Delete an issue link
-25. `list_namespaces` - List all namespaces available to the current user
-26. `get_namespace` - Get details of a namespace by ID or path
-27. `verify_namespace` - Verify if a namespace path exists
-28. `get_project` - Get details of a specific project
-29. `list_projects` - List projects accessible by the current user
-30. `list_labels` - List labels for a project
-31. `get_label` - Get a single label from a project
-32. `create_label` - Create a new label in a project
-33. `update_label` - Update an existing label in a project
-34. `delete_label` - Delete a label from a project
-35. `list_group_projects` - List projects in a GitLab group with filtering options
-36. `list_wiki_pages` - List wiki pages in a GitLab project
-37. `get_wiki_page` - Get details of a specific wiki page
-38. `create_wiki_page` - Create a new wiki page in a GitLab project
-39. `update_wiki_page` - Update an existing wiki page in a GitLab project
-40. `delete_wiki_page` - Delete a wiki page from a GitLab project
-41. `get_repository_tree` - Get the repository tree for a GitLab project (list files and directories)
+17. `add_merge_request_thread_note` - Add a new note to an existing merge request thread
+18. `list_issues` - List issues in a GitLab project with filtering options
+19. `get_issue` - Get details of a specific issue in a GitLab project
+20. `update_issue` - Update an issue in a GitLab project
+21. `delete_issue` - Delete an issue from a GitLab project
+22. `list_issue_links` - List all issue links for a specific issue
+23. `get_issue_link` - Get a specific issue link
+24. `create_issue_link` - Create an issue link between two issues
+25. `delete_issue_link` - Delete an issue link
+26. `list_namespaces` - List all namespaces available to the current user
+27. `get_namespace` - Get details of a namespace by ID or path
+28. `verify_namespace` - Verify if a namespace path exists
+29. `get_project` - Get details of a specific project
+30. `list_projects` - List projects accessible by the current user
+31. `list_labels` - List labels for a project
+32. `get_label` - Get a single label from a project
+33. `create_label` - Create a new label in a project
+34. `update_label` - Update an existing label in a project
+35. `delete_label` - Delete a label from a project
+36. `list_group_projects` - List projects in a GitLab group with filtering options
+37. `list_wiki_pages` - List wiki pages in a GitLab project
+38. `get_wiki_page` - Get details of a specific wiki page
+39. `create_wiki_page` - Create a new wiki page in a GitLab project
+40. `update_wiki_page` - Update an existing wiki page in a GitLab project
+41. `delete_wiki_page` - Delete a wiki page from a GitLab project
+42. `get_repository_tree` - Get the repository tree for a GitLab project (list files and directories)
 <!-- TOOLS-END -->

--- a/README.md
+++ b/README.md
@@ -55,31 +55,32 @@ When using with the Claude App, you need to set up your API key and URLs directl
 11. `get_merge_request_diffs` - Get the changes/diffs of a merge request (Either mergeRequestIid or branchName must be provided)
 12. `update_merge_request` - Update a merge request (Either mergeRequestIid or branchName must be provided)
 13. `create_note` - Create a new note (comment) to an issue or merge request
-14. `mr_discussions` - List discussion items for a merge request
-15. `update_merge_request_note` - Modify an existing merge request thread note
-16. `list_issues` - List issues in a GitLab project with filtering options
-17. `get_issue` - Get details of a specific issue in a GitLab project
-18. `update_issue` - Update an issue in a GitLab project
-19. `delete_issue` - Delete an issue from a GitLab project
-20. `list_issue_links` - List all issue links for a specific issue
-21. `get_issue_link` - Get a specific issue link
-22. `create_issue_link` - Create an issue link between two issues
-23. `delete_issue_link` - Delete an issue link
-24. `list_namespaces` - List all namespaces available to the current user
-25. `get_namespace` - Get details of a namespace by ID or path
-26. `verify_namespace` - Verify if a namespace path exists
-27. `get_project` - Get details of a specific project
-28. `list_projects` - List projects accessible by the current user
-29. `list_labels` - List labels for a project
-30. `get_label` - Get a single label from a project
-31. `create_label` - Create a new label in a project
-32. `update_label` - Update an existing label in a project
-33. `delete_label` - Delete a label from a project
-34. `list_group_projects` - List projects in a GitLab group with filtering options
-35. `list_wiki_pages` - List wiki pages in a GitLab project
-36. `get_wiki_page` - Get details of a specific wiki page
-37. `create_wiki_page` - Create a new wiki page in a GitLab project
-38. `update_wiki_page` - Update an existing wiki page in a GitLab project
-39. `delete_wiki_page` - Delete a wiki page from a GitLab project
-40. `get_repository_tree` - Get the repository tree for a GitLab project (list files and directories)
+14. `create_merge_request_thread` - Create a new thread on a merge request
+15. `mr_discussions` - List discussion items for a merge request
+16. `update_merge_request_note` - Modify an existing merge request thread note
+17. `list_issues` - List issues in a GitLab project with filtering options
+18. `get_issue` - Get details of a specific issue in a GitLab project
+19. `update_issue` - Update an issue in a GitLab project
+20. `delete_issue` - Delete an issue from a GitLab project
+21. `list_issue_links` - List all issue links for a specific issue
+22. `get_issue_link` - Get a specific issue link
+23. `create_issue_link` - Create an issue link between two issues
+24. `delete_issue_link` - Delete an issue link
+25. `list_namespaces` - List all namespaces available to the current user
+26. `get_namespace` - Get details of a namespace by ID or path
+27. `verify_namespace` - Verify if a namespace path exists
+28. `get_project` - Get details of a specific project
+29. `list_projects` - List projects accessible by the current user
+30. `list_labels` - List labels for a project
+31. `get_label` - Get a single label from a project
+32. `create_label` - Create a new label in a project
+33. `update_label` - Update an existing label in a project
+34. `delete_label` - Delete a label from a project
+35. `list_group_projects` - List projects in a GitLab group with filtering options
+36. `list_wiki_pages` - List wiki pages in a GitLab project
+37. `get_wiki_page` - Get details of a specific wiki page
+38. `create_wiki_page` - Create a new wiki page in a GitLab project
+39. `update_wiki_page` - Update an existing wiki page in a GitLab project
+40. `delete_wiki_page` - Delete a wiki page from a GitLab project
+41. `get_repository_tree` - Get the repository tree for a GitLab project (list files and directories)
 <!-- TOOLS-END -->

--- a/index.ts
+++ b/index.ts
@@ -87,7 +87,7 @@ import {
   GitLabDiscussionNoteSchema, // Added
   GitLabDiscussionSchema,
   UpdateMergeRequestNoteSchema, // Added
-  AddMergeRequestThreadNoteSchema, // Added
+  CreateMergeRequestNoteSchema, // Added
   ListMergeRequestDiscussionsSchema,
   type GitLabFork,
   type GitLabReference,
@@ -282,9 +282,9 @@ const allTools = [
     inputSchema: zodToJsonSchema(UpdateMergeRequestNoteSchema),
   },
   {
-    name: "add_merge_request_thread_note",
+    name: "create_merge_request_note",
     description: "Add a new note to an existing merge request thread",
-    inputSchema: zodToJsonSchema(AddMergeRequestThreadNoteSchema),
+    inputSchema: zodToJsonSchema(CreateMergeRequestNoteSchema),
   },
   {
     name: "list_issues",
@@ -1077,7 +1077,7 @@ async function updateMergeRequestNote(
  * @param {string} [createdAt] - The creation date of the note (ISO 8601 format)
  * @returns {Promise<GitLabDiscussionNote>} The created note
  */
-async function addMergeRequestThreadNote(
+async function createMergeRequestNote(
   projectId: string,
   mergeRequestIid: number,
   discussionId: string,
@@ -2385,11 +2385,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
       
-      case "add_merge_request_thread_note": {
-        const args = AddMergeRequestThreadNoteSchema.parse(
+      case "create_merge_request_note": {
+        const args = CreateMergeRequestNoteSchema.parse(
           request.params.arguments
         );
-        const note = await addMergeRequestThreadNote(
+        const note = await createMergeRequestNote(
           args.project_id,
           args.merge_request_iid,
           args.discussion_id,

--- a/schemas.ts
+++ b/schemas.ts
@@ -479,6 +479,14 @@ export const UpdateMergeRequestNoteSchema = ProjectParamsSchema.extend({
   resolved: z.boolean().optional().describe("Resolve or unresolve the note"), // Optional based on API docs
 });
 
+// Input schema for adding a note to an existing merge request discussion
+export const AddMergeRequestThreadNoteSchema = ProjectParamsSchema.extend({
+  merge_request_iid: z.number().describe("The IID of a merge request"),
+  discussion_id: z.string().describe("The ID of a thread"),
+  body: z.string().describe("The content of the note or reply"),
+  created_at: z.string().optional().describe("Date the note was created at (ISO 8601 format)"),
+});
+
 // API Operation Parameter Schemas
 
 export const CreateOrUpdateFileSchema = ProjectParamsSchema.extend({
@@ -1079,3 +1087,4 @@ export type GitLabTreeItem = z.infer<typeof GitLabTreeItemSchema>;
 export type GetRepositoryTreeOptions = z.infer<typeof GetRepositoryTreeSchema>;
 export type MergeRequestThreadPosition = z.infer<typeof MergeRequestThreadPositionSchema>;
 export type CreateMergeRequestThreadOptions = z.infer<typeof CreateMergeRequestThreadSchema>;
+export type AddMergeRequestThreadNoteOptions = z.infer<typeof AddMergeRequestThreadNoteSchema>;

--- a/schemas.ts
+++ b/schemas.ts
@@ -1004,6 +1004,30 @@ export const GitLabWikiPageSchema = z.object({
   updated_at: z.string().optional(),
 });
 
+// Merge Request Thread position schema - used for diff notes
+export const MergeRequestThreadPositionSchema = z.object({
+  base_sha: z.string().describe("Base commit SHA in the source branch"),
+  head_sha: z.string().describe("SHA referencing HEAD of the source branch"),
+  start_sha: z.string().describe("SHA referencing the start commit of the source branch"),
+  position_type: z.enum(["text", "image", "file"]).describe("Type of position reference"),
+  new_path: z.string().optional().describe("File path after change"),
+  old_path: z.string().optional().describe("File path before change"),
+  new_line: z.number().nullable().optional().describe("Line number after change"),
+  old_line: z.number().nullable().optional().describe("Line number before change"),
+  width: z.number().optional().describe("Width of the image (for image diffs)"),
+  height: z.number().optional().describe("Height of the image (for image diffs)"),
+  x: z.number().optional().describe("X coordinate on the image (for image diffs)"),
+  y: z.number().optional().describe("Y coordinate on the image (for image diffs)"),
+});
+
+// Schema for creating a new merge request thread
+export const CreateMergeRequestThreadSchema = ProjectParamsSchema.extend({
+  merge_request_iid: z.number().describe("The IID of a merge request"),
+  body: z.string().describe("The content of the thread"),
+  position: MergeRequestThreadPositionSchema.optional().describe("Position when creating a diff note"),
+  created_at: z.string().optional().describe("Date the thread was created at (ISO 8601 format)"),
+});
+
 // Export types
 export type GitLabAuthor = z.infer<typeof GitLabAuthorSchema>;
 export type GitLabFork = z.infer<typeof GitLabForkSchema>;
@@ -1053,3 +1077,5 @@ export type DeleteWikiPageOptions = z.infer<typeof DeleteWikiPageSchema>;
 export type GitLabWikiPage = z.infer<typeof GitLabWikiPageSchema>;
 export type GitLabTreeItem = z.infer<typeof GitLabTreeItemSchema>;
 export type GetRepositoryTreeOptions = z.infer<typeof GetRepositoryTreeSchema>;
+export type MergeRequestThreadPosition = z.infer<typeof MergeRequestThreadPositionSchema>;
+export type CreateMergeRequestThreadOptions = z.infer<typeof CreateMergeRequestThreadSchema>;

--- a/schemas.ts
+++ b/schemas.ts
@@ -480,7 +480,7 @@ export const UpdateMergeRequestNoteSchema = ProjectParamsSchema.extend({
 });
 
 // Input schema for adding a note to an existing merge request discussion
-export const AddMergeRequestThreadNoteSchema = ProjectParamsSchema.extend({
+export const CreateMergeRequestNoteSchema = ProjectParamsSchema.extend({
   merge_request_iid: z.number().describe("The IID of a merge request"),
   discussion_id: z.string().describe("The ID of a thread"),
   body: z.string().describe("The content of the note or reply"),
@@ -1087,4 +1087,4 @@ export type GitLabTreeItem = z.infer<typeof GitLabTreeItemSchema>;
 export type GetRepositoryTreeOptions = z.infer<typeof GetRepositoryTreeSchema>;
 export type MergeRequestThreadPosition = z.infer<typeof MergeRequestThreadPositionSchema>;
 export type CreateMergeRequestThreadOptions = z.infer<typeof CreateMergeRequestThreadSchema>;
-export type AddMergeRequestThreadNoteOptions = z.infer<typeof AddMergeRequestThreadNoteSchema>;
+export type CreateMergeRequestNoteOptions = z.infer<typeof CreateMergeRequestNoteSchema>;


### PR DESCRIPTION
Adds two new MCP tools to improve the comment experience on merge requests. These changes allow threads to be created with inline code suggestions and notes to be added to existing threads.

1. `create_merge_request_thread` - Start new threads on merge requests, with support for diff notes and comment positioning
2. `create_merge_request_note` - Reply to existing threads

`create_note` as is does not support this functionality, so figured I would extend to support these two new tools instead.