### PR TITLE
feat: add pipeline management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,17 @@ $ sh scripts/image_push.sh docker_user_name
 48. `list_pipeline_jobs` - List all jobs in a specific pipeline
 49. `get_pipeline_job` - Get details of a GitLab pipeline job number
 50. `get_pipeline_job_output` - Get the output/trace of a GitLab pipeline job number
-51. `list_merge_requests` - List merge requests in a GitLab project with filtering options
-52. `list_milestones` - List milestones in a GitLab project with filtering options
-53. `get_milestone` - Get details of a specific milestone
-54. `create_milestone` - Create a new milestone in a GitLab project
-55. `edit_milestone ` - Edit an existing milestone in a GitLab project
-56. `delete_milestone` - Delete a milestone from a GitLab project
-57. `get_milestone_issue` - Get issues associated with a specific milestone
-58. `get_milestone_merge_requests` - Get merge requests associated with a specific milestone
-59. `promote_milestone` - Promote a milestone to the next stage
-60. `get_milestone_burndown_events` - Get burndown events for a specific milestone
+51. `create_pipeline` - Create a new pipeline for a branch or tag
+52. `retry_pipeline` - Retry a failed or canceled pipeline
+53. `cancel_pipeline` - Cancel a running pipeline
+54. `list_merge_requests` - List merge requests in a GitLab project with filtering options
+55. `list_milestones` - List milestones in a GitLab project with filtering options
+56. `get_milestone` - Get details of a specific milestone
+57. `create_milestone` - Create a new milestone in a GitLab project
+58. `edit_milestone ` - Edit an existing milestone in a GitLab project
+59. `delete_milestone` - Delete a milestone from a GitLab project
+60. `get_milestone_issue` - Get issues associated with a specific milestone
+61. `get_milestone_merge_requests` - Get merge requests associated with a specific milestone
+62. `promote_milestone` - Promote a milestone to the next stage
+63. `get_milestone_burndown_events` - Get burndown events for a specific milestone
 <!-- TOOLS-END -->

--- a/schemas.ts
+++ b/schemas.ts
@@ -157,6 +157,33 @@ export const ListPipelineJobsSchema = z.object({
   per_page: z.number().optional().describe("Number of items per page (max 100)"),
 });
 
+// Schema for creating a new pipeline
+export const CreatePipelineSchema = z.object({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
+  ref: z.string().describe("The branch or tag to run the pipeline on"),
+  variables: z
+    .array(
+      z.object({
+        key: z.string().describe("The key of the variable"),
+        value: z.string().describe("The value of the variable"),
+      })
+    )
+    .optional()
+    .describe("An array of variables to use for the pipeline"),
+});
+
+// Schema for retrying a pipeline
+export const RetryPipelineSchema = z.object({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
+  pipeline_id: z.number().describe("The ID of the pipeline to retry"),
+});
+
+// Schema for canceling a pipeline
+export const CancelPipelineSchema = z.object({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
+  pipeline_id: z.number().describe("The ID of the pipeline to cancel"),
+});
+
 // Schema for the input parameters for pipeline job operations
 export const GetPipelineJobOutputSchema = z.object({
   project_id: z.string().describe("Project ID or URL-encoded path"),
@@ -1281,6 +1308,9 @@ export type GitLabPipeline = z.infer<typeof GitLabPipelineSchema>;
 export type ListPipelinesOptions = z.infer<typeof ListPipelinesSchema>;
 export type GetPipelineOptions = z.infer<typeof GetPipelineSchema>;
 export type ListPipelineJobsOptions = z.infer<typeof ListPipelineJobsSchema>;
+export type CreatePipelineOptions = z.infer<typeof CreatePipelineSchema>;
+export type RetryPipelineOptions = z.infer<typeof RetryPipelineSchema>;
+export type CancelPipelineOptions = z.infer<typeof CancelPipelineSchema>;
 export type GitLabMilestones = z.infer<typeof GitLabMilestonesSchema>;
 export type ListProjectMilestonesOptions = z.infer<typeof ListProjectMilestonesSchema>;
 export type GetProjectMilestoneOptions = z.infer<typeof GetProjectMilestoneSchema>;


### PR DESCRIPTION
## Summary
This PR adds pipeline management commands to address #46.

## New Features
- `create_pipeline` - Create a new pipeline for a branch or tag
- `retry_pipeline` - Retry a failed or canceled pipeline  
- `cancel_pipeline` - Cancel a running pipeline

## Changes
- Added pipeline management schemas in `schemas.ts`
- Implemented pipeline functions in `index.ts`
- Added pipeline API tests in `test/validate-api.js`
- Updated README with new pipeline commands

## Testing
- All existing tests pass
- Added new pipeline API validation tests
- Tested list_pipelines and get_pipeline endpoints

Closes #46