### PR TITLE
fix: current list_wiki_pages tool is not working and add support for retrieving wiki page content in list_wiki_pages

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -1197,7 +1197,9 @@ export const ListGroupProjectsSchema = z.object({
 // Add wiki operation schemas
 export const ListWikiPagesSchema = z.object({
   project_id: z.string().describe("Project ID or URL-encoded path"),
+  with_content: z.boolean().optional().describe("Include content of the wiki pages"),
 }).merge(PaginationOptionsSchema);
+
 export const GetWikiPageSchema = z.object({
   project_id: z.string().describe("Project ID or URL-encoded path"),
   slug: z.string().describe("URL-encoded slug of the wiki page"),
@@ -1226,7 +1228,7 @@ export const GitLabWikiPageSchema = z.object({
   title: z.string(),
   slug: z.string(),
   format: z.string(),
-  content: z.string(),
+  content: z.string().optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 });


### PR DESCRIPTION
According to GitLab's API documentation (https://docs.gitlab.com/api/wikis/#list-wiki-pages), the response of the wiki pages API only includes the content field when the `with_content` parameter is set to true.

Changes made:
- Added optional `with_content` parameter to ListWikiPagesSchema
- Made the content field optional in GitLabWikiPageSchema to properly handle responses with and without content
- Updated the listWikiPages function to support the new parameter
- Updated the request handler to pass the parameter to the API