### PR TITLE
fix: update pagination parameters in getRepositoryTree function and s…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4044,7 +4044,7 @@ async function getRepositoryTree(options: GetRepositoryTreeOptions): Promise<Git
   if (options.recursive) queryParams.append("recursive", "true");
   if (options.per_page) queryParams.append("per_page", options.per_page.toString());
   if (options.page_token) queryParams.append("page_token", options.page_token);
-  if (options.pagination) queryParams.append("pagination", options.pagination);
+  if (options.page) queryParams.append("page", options.page);
 
   const headers: Record<string, string> = {
     ...BASE_HEADERS,

--- a/schemas.ts
+++ b/schemas.ts
@@ -526,8 +526,8 @@ export const GetRepositoryTreeSchema = z.object({
     .describe("The name of a repository branch or tag. Defaults to the default branch."),
   recursive: z.boolean().optional().describe("Boolean value to get a recursive tree"),
   per_page: z.number().optional().describe("Number of results to show per page"),
-  page_token: z.string().optional().describe("The tree record ID for pagination"),
-  pagination: z.string().optional().describe("Pagination method (keyset)"),
+  page_token: z.string().optional().describe("The tree record ID for page"),
+  page: z.string().optional().describe("Page method (keyset)"),
 });
 
 export const GitLabTreeSchema = z.object({


### PR DESCRIPTION
Parameters of the /repository/tree interface

1. Required parameters
ID (string or integer)
Description: The ID or URL encoding path of the project (such as namespace/project name).
Example: id=42 or id=mygroup% 2Fmyproject.
2. Optional parameters
Path (string)
Description: Specify the subdirectories path within the repository (default is the root directory).
Example: path=src/components means to view the contents of the src/components directory.
Ref (string)
Description: Branch name, label, or commit hash (defaults to the default branch of the project, usually main or master).
Example: ref=develop or ref=abc123f (submit hash).
Recursive (Boolean value)
Explanation: Recursively return all subdirectories' contents (default is false, only direct sub items are returned).
Example: Recursive=true can obtain the complete directory tree.
Per_rage (integer)
Description: The number of items returned per page (used for pagination, in conjunction with the page parameter).
Example: per_mage=20 means a maximum of 20 files/folders per page.
Page (integer)
Description: Specify the page number of the returned result (in conjunction with per_mage to implement pagination).
Example: Page=2 returns data from the second page.