### PR TITLE
feat(gitlab): GitLab Merge Request Notes and Discussions: Full CRUD + Thread Resolution

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -210,7 +210,7 @@ import {
   DeleteReleaseSchema,
   CreateReleaseEvidenceSchema,
   DownloadReleaseAssetSchema,
-  ListMergeRequestNotesSchema,
+  GetMergeRequestNotesSchema,
   GetMergeRequestNoteSchema,
   DeleteMergeRequestDiscussionNoteSchema,
   ResolveMergeRequestThreadSchema
@@ -672,9 +672,9 @@ const allTools = [
     inputSchema: toJSONSchema(GetMergeRequestNoteSchema),
   },
   {
-    name: 'list_merge_request_notes',
+    name: 'get_merge_request_notes',
     description: "List notes for a merge request",
-    inputSchema: toJSONSchema(ListMergeRequestNotesSchema),
+    inputSchema: toJSONSchema(GetMergeRequestNotesSchema),
   },
   {
     name: "update_merge_request_note",
@@ -2128,7 +2128,7 @@ async function getMergeRequestNote(
   return GitLabDiscussionNoteSchema.parse(data);
 }
 
-async function listMergeRequestNotes(
+async function getMergeRequestNotes(
   projectId: string,
   mergeRequestIid: string,
   sort?: 'asc' | 'desc',
@@ -5254,9 +5254,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
         };
       }
 
-      case 'list_merge_request_notes': {
-        const args = ListMergeRequestNotesSchema.parse(request.params.arguments);
-        const notes = await listMergeRequestNotes(
+      case 'get_merge_request_notes': {
+        const args = GetMergeRequestNotesSchema.parse(request.params.arguments);
+        const notes = await getMergeRequestNotes(
           args.project_id,
           args.merge_request_iid,
           args.sort,

--- a/schemas.ts
+++ b/schemas.ts
@@ -954,7 +954,7 @@ export const ListMergeRequestDiscussionsSchema = ProjectParamsSchema.extend({
   merge_request_iid: z.coerce.string().describe("The IID of a merge request"),
 }).merge(PaginationOptionsSchema);
 
-export const ListMergeRequestNotesSchema = ProjectParamsSchema.extend({
+export const GetMergeRequestNotesSchema = ProjectParamsSchema.extend({
   merge_request_iid: z.coerce.string().describe("The IID of a merge request"),
   sort: z.enum(["asc", "desc"]).optional().describe("The sort order of the notes"),
   order_by: z.enum(["created_at", "updated_at"]).optional().describe("The field to sort the notes by"),


### PR DESCRIPTION
### Overview
This change adds full CRUD support for both Merge Request (MR) Notes and Discussion Notes, plus the ability to resolve/unresolve MR discussion threads. It also clarifies naming to distinguish MR-level notes from discussion-thread notes.

### Key Changes
- Expanded schema imports to cover new MR note and discussion note operations.
- Added tools and request handlers for:
  - Resolving/unresolving MR discussion threads.
  - Creating/updating/deleting discussion notes within threads.
  - Creating/updating/deleting MR-level notes, plus fetching a single note and listing notes.
- Minor formatting improvement for the denied tools regex line.

### New/Updated Schemas
- Added: `CreateMergeRequestDiscussionNoteSchema`, `DeleteMergeRequestNoteSchema`, `UpdateMergeRequestDiscussionNoteSchema`, `GetMergeRequestNotesSchema`, `GetMergeRequestNoteSchema`, `DeleteMergeRequestDiscussionNoteSchema`, `ResolveMergeRequestThreadSchema`.

### New Tools
- Thread resolution:
  - `resolve_merge_request_thread`
- Discussion notes (thread-attached):
  - `create_merge_request_discussion_note`
  - `update_merge_request_discussion_note`
  - `delete_merge_request_discussion_note`
- MR-level notes:
  - `create_merge_request_note`
  - `update_merge_request_note`
  - `delete_merge_request_note`
  - `get_merge_request_note`
  - `get_merge_request_notes`

### New/Renamed Functions
- New:
  - `deleteMergeRequestDiscussionNote`
  - `createMergeRequestNote`
  - `deleteMergeRequestNote`
  - `getMergeRequestNote`
  - `getMergeRequestNotes`
  - `updateMergeRequestNote` (MR-level)
  - `resolveMergeRequestThread`
- Renamed:
  - `updateMergeRequestNote` → `updateMergeRequestDiscussionNote` (discussion note)
  - `createMergeRequestNote` (discussion) → `createMergeRequestDiscussionNote`

### Request Routing Updates
- Added handlers for all the new tools and aligned responses:
  - `resolve_merge_request_thread`
  - `create_merge_request_discussion_note`
  - `update_merge_request_discussion_note`
  - `delete_merge_request_discussion_note`
  - `create_merge_request_note`
  - `update_merge_request_note`
  - `delete_merge_request_note`
  - `get_merge_request_note`
  - `get_merge_request_notes`

### Breaking Changes
- Tool semantics adjusted:
  - Previously, `update_merge_request_note` updated discussion notes. Now, it updates MR-level notes.
  - Use `update_merge_request_discussion_note` for discussion notes going forward.
- If your integration relied on the old semantics:
  - For discussion note updates, migrate to `update_merge_request_discussion_note`.
  - For MR-level note updates, keep using `update_merge_request_note`.

### API Usage (Examples)
- Create MR-level note:
  - `create_merge_request_note { project_id, merge_request_iid, body }`
- Get MR-level notes:
  - `get_merge_request_notes { project_id, merge_request_iid, sort?, order_by? }`
- Get/Update/Delete MR-level note:
  - `get_merge_request_note`
  - `update_merge_request_note`
  - `delete_merge_request_note`
- Manage discussion notes within a thread:
  - `create_merge_request_discussion_note`
  - `update_merge_request_discussion_note`
  - `delete_merge_request_discussion_note`
- Resolve/unresolve a discussion thread:
  - `resolve_merge_request_thread { project_id, merge_request_iid, discussion_id, resolved? }`

### Testing Recommendations
- Validate CRUD flows separately for discussion notes vs MR-level notes.
- Verify `resolve_merge_request_thread` toggles resolution state correctly.
- Exercise error paths (permission denied, missing resources, invalid params) to confirm error handling and messages.

### Affected Files
- `index.ts` (tool registration, request routing, and core GitLab API interactions)
