### PR TITLE
(feat): add tool to upload file for markdown content

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import {flexibleBoolean,flexibleBooleanNullable} from "./customSchemas.js"
+import { flexibleBoolean, flexibleBooleanNullable } from "./customSchemas.js";
 
 // Base schemas for common types
 export const GitLabAuthorSchema = z.object({
@@ -1363,6 +1363,20 @@ export const GetCommitDiffSchema = z.object({
   sha: z.string().describe("The commit hash or name of a repository branch or tag"),
 });
 
+// Markdown upload schemas
+export const GitLabMarkdownUploadSchema = z.object({
+  id: z.number(),
+  alt: z.string(),
+  url: z.string(),
+  full_path: z.string(),
+  markdown: z.string(),
+});
+
+export const MarkdownUploadSchema = z.object({
+  project_id: z.string().describe("Project ID or URL-encoded path of the project"),
+  file_path: z.string().describe("Path to the file to upload"),
+});
+
 export const GroupIteration = z.object({
   id: z.coerce.string(),
   iid: z.coerce.string(),
@@ -1460,3 +1474,5 @@ export type GetCommitOptions = z.infer<typeof GetCommitSchema>;
 export type GetCommitDiffOptions = z.infer<typeof GetCommitDiffSchema>;
 export type GroupIteration = z.infer<typeof GroupIteration>;
 export type ListGroupIterationsOptions = z.infer<typeof ListGroupIterationsSchema>;
+export type GitLabMarkdownUpload = z.infer<typeof GitLabMarkdownUploadSchema>;
+export type MarkdownUploadOptions = z.infer<typeof MarkdownUploadSchema>;


### PR DESCRIPTION
# Add tool to upload file for markdown content

## Summary
This PR adds a new tool `upload_markdown` that allows uploading files to GitLab projects for use in markdown content. This is particularly useful for embedding images, documents, or other files in GitLab markdown content.

## Changes

### New Features
- **Added `upload_markdown` tool**: Uploads files to GitLab projects and returns the markdown reference
- **New schemas**: Added `GitLabMarkdownUploadSchema` and `MarkdownUploadSchema` for type safety
- **File upload functionality**: Implements file reading and form-data upload to [GitLab's upload API](https://docs.gitlab.com/api/project_markdown_uploads/#upload-a-file)

### Technical Details
- **File validation**: Checks if the specified file exists before attempting upload
- **Form data handling**: Uses `form-data` library to properly handle file uploads
- **Error handling**: Integrates with existing GitLab error handling system
- **Type safety**: Full TypeScript support with proper schema validation

### Code Changes
- **`index.ts`**: 
  - Added `markdownUpload` function implementation
  - Added tool definition to `allTools` array
  - Added case handler for `upload_markdown` tool
  - Reorganized imports for better maintainability
- **`schemas.ts`**: 
  - Added `GitLabMarkdownUploadSchema` for response type
  - Added `MarkdownUploadSchema` for input parameters
  - Added corresponding TypeScript type exports

## Usage
The new tool can be used to upload files and get their markdown reference:

```typescript
// Example usage
const upload = await markdownUpload("project-id", "/path/to/image.png");
// Returns: { id: 123, alt: "image.png", url: "...", full_path: "...", markdown: "![image.png](...)" }
```

## Benefits
- Enables programmatic file uploads for markdown content
- Provides immediate markdown reference for uploaded files