### PR TITLE
fix: merge_requests_template can be null

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -310,7 +310,7 @@ export const GitLabRepositorySchema = z.object({
   container_registry_access_level: z.string().optional(),
   issues_enabled: z.boolean().optional(),
   merge_requests_enabled: z.boolean().optional(),
-  merge_requests_template: z.string().optional(),
+  merge_requests_template: z.string().nullable().optional(),
   wiki_enabled: z.boolean().optional(),
   jobs_enabled: z.boolean().optional(),
   snippets_enabled: z.boolean().optional(),


### PR DESCRIPTION
Error executing MCP tool:
MCP error -32603: Invalid arguments: items.0.merge_requests_template: Expected string, received null, items.1.merge_requests_template: Expected string, received null, items.2.merge_requests_template: Expected string, received null, items.3.merge_requests_template: Expected string, received null, items.4.merge_requests_template: Expected string, received null

see https://docs.gitlab.com/api/projects/#templates-for-issues-and-merge-requests

but i didn't find any docs that can check other fields is nullable or not, even the https://gitlab.com/gitlab-org/gitlab/-/blob/master/doc/api/openapi/openapi_v2.yaml?plain=1#L45312 

