### PR TITLE
FIX: description null error

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -407,7 +407,7 @@ export const GitLabMilestoneSchema = z.object({
   id: z.number(),
   iid: z.number(), // Added to match GitLab API
   title: z.string(),
-  description: z.string(),
+  description: z.string().nullable().default(""),
   state: z.string(),
   web_url: z.string(), // Changed from html_url to match GitLab API
 });
@@ -417,7 +417,7 @@ export const GitLabIssueSchema = z.object({
   iid: z.number(), // Added to match GitLab API
   project_id: z.number(), // Added to match GitLab API
   title: z.string(),
-  description: z.string(), // Changed from body to match GitLab API
+  description: z.string().nullable().default(""), // Changed from body to match GitLab API
   state: z.string(),
   author: GitLabUserSchema,
   assignees: z.array(GitLabUserSchema),


### PR DESCRIPTION
@zereight 
I apologize if the MR writing format or branch name violates the rules.
Thank you for the invitation.


[Issue](https://github.com/zereight/gitlab-mcp/issues/51):

The MCP server fails to process GitLab issues that contain a null value for the description field. This causes the server to throw a JSON-RPC error instead of returning issue details.

Error Message:
```
{
  "jsonrpc": "2.0",
  "id": 8,
  "error": {
    "code": -32603,
    "message": "Invalid arguments: description: Expected string, received null"
  }
}

```

