### PR TITLE
feat: add pagination support for CI job logs to prevent context window flooding

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -191,6 +191,8 @@ export const CancelPipelineSchema = z.object({
 export const GetPipelineJobOutputSchema = z.object({
   project_id: z.string().describe("Project ID or URL-encoded path"),
   job_id: z.number().describe("The ID of the job"),
+  limit: z.number().optional().describe("Maximum number of lines to return from the end of the log (default: 1000)"),
+  offset: z.number().optional().describe("Number of lines to skip from the end of the log (default: 0)"),
 });
 
 // User schemas


### PR DESCRIPTION
- Add optional `limit` and `offset` parameters to get_pipeline_job_output
- Default limit is 1000 lines when pagination is used
- Returns lines from the end of the log, with configurable offset
- Includes truncation metadata showing what was skipped
- Maintains backward compatibility (no parameters = full log)

This prevents large CI logs from overwhelming AI tooling context windows while still providing access to the most recent and relevant log output.