### PR TITLE
Fix regex for GitLab PAT token validation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6109,7 +6109,7 @@ async function startStreamableHTTPServer(): Promise<void> {
   const validateToken = (token: string): boolean => {
     // GitLab PAT format: glpat-xxxxx (min 20 chars)
     if (token.length < 20) return false;
-    if (!/^[a-zA-Z0-9_-]+$/.test(token)) return false;
+    if (!/^[a-zA-Z0-9_\.-]+$/.test(token)) return false;
     return true;
   };
 


### PR DESCRIPTION
Some tokens have a "." (period) which makes them invalid from this mcp server perspective, returning a 401 while the token is actually valid