### PR TITLE
Print logs to stderr

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -193,6 +193,7 @@ const logger = pino({
     options: {
       colorize: true,
       levelFirst: true,
+      destination: 2,
     },
   },
 });


### PR DESCRIPTION
Commit 3ad2954 inadvertently sent log messages to stdout instead of stderr. This breaks the stdio transport.