### PR TITLE
feat: add cookie-based authentication support for GitLab instances 🍪

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ $ sh scripts/image_push.sh docker_user_name
 - `USE_GITLAB_WIKI`: When set to 'true', enables the wiki-related tools (list_wiki_pages, get_wiki_page, create_wiki_page, update_wiki_page, delete_wiki_page). By default, wiki features are disabled.
 - `USE_MILESTONE`: When set to 'true', enables the milestone-related tools (list_milestones, get_milestone, create_milestone, edit_milestone, delete_milestone, get_milestone_issue, get_milestone_merge_requests, promote_milestone, get_milestone_burndown_events). By default, milestone features are disabled.
 - `USE_PIPELINE`: When set to 'true', enables the pipeline-related tools (list_pipelines, get_pipeline, list_pipeline_jobs, get_pipeline_job, get_pipeline_job_output, create_pipeline, retry_pipeline, cancel_pipeline). By default, pipeline features are disabled.
+- `GITLAB_AUTH_COOKIE_PATH`: Path to an authentication cookie file for GitLab instances that require cookie-based authentication. When provided, the cookie will be included in all GitLab API requests.
+- `GITLAB_AUTH_COOKIE_PATH`: Path to an authentication cookie file for GitLab instances that require cookie-based authentication. When provided, the cookie will be included in all GitLab API requests.
 
 ## Tools 🛠️
 


### PR DESCRIPTION
- Add GITLAB_AUTH_COOKIE_PATH environment variable support
- Handle #HttpOnly_ prefix in cookie files properly
- Enable redirect following when cookies are present
- Maintain compatibility with existing token-based auth