### PR TITLE
Change old_line, new_line in GitLabDiscussionNoteSchema to optional

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -618,21 +618,21 @@ export const GitLabDiscussionNoteSchema = z.object({
       old_path: z.string(),
       new_path: z.string(),
       position_type: z.enum(["text", "image", "file"]),
-      old_line: z.number().nullable(),
-      new_line: z.number().nullable(),
+      old_line: z.number().nullish(), // This is missing for image diffs
+      new_line: z.number().nullish(), // This is missing for image diffs
       line_range: z
         .object({
           start: z.object({
             line_code: z.string(),
             type: z.enum(["new", "old", "expanded"]),
-            old_line: z.number().nullable(),
-            new_line: z.number().nullable(),
+            old_line: z.number().nullish(), // This is missing for image diffs
+            new_line: z.number().nullish(), // This is missing for image diffs
           }),
           end: z.object({
             line_code: z.string(),
             type: z.enum(["new", "old", "expanded"]),
-            old_line: z.number().nullable(),
-            new_line: z.number().nullable(),
+            old_line: z.number().nullish(), // This is missing for image diffs
+            new_line: z.number().nullish(), // This is missing for image diffs
           }),
         })
         .nullable()


### PR DESCRIPTION
## Motivation

While using MCP with Claude Code/Cursor, I ran into the following error message with the `mr_discussions` tool call:

```
⏺ GitLab:mr_discussions (MCP)(project_id: "travelchime/itineraries", merge_request_iid: 9121)…
  ⎿  Error: MCP error -32603: Invalid arguments: 8.notes.0.position.old_line: Required,
     8.notes.0.position.new_line: Required, 9.notes.0.position.old_line: Required, 9.notes.0.position.new_line:
     Required, 11.notes.0.position.old_line: Required, 11.notes.0.position.new_line: Required,
     12.notes.0.position.old_line: Required, 12.notes.0.position.new_line: Required
```

After looking into this, this was because for images, we get a diff without a old_line or new_line: e.g.,

```json
[
  {
    "id": "dbcf604610d2c8e974f18a10a8baf22acec722da",
    "individual_note": false,
    "notes": [
      {
        "id": 2533796925,
        "type": "DiffNote",
        "body": "We also likely don't need this icon quite yet, so you can exclude this",
        "author": {
          "username": "peterxu",
          "id": 542981,
          "name": "Peter Xu",
          "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/542981/avatar.png",
          "web_url": "https://gitlab.com/peterxu"
        },
        "created_at": "2025-05-30T00:08:32.429Z",
        "updated_at": "2025-05-30T00:08:32.429Z",
        "system": false,
        "noteable_id": 387096838,
        "noteable_type": "MergeRequest",
        "project_id": 9347980,
        "noteable_iid": 9121,
        "resolvable": true,
        "resolved": false,
        "resolved_by": null,
        "resolved_at": null,
        "position": {
          "base_sha": "9cf4998d12713eadd7c3b127d537f92302132cde",
          "start_sha": "44a4fd7f1c4476dac500a5d885c34f26baf463e0",
          "head_sha": "862d79708569f22ff5594234b0b121022cf58d65",
          "old_path": "mobile/assets/images/sourceIcons/wanderlog.png",
          "new_path": "mobile/assets/images/sourceIcons/wanderlog.png",
          "position_type": "image",
          "width": 16,
          "height": 16,
          "x": 8,
          "y": 5
        }
      }
    ]
  }
]
```

## Changes

Change the `zod` type validation have the `old_line` and `new_line` keys be optional, not just nullable

## Testing

Used the following `mcp.json` and verified that tool use with Claude worked when asked to retrieve merge request comments for this MR:

```json
{
  "mcpServers": {
    "GitLab": {
      "command": "npx",
      "args": ["-y", "github:wanderlog/gitlab-mcp"],
      "env": {
        "GITLAB_PERSONAL_ACCESS_TOKEN": "glpat-..."
      }
    }
  }
}
```