### PR TITLE
fix: avoid error caused by line_range type: null in discussion

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -662,13 +662,13 @@ export const GitLabMergeRequestSchema = z.object({
 export const LineRangeSchema = z.object({
   start: z.object({
     line_code: z.string().nullable().optional().describe("CRITICAL: Line identifier in format '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. USUALLY REQUIRED for GitLab diff comments despite being optional in schema. Example: 'a1b2c3d4e5f6_10_15'. Get this from GitLab diff API response, never fabricate."),
-    type: z.enum(["new", "old"]).nullable().optional().describe("Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. MUST match the line_code format and old_line/new_line values."),
+    type: z.enum(["new", "old", "expanded"]).nullable().optional().describe("Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. MUST match the line_code format and old_line/new_line values."),
     old_line: z.number().nullable().optional().describe("Line number in original file (before changes). REQUIRED when type='old', NULL when type='new' (for purely added lines), can be present for context lines."),
     new_line: z.number().nullable().optional().describe("Line number in modified file (after changes). REQUIRED when type='new', NULL when type='old' (for purely deleted lines), can be present for context lines."),
   }).describe("Start line position for multiline comment range. MUST specify either old_line OR new_line (or both for context), never neither."),
   end: z.object({
     line_code: z.string().nullable().optional().describe("CRITICAL: Line identifier in format '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. USUALLY REQUIRED for GitLab diff comments despite being optional in schema. Example: 'a1b2c3d4e5f6_12_17'. Must be from same file as start.line_code."),
-    type: z.enum(["new", "old"]).nullable().optional().describe("Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. SHOULD MATCH start.type for consistent ranges (don't mix old/new types)."),
+    type: z.enum(["new", "old", "expanded"]).nullable().optional().describe("Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. SHOULD MATCH start.type for consistent ranges (don't mix old/new types)."),
     old_line: z.number().nullable().optional().describe("Line number in original file (before changes). REQUIRED when type='old', NULL when type='new' (for purely added lines), can be present for context lines. MUST be >= start.old_line if both specified."),
     new_line: z.number().nullable().optional().describe("Line number in modified file (after changes). REQUIRED when type='new', NULL when type='old' (for purely deleted lines), can be present for context lines. MUST be >= start.new_line if both specified."),
   }).describe("End line position for multiline comment range. MUST specify either old_line OR new_line (or both for context), never neither. Range must be valid (end >= start)."),
@@ -703,23 +703,7 @@ export const GitLabDiscussionNoteSchema = z.object({
       position_type: z.enum(["text", "image", "file"]),
       new_line: z.number().nullable().optional().describe("Line number in the modified file (after changes). Used for added lines and context lines. Null for deleted lines."),
       old_line: z.number().nullable().optional().describe("Line number in the original file (before changes). Used for deleted lines and context lines. Null for newly added lines."),
-      line_range: z
-        .object({
-          start: z.object({
-            line_code: z.string().nullable().optional().describe("Line identifier in format: '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. Used to uniquely identify a specific line in the diff."),
-            type: z.enum(["new", "old", "expanded"]),
-            old_line: z.number().nullable().optional().describe("Line number in the original file (before changes). Null for newly added lines or unchanged context lines."),
-            new_line: z.number().nullable().optional().describe("Line number in the modified file (after changes). Null for deleted lines or unchanged context lines."),
-          }),
-          end: z.object({
-            line_code: z.string().nullable().optional().describe("Line identifier in format: '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. Used to uniquely identify a specific line in the diff."),
-            type: z.enum(["new", "old", "expanded"]),
-            old_line: z.number().nullable().optional().describe("Line number in the original file (before changes). Null for newly added lines or unchanged context lines."),
-            new_line: z.number().nullable().optional().describe("Line number in the modified file (after changes). Null for deleted lines or unchanged context lines."),
-          }),
-        })
-        .nullable()
-        .optional(), // For multi-line diff notes
+      line_range: LineRangeSchema.nullable().optional(), // For multi-line diff notes
       width: z.number().optional(), // For image diff notes
       height: z.number().optional(), // For image diff notes
       x: z.number().optional(), // For image diff notes


### PR DESCRIPTION
## Motivation

While testing the mr_discussions tool in MCP with Cursor, I encountered the following error for certain MRs:

```
⏺ GitLab:mr_discussions (MCP)(project_id: "...", merge_request_iid: 9156)…
  ⎿  Error: MCP error -32603: Invalid arguments: 0.notes.0.position.line_range.end.type: Required
```

Looking at the underlying API response, the issue was caused by a line_range block that did not include a type field. For example:

```json
"line_range": {
  "start": {
    "line_code": "709d83f82c721d666fe983bab82fafc2b75e79d6_67_65",
    "type": null,
    "old_line": 67,
    "new_line": 65
  },
  "end": {
    "line_code": "709d83f82c721d666fe983bab82fafc2b75e79d6_69_67",
    "type": null,
    "old_line": 69,
    "new_line": null
  }
}
```

In this case, end.type was not just one of new/old/expandable but null.

## Changes

Updated the zod schema for line_range to use the common LineRangeSchema, which already had `type` as nullable

## Testing

Confirmed that running the mr_discussions tool against the affected MR now works as expected using the following mcp.json configuration:

```json
{
  "mcpServers": {
    "GitLab": {
      "command": "npx",
      "args": ["-y", "github:wanderlog/gitlab-mcp"],
      "env": {
        "GITLAB_PERSONAL_ACCESS_TOKEN": "glpat-..."
      }
    }
  }
}
```

<img width="505" alt="image" src="https://github.com/user-attachments/assets/3a63abaf-cd5c-42bd-aed2-1aa1b7f770d7" />


<details>
  <summary>Full JSON of erroring response</summary>

```json
{
  "items": [
    {
      "id": "49c2eb8b154f939a82c521f897234b2446bea3c1",
      "individual_note": false,
      "notes": [
        {
          "id": 2568940190,
          "type": "DiffNote",
          "body": "Nit, since we're note passing in variant anymore, can you just pass in `defaultInputs` without destructuring it?",
          "author": {
            "username": "johndoe",
            "id": 21588835,
            "name": "John Doe",
            "avatar_url": "https://secure.gravatar.com/avatar/0cfdf18af5d52525ae4fd2f837780a997913a9d01dcfb5d363318ab24344185c?s=80&d=identicon",
            "web_url": "https://gitlab.com/johndoe"
          },
          "created_at": "2025-06-17T19:57:10.740Z",
          "updated_at": "2025-06-17T19:57:10.740Z",
          "system": false,
          "noteable_id": 391825028,
          "noteable_type": "MergeRequest",
          "project_id": 9347980,
          "noteable_iid": 9156,
          "resolvable": true,
          "resolved": false,
          "resolved_by": null,
          "resolved_at": null,
          "position": {
            "base_sha": "e76bdae00d127d01909774f5739c02e9b8c4fdf4",
            "start_sha": "e76bdae00d127d01909774f5739c02e9b8c4fdf4",
            "head_sha": "1d91425520553846b1b779647dc5e1c3b466a03a",
            "old_path": "mobile/templates/GuidedNewTripPlanScreen/CreateTripOnboardingSurvey/makeCreateTripOnboardingSurveySlides.test.ts",
            "new_path": "mobile/templates/GuidedNewTripPlanScreen/CreateTripOnboardingSurvey/makeCreateTripOnboardingSurveySlides.test.ts",
            "position_type": "text",
            "new_line": null,
            "old_line": 69,
            "line_range": {
              "start": {
                "line_code": "709d83f82c721d666fe983bab82fafc2b75e79d6_67_65",
                "type": null,
                "old_line": 67,
                "new_line": 65
              },
              "end": {
                "line_code": "709d83f82c721d666fe983bab82fafc2b75e79d6_69_67",
                "type": "old",
                "old_line": 69,
                "new_line": null
              }
            }
          }
        }
      ]
    }
  ],
  "pagination": {
    "x_next_page": null,
    "x_page": 1,
    "x_per_page": 100,
    "x_prev_page": null,
    "x_total": 1,
    "x_total_pages": 1
  }
}
```
</details>
