### PR TITLE
Fix GitHub Actions workflow syntax errors

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run tests
       run: npm test
       env:
-        GITLAB_API_URL: ${{ secrets.GITLAB_API_URL || 'https://gitlab.com' }}
+        GITLAB_API_URL: ${{ secrets.GITLAB_API_URL }}
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN_TEST }}
     
     - name: Type check
@@ -60,8 +60,8 @@ jobs:
           exit 1
         fi
       env:
-        GITLAB_API_URL: ${{ secrets.GITLAB_API_URL || 'https://gitlab.com' }}
-        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN_TEST || 'dummy-token-for-test' }}
+        GITLAB_API_URL: ${{ secrets.GITLAB_API_URL }}
+        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN_TEST }}
 
   integration-test:
     runs-on: ubuntu-latest
@@ -90,7 +90,7 @@ jobs:
         echo "Running integration tests with real GitLab API..."
         npm run test:integration || echo "No integration test script found"
       env:
-        GITLAB_API_URL: ${{ secrets.GITLAB_API_URL || 'https://gitlab.com' }}
+        GITLAB_API_URL: ${{ secrets.GITLAB_API_URL }}
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN_TEST }}
         PROJECT_ID: ${{ secrets.TEST_PROJECT_ID }}
     
@@ -160,6 +160,6 @@ jobs:
     - name: Run tests
       run: npm test
       env:
-        GITLAB_API_URL: ${{ secrets.GITLAB_API_URL || 'https://gitlab.com' }}
+        GITLAB_API_URL: ${{ secrets.GITLAB_API_URL }}
         GITLAB_TOKEN_TEST: ${{ secrets.GITLAB_TOKEN_TEST }}
         TEST_PROJECT_ID: ${{ secrets.TEST_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- Fix startup_failure errors in PR validation workflow
- Remove unsupported default value syntax from secrets

## Problem
GitHub Actions doesn't support the `||` operator for providing default values in secret expressions like:
```yaml
${{ secrets.GITLAB_API_URL || 'https://gitlab.com' }}
```

This causes a startup_failure error and prevents the workflow from running.

## Solution
Removed all default value expressions from secrets. The workflow now uses only:
```yaml
${{ secrets.GITLAB_API_URL }}
```

## Test
After merging this PR, other PRs will be able to run the automated tests properly.