### PR TITLE
Feat/add delete to streamhttp

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5594,7 +5594,7 @@ async function startStreamableHTTPServer(): Promise<void> {
     } else {
       res.status(404).json({ error: "Session not found" });
     }
-});
+  });
 
 
   // Health check endpoint


### PR DESCRIPTION
i add a delete method to streamable-http connection
becase due to the official documents:https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http (states that : "Clients that no longer need a particular session (e.g., because the user is leaving the client application) SHOULD send an HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header, to explicitly terminate the session.")

i also think it can reduce the connection of the server so i add this part 
example of curl is as follow :
curl --location --request DELETE 'http://127.0.0.1:3002/mcp' \
--header 'mcp-session-id: 85be2a64-fd61-46a1-a710-213754545f85(your mcp-session-id)'