### PR TITLE
feat: Add support for "inputs" parameter when running a pipeline

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3387,7 +3387,8 @@ async function getPipelineJobOutput(
 async function createPipeline(
   projectId: string,
   ref: string,
-  variables?: Array<{ key: string; value: string }>
+  variables?: Array<{ key: string; value: string }>,
+  inputs?: Record<string, string>
 ): Promise<GitLabPipeline> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
@@ -3397,6 +3398,9 @@ async function createPipeline(
   const body: any = { ref };
   if (variables && variables.length > 0) {
     body.variables = variables;
+  }
+  if (inputs && Object.keys(inputs).length > 0) {
+    body.inputs = inputs;
   }
 
   const response = await fetch(url.toString(), {
@@ -4940,8 +4944,8 @@ server.setRequestHandler(CallToolRequestSchema, async request => {
       }
 
       case "create_pipeline": {
-        const { project_id, ref, variables } = CreatePipelineSchema.parse(request.params.arguments);
-        const pipeline = await createPipeline(project_id, ref, variables);
+        const { project_id, ref, variables, inputs } = CreatePipelineSchema.parse(request.params.arguments);
+        const pipeline = await createPipeline(project_id, ref, variables, inputs);
         return {
           content: [
             {

--- a/schemas.ts
+++ b/schemas.ts
@@ -273,6 +273,10 @@ export const CreatePipelineSchema = z.object({
     )
     .optional()
     .describe("An array of variables to use for the pipeline"),
+  inputs: z
+    .record(z.string())
+    .optional()
+    .describe("Input values for spec-based pipelines (key-value pairs)"),
 });
 
 // Schema for retrying a pipeline


### PR DESCRIPTION
GitLab's newer spec-format pipelines require manual inputs that use the $[[ inputs.BUILD_API ]] syntax, which wasn't supported by the create_pipeline function. This prevented programmatic triggering of pipelines that depend on manual input parameters.

Changes:
- Add optional inputs parameter to CreatePipelineSchema as Record<string, string>
- Update createPipeline function signature to accept inputs parameter
- Include inputs in GitLab API request body when provided
- Maintain backward compatibility with existing variables parameter

This enables automated triggering of complex CI pipelines that build multiple container images based on input selections, resolving the limitation where such pipelines could only be triggered manually via GitLab's web interface.

🤖 Generated with [Claude Code](https://claude.ai/code)