### PR TITLE
ci: add missing tests to PR workflow

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -104,6 +104,16 @@ jobs:
         GITLAB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITLAB_PERSONAL_ACCESS_TOKEN }}
         GITLAB_PROJECT_ID: ${{ secrets.TEST_PROJECT_ID }}
     
+    - name: Run OAuth tests (mock server)
+      run: |
+        echo "Running OAuth tests with mock server..."
+        npm run test:oauth
+    
+    - name: Run list_merge_requests tests (mock server)
+      run: |
+        echo "Running list_merge_requests tests with mock server..."
+        npm run test:list-merge-requests
+
     - name: Test Docker build
       run: |
         docker build -t mcp-gitlab-test .

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:mcp:readonly": "tsx test/readonly-mcp-tests.ts",
     "test:oauth": "tsx test/oauth-tests.ts",
     "test:list-merge-requests": "npm run build && tsx test/test-list-merge-requests.ts",
-    "test:all": "npm run test && npm run test:mcp:readonly && npm run test:oauth",
+    "test:all": "npm run test && npm run test:mcp:readonly && npm run test:oauth && npm run test:list-merge-requests",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "format": "prettier --write \"**/*.{js,ts,json,md}\"",


### PR DESCRIPTION
## Summary
Ensures all test scripts in package.json are executed during CI.

## Changes

### .github/workflows/pr-test.yml
- Add `test:oauth` to integration-test job (uses mock server, no secrets needed)
- Add `test:list-merge-requests` to integration-test job (uses mock server)

### package.json
- Update `test:all` script to include `test:list-merge-requests`

## Before vs After

| Test Script | Before | After |
|-------------|--------|-------|
| test | ✅ | ✅ |
| test:integration | ✅ | ✅ |
| test:remote-auth | ✅ | ✅ |
| test:mcp:readonly | ✅ | ✅ |
| test:oauth | ❌ | ✅ |
| test:list-merge-requests | ❌ | ✅ |
| test:server | ❌ | ❌ (requires manual execution) |

## Note
`test:server` is not added as it requires a specific server setup. All other tests that can run with mock servers are now included.