### PR TITLE
Fix: Allow null for avatar_url in GitLab schemas

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -212,7 +212,7 @@ export const GitLabUsersResponseSchema = z.record(
     id: z.number(),
     username: z.string(),
     name: z.string(),
-    avatar_url: z.string(),
+    avatar_url: z.string().nullable(),
     web_url: z.string(),
   }).nullable()
 );
@@ -253,7 +253,7 @@ export const GitLabNamespaceExistsResponseSchema = z.object({
 export const GitLabOwnerSchema = z.object({
   username: z.string(), // Changed from login to match GitLab API
   id: z.number(),
-  avatar_url: z.string(),
+  avatar_url: z.string().nullable(),
   web_url: z.string(), // Changed from html_url to match GitLab API
   name: z.string(), // Added as GitLab includes full name
   state: z.string(), // Added as GitLab includes user state
@@ -593,7 +593,7 @@ export const GitLabForkParentSchema = z.object({
     .object({
       username: z.string(), // Changed from login to match GitLab API
       id: z.number(),
-      avatar_url: z.string(),
+      avatar_url: z.string().nullable(),
     })
     .optional(), // Made optional to handle cases where GitLab API doesn't include it
   web_url: z.string(), // Changed from html_url to match GitLab API


### PR DESCRIPTION
This PR fixes a validation error in the `search_repositories` MCP call where `items.0.owner.avatar_url` was expected to be a string but received `null` from the GitLab API.

Closes #51 

**Problem Solved:**
The GitLab API can return `null` for a user's `avatar_url` if they haven't set one. The existing schemas in `schemas.ts` did not account for this, defining `avatar_url` strictly as `z.string()`, leading to validation errors [1].

**Changes Made:**
The `avatar_url` field has been made nullable in the relevant Zod schemas within `schemas.ts`:

1.  **`GitLabOwnerSchema` (around line 255):**
    ```diff
    // Repository related schemas
    export const GitLabOwnerSchema = z.object({
      username: z.string(), // Changed from login to match GitLab API
      id: z.number(),
    - avatar_url: z.string(),
    + avatar_url: z.string().nullable(),
      web_url: z.string(), // Changed from html_url to match GitLab API
      name: z.string(), // Added as GitLab includes full name
      state: z.string(), // Added as GitLab includes user state
    });
    ```
    [1]

2.  **Union type for user object (around line 214):**
    ```diff
      z.string(),
      z.object({
        id: z.number(),
        username: z.string(),
        name: z.string(),
    -   avatar_url: z.string(),
    +   avatar_url: z.string().nullable(),
        web_url: z.string(),
      }).nullable()
    );
    ```
    [1]

3.  **`GitLabForkParentSchema` owner object (around line 595):**
    ```diff
      owner: z
        .object({
          username: z.string(), // Changed from login to match GitLab API
          id: z.number(),
    -     avatar_url: z.string(),
    +     avatar_url: z.string().nullable(),
        })
        .optional(), // Made optional to handle cases where GitLab API doesn't include it
    ```
    [1]

These changes ensure that the schema validation correctly handles `null` values for `avatar_url` returned by the GitLab API.

**Verification:**
After applying these changes:
1.  A Docker build of `gitlab-mcp` was successfully completed.
2.  The `search_repositories` MCP call was executed again.
3.  The call completed successfully without the `Invalid arguments: items.0.owner.avatar_url: Expected string, received null` error, confirming the fix.

