### PR TITLE
fix: add fallback to config token when authInfo token is empty

### DIFF
--- a/src/mcpserver.ts
+++ b/src/mcpserver.ts
@@ -678,7 +678,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     }
     // Create GitlabSession instance
     // TODO: we silently do nothing if the authInfo is not properly forwared. should we do something?
-    const gitlabSession = new GitlabHandler(extra.authInfo?.token || "", cookieJar);
+    const gitlabSession = new GitlabHandler(extra.authInfo?.token || config.GITLAB_PERSONAL_ACCESS_TOKEN || "", cookieJar);
     if(cookieJar) {
       await gitlabSession.ensureSessionForCookieJar();
     }


### PR DESCRIPTION
When extra.authInfo?.token is undefined or empty, fallback to config.GITLAB_PERSONAL_ACCESS_TOKEN to ensure API calls work with proper authentication.

Fixes issue #217 