### PR TITLE
Fix notification_level null handling for GitLab group owners

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -296,14 +296,14 @@ export const GitLabRepositorySchema = z.object({
       project_access: z
         .object({
           access_level: z.number(),
-          notification_level: z.number().optional(),
+          notification_level: z.number().nullable().optional(),
         })
         .optional()
         .nullable(),
       group_access: z
         .object({
           access_level: z.number(),
-          notification_level: z.number().optional(),
+          notification_level: z.number().nullable().optional(),
         })
         .optional()
         .nullable(),


### PR DESCRIPTION
GitLab API returns null for notification_level when users are group owners, instead of a numeric value. This change updates the Zod schema to accept both number and null values for notification_level in both project_access and group_access permission objects.

Fixes TypeError when parsing repository permissions for group owners.

🤖 Generated with [Claude Code](https://claude.ai/code)