### PR TITLE
feat: add unrestricted mode for GITLAB_ALLOWED_PROJECT_IDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When using with the Claude App, you need to set up your API key and URLs directl
       "env": {
         "GITLAB_PERSONAL_ACCESS_TOKEN": "your_gitlab_token",
         "GITLAB_API_URL": "your_gitlab_api_url",
-        "GITLAB_ALLOWED_PROJECT_IDS": "your_project_id",
+        "GITLAB_ALLOWED_PROJECT_IDS": "your_project_id", // Optional: restrict access to specific projects
         "GITLAB_READ_ONLY_MODE": "false",
         "GITLAB_DENIED_TOOLS_REGEX": "",// Optional: exclude dangerous operations. ex) create.*|delete.*|update.*
         "USE_GITLAB_WIKI": "false", // use wiki api?
@@ -59,6 +59,7 @@ When using with the Claude App, you need to set up your API key and URLs directl
       "env": {
         "GITLAB_PERSONAL_ACCESS_TOKEN": "${input:gitlab-token}",
         "GITLAB_API_URL": "your-fancy-gitlab-url",
+        "GITLAB_ALLOWED_PROJECT_IDS": "", // Optional: leave empty for unrestricted access
         "GITLAB_READ_ONLY_MODE": "false",
         "GITLAB_DENIED_TOOLS_REGEX": "", // Optional: exclude dangerous operations. ex) create.*|delete.*|update.*
         "USE_GITLAB_WIKI": "false", // use wiki api?
@@ -100,6 +101,7 @@ When using with the Claude App, you need to set up your API key and URLs directl
       "env": {
         "GITLAB_PERSONAL_ACCESS_TOKEN": "your_gitlab_token",
         "GITLAB_API_URL": "https://gitlab.com/api/v4", // Optional, for self-hosted GitLab
+        "GITLAB_ALLOWED_PROJECT_IDS": "", // Optional: leave empty for unrestricted access
         "GITLAB_READ_ONLY_MODE": "false",
         "GITLAB_DENIED_TOOLS_REGEX": "create.*|delete.*|update.*",// Optional: exclude dangerous operations. ex) create.*|delete.*|update.*
         "USE_GITLAB_WIKI": "true",
@@ -117,6 +119,7 @@ When using with the Claude App, you need to set up your API key and URLs directl
 docker run -i --rm \
   -e GITLAB_PERSONAL_ACCESS_TOKEN=your_gitlab_token \
   -e GITLAB_API_URL="https://gitlab.com/api/v4" \
+  -e GITLAB_ALLOWED_PROJECT_IDS="" \
   -e GITLAB_READ_ONLY_MODE=true \
   -e USE_GITLAB_WIKI=true \
   -e USE_MILESTONE=true \
@@ -143,6 +146,7 @@ docker run -i --rm \
 docker run -i --rm \
   -e GITLAB_PERSONAL_ACCESS_TOKEN=your_gitlab_token \
   -e GITLAB_API_URL="https://gitlab.com/api/v4" \
+  -e GITLAB_ALLOWED_PROJECT_IDS="" \
   -e GITLAB_READ_ONLY_MODE=true \
   -e USE_GITLAB_WIKI=true \
   -e USE_MILESTONE=true \
@@ -167,9 +171,10 @@ docker run -i --rm \
 
 - `GITLAB_PERSONAL_ACCESS_TOKEN`: Your GitLab personal access token.
 - `GITLAB_API_URL`: Your GitLab API URL. (Default: `https://gitlab.com/api/v4`)
-- `GITLAB_ALLOWED_PROJECT_IDS`: Comma-separated list of allowed project IDs for security. Required for API access. Examples:
-  - Single value `your_project_id`: MCP server can only access that project and uses it as default
-  - Multiple values `123,456,789`: MCP server can access all three projects but requires explicit project ID in requests
+- `GITLAB_ALLOWED_PROJECT_IDS`: Comma-separated list of allowed project IDs for security. **Optional** - when not set, allows access to all projects the token has permission for. Examples:
+  - **Not set (Unrestricted Mode)**: Access to any project the token has permission for. `project_id` parameter must be provided for each operation. `fork_repository` and `create_repository` are enabled.
+  - **Single value `your_project_id` (Restricted Mode)**: MCP server can only access that project and uses it as default
+  - **Multiple values `123,456,789` (Restricted Mode)**: MCP server can access all three projects but requires explicit project ID in requests
 - `GITLAB_READ_ONLY_MODE`: When set to 'true', restricts the server to only expose read-only operations. Useful for enhanced security or when write access is not needed. Also useful for using with Cursor and it's 40 tool limit.
 - `GITLAB_DENIED_TOOLS_REGEX`: When set as a regular expression, it excludes the matching tools. This is crucial for security and tool limitation. Examples:
   - `create.*|delete.*|update.*` - exclude all create, delete, and update operations

--- a/index.ts
+++ b/index.ts
@@ -1005,6 +1005,19 @@ async function handleGitLabError(response: import("node-fetch").Response): Promi
  * @param {string} projectId - The project ID parameter passed to the function
  * @returns {string} The project ID to use for the API call
  * @throws {Error} If GITLAB_ALLOWED_PROJECT_IDS is set and the requested project is not in the whitelist
+ * 
+ * Security Modes:
+ * 1. GITLAB_ALLOWED_PROJECT_IDS is set (Restricted Mode):
+ *    - Only projects in the whitelist can be accessed
+ *    - If only one project is allowed, it becomes the default
+ *    - If multiple projects are allowed, projectId must be explicitly provided
+ *    - fork_repository and create_repository are disabled
+ * 
+ * 2. GITLAB_ALLOWED_PROJECT_IDS is not set (Unrestricted Mode):
+ *    - Any project can be accessed if projectId is provided
+ *    - projectId must be explicitly provided for each operation
+ *    - fork_repository and create_repository are enabled
+ *    - WARNING: This allows access to all projects the token has permission for
  */
 function getEffectiveProjectId(projectId: string): string {
   if (GITLAB_ALLOWED_PROJECT_IDS.length > 0) {
@@ -1026,11 +1039,12 @@ function getEffectiveProjectId(projectId: string): string {
     return projectId || GITLAB_ALLOWED_PROJECT_IDS[0];
   }
 
-  // If no allowed project list is set, use the provided project ID or throw error
+  // If no allowed project list is set (Unrestricted Mode), use the provided project ID or throw error
   if (!projectId) {
     throw new Error("No project ID provided and no default project configured. Please specify a project ID or set GITLAB_ALLOWED_PROJECT_IDS.");
   }
 
+  // In unrestricted mode, return the provided project ID (any project the token has access to)
   return projectId;
 }
 


### PR DESCRIPTION
- Make GITLAB_ALLOWED_PROJECT_IDS optional
- Add unrestricted mode documentation and implementation
- Update security mode explanations in code and README