### PR TITLE
feat: add 405 response for GET /mcp endpoint when STREAMABLE_HTTP is …

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6662,6 +6662,15 @@ async function startStreamableHTTPServer(): Promise<void> {
     }
   });
 
+  // Reject unsupported methods on /mcp
+  app.get("/mcp", (_req: Request, res: Response) => {
+    res.setHeader("Allow", "POST, DELETE");
+    res.status(405).json({
+      error: "Method Not Allowed",
+      message: "GET /mcp is not supported when STREAMABLE_HTTP is enabled. Use POST to communicate with the MCP server."
+    });
+  });
+
   // Metrics endpoint
   app.get("/metrics", (_req: Request, res: Response) => {
     res.json({

--- a/test/test-all-transport-server.ts
+++ b/test/test-all-transport-server.ts
@@ -263,6 +263,13 @@ describe('GitLab MCP Server - Streamable HTTP Transport', () => {
     console.log('Client disconnected from Streamable HTTP server');
   });
 
+  test('should return 405 for GET /mcp', async () => {
+    const response = await fetch(`http://${HOST}:${port}/mcp`);
+    assert.strictEqual(response.status, 405, 'GET /mcp should respond with 405');
+    const body = await response.json();
+    assert.strictEqual(body?.error, 'Method Not Allowed');
+  });
+
   test('should list tools via Streamable HTTP', async () => {
     const tools: ListToolsResult = await client.listTools();
     assert.ok(tools !== null && tools !== undefined, 'Tools response should be defined');


### PR DESCRIPTION
when STREAMABLE_HTTP=true then answer with 405 to GET /mcp instead of 404.

https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#listening-for-messages-from-the-server

