### PR TITLE
Pin zod-to-json-schema to 3.24.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zereight/mcp-gitlab",
-  "version": "2.0.9",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zereight/mcp-gitlab",
-      "version": "2.0.9",
+      "version": "2.0.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",
@@ -23,7 +23,7 @@
         "pkce-challenge": "^5.0.0",
         "socks-proxy-agent": "^8.0.5",
         "tough-cookie": "^5.1.2",
-        "zod-to-json-schema": "^3.23.5"
+        "zod-to-json-schema": "3.24.5"
       },
       "bin": {
         "mcp-gitlab": "build/index.js"
@@ -974,7 +974,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
       "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1062,7 +1061,6 @@
       "integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.33.0",
         "@typescript-eslint/types": "8.33.0",
@@ -1277,7 +1275,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1947,7 +1944,6 @@
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2180,7 +2176,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -4177,7 +4172,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4347,7 +4341,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pkce-challenge": "^5.0.0",
     "socks-proxy-agent": "^8.0.5",
     "tough-cookie": "^5.1.2",
-    "zod-to-json-schema": "^3.23.5"
+    "zod-to-json-schema": "3.24.5"
   },
   "devDependencies": {
     "@types/express": "^5.0.2",


### PR DESCRIPTION
## Summary

- Pin `zod-to-json-schema` to exactly `3.24.5` by removing the caret range (`^`) to prevent end users from getting the broken v3.25.0

## Problem

`package.json` declared `zod-to-json-schema` with a caret range (`^3.23.5`). When [version 3.25.0](https://www.npmjs.com/package/zod-to-json-schema) was released yesterday, the converter stopped emitting `type: "object"` for multiple tool schemas. MCP Inspector (and any strict MCP SDK client) now rejects `list_tools` with dozens of `invalid_literal expected "object"` errors.

**Why this went unnoticed in development:**

The repo's `package-lock.json` locked the version to `3.24.5`, so developers running `npm install` in the repo always got the working version. However, **`package-lock.json` is not published to npm** by default—it's automatically excluded from the published package tarball.

**What happens to end users since v3.25.0 was released yesterday:**

When users install via `npm install @zereight/mcp-gitlab` or `npx @zereight/mcp-gitlab`:
1. They receive the published package **without** the lock file
2. npm resolves dependencies fresh from `package.json` ranges
3. The caret range `^3.23.5` allows any version `>=3.23.5 <4.0.0`
4. npm fetches the latest matching version → **broken `3.25.0`**

**This means anyone doing a fresh install of the package since yesterday is receiving an incompatible version of `zod-to-json-schema` that breaks tool schema generation.**

## Fix

Change `"zod-to-json-schema": "^3.23.5"` to `"zod-to-json-schema": "3.24.5"` (exact pin, no caret). This ensures the known-working version from `package-lock.json` is always installed for end users.