### PR TITLE
Fixes coverage parsing error on Pipelines related types

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -22,7 +22,7 @@ export const GitLabPipelineSchema = z.object({
   duration: z.number().nullable().optional(),
   started_at: z.string().nullable().optional(),
   finished_at: z.string().nullable().optional(),
-  coverage: z.number().nullable().optional(),
+  coverage: z.coerce.number().nullable().optional(),
   user: z
     .object({
       id: z.coerce.string(),
@@ -61,7 +61,7 @@ export const GitLabPipelineJobSchema = z.object({
   name: z.string(),
   ref: z.string(),
   tag: flexibleBoolean,
-  coverage: z.number().nullable().optional(),
+  coverage: z.coerce.number().nullable().optional(),
   created_at: z.string(),
   started_at: z.string().nullable().optional(),
   finished_at: z.string().nullable().optional(),


### PR DESCRIPTION
OpenApi spec for Gitlab specifies coverage is either null or float. 

Coercing the type should solve the parsing issue.

https://gitlab.com/gitlab-org/gitlab/-/raw/master/doc/api/openapi/openapi_v2.yaml (API_Entities_Ci_PipelineWithMetadata) 

```
  API_Entities_Ci_PipelineWithMetadata:
    type: object
    properties:
      id:
        type: integer
        format: int32
        example: 1
      iid:
        type: integer
        format: int32
        example: 2
...
      coverage:
        type: number
        format: float
        example: 98.29
      detailed_status:
        "$ref": "#/definitions/DetailedStatusEntity"
      name:
        type: string
        example: Build pipeline
    description: API_Entities_Ci_PipelineWithMetadata model

```