### PR TITLE
feat: add my_issues and list_project_members tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ When using with the Claude App, you need to set up your API key and URLs directl
       "env": {
         "GITLAB_PERSONAL_ACCESS_TOKEN": "your_gitlab_token",
         "GITLAB_API_URL": "your_gitlab_api_url",
+        "GITLAB_PROJECT_ID": "your_project_id", // Optional: default project
+        "GITLAB_LOCK_PROJECT": "false", // Optional: lock to single project
         "GITLAB_READ_ONLY_MODE": "false",
         "USE_GITLAB_WIKI": "false", // use wiki api?
         "USE_MILESTONE": "false", // use milestone api?
@@ -168,6 +170,7 @@ $ sh scripts/image_push.sh docker_user_name
 - `GITLAB_PERSONAL_ACCESS_TOKEN`: Your GitLab personal access token.
 - `GITLAB_API_URL`: Your GitLab API URL. (Default: `https://gitlab.com/api/v4`)
 - `GITLAB_PROJECT_ID`: Default project ID. If set, Overwrite this value when making an API request.
+- `GITLAB_LOCK_PROJECT`: When set to 'true', locks the MCP server to only access the project specified in `GITLAB_PROJECT_ID`. Any attempts to access other projects will be denied. Requires `GITLAB_PROJECT_ID` to be set.
 - `GITLAB_READ_ONLY_MODE`: When set to 'true', restricts the server to only expose read-only operations. Useful for enhanced security or when write access is not needed. Also useful for using with Cursor and it's 40 tool limit.
 - `USE_GITLAB_WIKI`: When set to 'true', enables the wiki-related tools (list_wiki_pages, get_wiki_page, create_wiki_page, update_wiki_page, delete_wiki_page). By default, wiki features are disabled.
 - `USE_MILESTONE`: When set to 'true', enables the milestone-related tools (list_milestones, get_milestone, create_milestone, edit_milestone, delete_milestone, get_milestone_issue, get_milestone_merge_requests, promote_milestone, get_milestone_burndown_events). By default, milestone features are disabled.

--- a/README.md
+++ b/README.md
@@ -207,48 +207,50 @@ $ sh scripts/image_push.sh docker_user_name
 20. `update_issue_note` - Modify an existing issue thread note
 21. `create_issue_note` - Add a new note to an existing issue thread
 22. `list_issues` - List issues in a GitLab project with filtering options
-23. `get_issue` - Get details of a specific issue in a GitLab project
-24. `update_issue` - Update an issue in a GitLab project
-25. `delete_issue` - Delete an issue from a GitLab project
-26. `list_issue_links` - List all issue links for a specific issue
-27. `list_issue_discussions` - List discussions for an issue in a GitLab project
-28. `get_issue_link` - Get a specific issue link
-29. `create_issue_link` - Create an issue link between two issues
-30. `delete_issue_link` - Delete an issue link
-31. `list_namespaces` - List all namespaces available to the current user
-32. `get_namespace` - Get details of a namespace by ID or path
-33. `verify_namespace` - Verify if a namespace path exists
-34. `get_project` - Get details of a specific project
-35. `list_projects` - List projects accessible by the current user
-36. `list_labels` - List labels for a project
-37. `get_label` - Get a single label from a project
-38. `create_label` - Create a new label in a project
-39. `update_label` - Update an existing label in a project
-40. `delete_label` - Delete a label from a project
-41. `list_group_projects` - List projects in a GitLab group with filtering options
-42. `list_wiki_pages` - List wiki pages in a GitLab project
-43. `get_wiki_page` - Get details of a specific wiki page
-44. `create_wiki_page` - Create a new wiki page in a GitLab project
-45. `update_wiki_page` - Update an existing wiki page in a GitLab project
-46. `delete_wiki_page` - Delete a wiki page from a GitLab project
-47. `get_repository_tree` - Get the repository tree for a GitLab project (list files and directories)
-48. `list_pipelines` - List pipelines in a GitLab project with filtering options
-49. `get_pipeline` - Get details of a specific pipeline in a GitLab project
-50. `list_pipeline_jobs` - List all jobs in a specific pipeline
-51. `get_pipeline_job` - Get details of a GitLab pipeline job number
-52. `get_pipeline_job_output` - Get the output/trace of a GitLab pipeline job number
-53. `create_pipeline` - Create a new pipeline for a branch or tag
-54. `retry_pipeline` - Retry a failed or canceled pipeline
-55. `cancel_pipeline` - Cancel a running pipeline
-56. `list_merge_requests` - List merge requests in a GitLab project with filtering options
-57. `list_milestones` - List milestones in a GitLab project with filtering options
-58. `get_milestone` - Get details of a specific milestone
-59. `create_milestone` - Create a new milestone in a GitLab project
-60. `edit_milestone` - Edit an existing milestone in a GitLab project
-61. `delete_milestone` - Delete a milestone from a GitLab project
-62. `get_milestone_issue` - Get issues associated with a specific milestone
-63. `get_milestone_merge_requests` - Get merge requests associated with a specific milestone
-64. `promote_milestone` - Promote a milestone to the next stage
-65. `get_milestone_burndown_events` - Get burndown events for a specific milestone
-66. `get_users` - Get GitLab user details by usernames
+23. `my_issues` - List issues assigned to the authenticated user
+24. `get_issue` - Get details of a specific issue in a GitLab project
+25. `update_issue` - Update an issue in a GitLab project
+26. `delete_issue` - Delete an issue from a GitLab project
+27. `list_issue_links` - List all issue links for a specific issue
+28. `list_issue_discussions` - List discussions for an issue in a GitLab project
+29. `get_issue_link` - Get a specific issue link
+30. `create_issue_link` - Create an issue link between two issues
+31. `delete_issue_link` - Delete an issue link
+32. `list_namespaces` - List all namespaces available to the current user
+33. `get_namespace` - Get details of a namespace by ID or path
+34. `verify_namespace` - Verify if a namespace path exists
+35. `get_project` - Get details of a specific project
+36. `list_projects` - List projects accessible by the current user
+37. `list_project_members` - List members of a GitLab project
+38. `list_labels` - List labels for a project
+39. `get_label` - Get a single label from a project
+40. `create_label` - Create a new label in a project
+41. `update_label` - Update an existing label in a project
+42. `delete_label` - Delete a label from a project
+43. `list_group_projects` - List projects in a GitLab group with filtering options
+44. `list_wiki_pages` - List wiki pages in a GitLab project
+45. `get_wiki_page` - Get details of a specific wiki page
+46. `create_wiki_page` - Create a new wiki page in a GitLab project
+47. `update_wiki_page` - Update an existing wiki page in a GitLab project
+48. `delete_wiki_page` - Delete a wiki page from a GitLab project
+49. `get_repository_tree` - Get the repository tree for a GitLab project (list files and directories)
+50. `list_pipelines` - List pipelines in a GitLab project with filtering options
+51. `get_pipeline` - Get details of a specific pipeline in a GitLab project
+52. `list_pipeline_jobs` - List all jobs in a specific pipeline
+53. `get_pipeline_job` - Get details of a GitLab pipeline job number
+54. `get_pipeline_job_output` - Get the output/trace of a GitLab pipeline job number
+55. `create_pipeline` - Create a new pipeline for a branch or tag
+56. `retry_pipeline` - Retry a failed or canceled pipeline
+57. `cancel_pipeline` - Cancel a running pipeline
+58. `list_merge_requests` - List merge requests in a GitLab project with filtering options
+59. `list_milestones` - List milestones in a GitLab project with filtering options
+60. `get_milestone` - Get details of a specific milestone
+61. `create_milestone` - Create a new milestone in a GitLab project
+62. `edit_milestone` - Edit an existing milestone in a GitLab project
+63. `delete_milestone` - Delete a milestone from a GitLab project
+64. `get_milestone_issue` - Get issues associated with a specific milestone
+65. `get_milestone_merge_requests` - Get merge requests associated with a specific milestone
+66. `promote_milestone` - Promote a milestone to the next stage
+67. `get_milestone_burndown_events` - Get burndown events for a specific milestone
+68. `get_users` - Get GitLab user details by usernames
 <!-- TOOLS-END -->

--- a/schemas.ts
+++ b/schemas.ts
@@ -1380,6 +1380,49 @@ export const GetCommitDiffSchema = z.object({
   sha: z.string().describe("The commit hash or name of a repository branch or tag"),
 });
 
+// Schema for listing issues assigned to the current user
+export const MyIssuesSchema = z.object({
+  project_id: z.string().optional().describe("Project ID or URL-encoded path (optional when GITLAB_PROJECT_ID is set)"),
+  state: z
+    .enum(["opened", "closed", "all"])
+    .optional()
+    .describe("Return issues with a specific state (default: opened)"),
+  labels: z.array(z.string()).optional().describe("Array of label names to filter by"),
+  milestone: z.string().optional().describe("Milestone title to filter by"),
+  search: z.string().optional().describe("Search for specific terms in title and description"),
+  created_after: z.string().optional().describe("Return issues created after the given time (ISO 8601)"),
+  created_before: z.string().optional().describe("Return issues created before the given time (ISO 8601)"),
+  updated_after: z.string().optional().describe("Return issues updated after the given time (ISO 8601)"),
+  updated_before: z.string().optional().describe("Return issues updated before the given time (ISO 8601)"),
+  per_page: z.number().optional().describe("Number of items per page (default: 20, max: 100)"),
+  page: z.number().optional().describe("Page number for pagination (default: 1)"),
+});
+
+// Schema for listing project members
+export const ListProjectMembersSchema = z.object({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
+  query: z.string().optional().describe("Search for members by name or username"),
+  user_ids: z.array(z.number()).optional().describe("Filter by user IDs"),
+  skip_users: z.array(z.number()).optional().describe("User IDs to exclude"),
+  per_page: z.number().optional().describe("Number of items per page (default: 20, max: 100)"),
+  page: z.number().optional().describe("Page number for pagination (default: 1)"),
+});
+
+// Schema for GitLab project member
+export const GitLabProjectMemberSchema = z.object({
+  id: z.number(),
+  username: z.string(),
+  name: z.string(),
+  state: z.string(),
+  avatar_url: z.string().nullable(),
+  web_url: z.string(),
+  access_level: z.number(),
+  access_level_description: z.string().optional(),
+  created_at: z.string(),
+  expires_at: z.string().nullable().optional(),
+  email: z.string().optional(),
+});
+
 // Export types
 export type GitLabAuthor = z.infer<typeof GitLabAuthorSchema>;
 export type GitLabFork = z.infer<typeof GitLabForkSchema>;
@@ -1449,3 +1492,6 @@ export type PaginationOptions = z.infer<typeof PaginationOptionsSchema>;
 export type ListCommitsOptions = z.infer<typeof ListCommitsSchema>;
 export type GetCommitOptions = z.infer<typeof GetCommitSchema>;
 export type GetCommitDiffOptions = z.infer<typeof GetCommitDiffSchema>;
+export type MyIssuesOptions = z.infer<typeof MyIssuesSchema>;
+export type ListProjectMembersOptions = z.infer<typeof ListProjectMembersSchema>;
+export type GitLabProjectMember = z.infer<typeof GitLabProjectMemberSchema>;


### PR DESCRIPTION
## Summary

This PR adds two new useful tools to the GitLab MCP server:

1. **`my_issues`** - Lists issues assigned to the authenticated user
2. **`list_project_members`** - Lists members of a GitLab project

## Features

### my_issues Tool
- Automatically fetches the current authenticated user via GitLab API
- Defaults to showing only open issues (can be overridden with state parameter)
- Supports all standard issue filters (labels, milestone, search, date ranges)
- Works with or without explicit project_id (uses GITLAB_PROJECT_ID if set)
- Added to read-only tools list

### list_project_members Tool  
- Lists all members of a specified GitLab project
- Useful for finding possible assignees when creating/updating issues
- Supports searching by name or username
- Includes pagination support
- Added to read-only tools list

## Implementation Details

- Added `getCurrentUser()` helper function to fetch authenticated user details
- Both tools follow existing patterns and conventions in the codebase
- Proper TypeScript types and Zod schemas included
- Updated README documentation with new tools (now 68 tools total)
- All changes are backward compatible

## Testing

Both tools have been tested locally with:
- TypeScript compilation (no errors)
- Various parameter combinations
- Error handling for missing project_id

## Usage Examples

```typescript
// Get all open issues assigned to me
my_issues()

// Get my closed issues with specific label
my_issues({ state: "closed", labels: ["bug"] })

// List project members
list_project_members({ project_id: "123" })

// Search for specific members
list_project_members({ project_id: "123", query: "john" })
```