### PR TITLE
feat: add excluded_file_patterns parameter to get_merge_request_diffs

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -1172,6 +1172,12 @@ export const MergeMergeRequestSchema = ProjectParamsSchema.extend({
 
 export const GetMergeRequestDiffsSchema = GetMergeRequestSchema.extend({
   view: z.enum(["inline", "parallel"]).optional().describe("Diff view type"),
+  excluded_file_patterns: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Array of regex patterns to exclude files from the diff results. Each pattern is a JavaScript-compatible regular expression that matches file paths to ignore. Examples: ["^vendor/", "\\.lock$", "package-lock\\.json"]'
+    ),
 });
 
 export const ListMergeRequestDiffsSchema = GetMergeRequestSchema.extend({

--- a/test/test-mr-diffs-filter.ts
+++ b/test/test-mr-diffs-filter.ts
@@ -1,0 +1,156 @@
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'child_process';
+import { MockGitLabServer, findMockServerPort } from './utils/mock-gitlab-server.js';
+
+const MOCK_TOKEN = 'glpat-mock-token-12345';
+const TEST_PROJECT_ID = '123';
+const TEST_MR_IID = '1';
+
+// Helper to call get_merge_request_diffs
+async function callGetMergeRequestDiffs(args: Record<string, any> = {}, env: NodeJS.ProcessEnv) {
+  return new Promise<any[]>((resolve, reject) => {
+    const proc = spawn('node', ['build/index.js'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        ...env,
+        GITLAB_READ_ONLY_MODE: 'true'
+      }
+    });
+
+    let output = '';
+    let errorOutput = '';
+    proc.stdout?.on('data', d => output += d);
+    proc.stderr?.on('data', d => errorOutput += d);
+
+    proc.on('close', (code) => {
+      if (code !== 0) return reject(new Error(`Process exited with code ${code}: ${errorOutput}`));
+
+      // Find the JSON line in stdout
+      const line = output.split('\n').find(l => l.startsWith('{'));
+      if (!line) return reject(new Error('No JSON output found'));
+
+      try {
+        const response = JSON.parse(line);
+        if (response.error) {
+          reject(response.error);
+        } else {
+          // Parse the tool result content
+          const content = response.result?.content?.[0]?.text;
+          if (content) {
+            try {
+              resolve(JSON.parse(content));
+            } catch (e) {
+              reject(new Error(`Failed to parse tool output JSON: ${content}`));
+            }
+          } else {
+            resolve(response.result);
+          }
+        }
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    proc.stdin?.end(JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "get_merge_request_diffs", arguments: args }
+    }) + '\n');
+  });
+}
+
+describe('get_merge_request_diffs with excluded_file_patterns', () => {
+  let mockGitLab: MockGitLabServer;
+  let mockGitLabUrl: string;
+
+  before(async () => {
+    const mockPort = await findMockServerPort(9100);
+    mockGitLab = new MockGitLabServer({
+      port: mockPort,
+      validTokens: [MOCK_TOKEN]
+    });
+    await mockGitLab.start();
+    mockGitLabUrl = mockGitLab.getUrl();
+  });
+
+  after(async () => {
+    await mockGitLab.stop();
+  });
+
+  test('returns all diffs without filtering', async () => {
+    const diffs = await callGetMergeRequestDiffs(
+      { project_id: TEST_PROJECT_ID, merge_request_iid: TEST_MR_IID },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN
+      }
+    );
+
+    assert.ok(Array.isArray(diffs), 'Response should be an array');
+    assert.strictEqual(diffs.length, 4, 'Should return 4 diffs');
+    assert.strictEqual(diffs[0].new_path, 'src/index.ts');
+    assert.strictEqual(diffs[1].new_path, 'vendor/package/file.js');
+    assert.strictEqual(diffs[2].new_path, 'README.md');
+    assert.strictEqual(diffs[3].new_path, 'package-lock.json');
+  });
+
+  test('filters out vendor folder with ^vendor/ pattern', async () => {
+    const diffs = await callGetMergeRequestDiffs(
+      {
+        project_id: TEST_PROJECT_ID,
+        merge_request_iid: TEST_MR_IID,
+        excluded_file_patterns: ['^vendor/']
+      },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN
+      }
+    );
+
+    assert.ok(Array.isArray(diffs), 'Response should be an array');
+    assert.strictEqual(diffs.length, 3, 'Should return 3 diffs (vendor filtered out)');
+    assert.strictEqual(diffs[0].new_path, 'src/index.ts');
+    assert.strictEqual(diffs[1].new_path, 'README.md');
+    assert.strictEqual(diffs[2].new_path, 'package-lock.json');
+  });
+
+  test('filters out package-lock.json with package-lock pattern', async () => {
+    const diffs = await callGetMergeRequestDiffs(
+      {
+        project_id: TEST_PROJECT_ID,
+        merge_request_iid: TEST_MR_IID,
+        excluded_file_patterns: ['package-lock\\.json']
+      },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN
+      }
+    );
+
+    assert.ok(Array.isArray(diffs), 'Response should be an array');
+    assert.strictEqual(diffs.length, 3, 'Should return 3 diffs (package-lock.json filtered out)');
+    assert.strictEqual(diffs[0].new_path, 'src/index.ts');
+    assert.strictEqual(diffs[1].new_path, 'vendor/package/file.js');
+    assert.strictEqual(diffs[2].new_path, 'README.md');
+  });
+
+  test('filters multiple patterns at once', async () => {
+    const diffs = await callGetMergeRequestDiffs(
+      {
+        project_id: TEST_PROJECT_ID,
+        merge_request_iid: TEST_MR_IID,
+        excluded_file_patterns: ['^vendor/', 'package-lock\\.json']
+      },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN
+      }
+    );
+
+    assert.ok(Array.isArray(diffs), 'Response should be an array');
+    assert.strictEqual(diffs.length, 2, 'Should return 2 diffs (vendor and package-lock filtered out)');
+    assert.strictEqual(diffs[0].new_path, 'src/index.ts');
+    assert.strictEqual(diffs[1].new_path, 'README.md');
+  });
+});

--- a/test/utils/mock-gitlab-server.ts
+++ b/test/utils/mock-gitlab-server.ts
@@ -366,6 +366,61 @@ export class MockGitLabServer {
       ]);
     });
 
+    // GET /api/v4/projects/:projectId/merge_requests/:mr_iid/changes - Get MR diffs
+    this.app.get('/api/v4/projects/:projectId/merge_requests/:mr_iid/changes', (req: AuthenticatedRequest, res: Response) => {
+      const mrIid = parseInt(req.params.mr_iid);
+      res.json({
+        id: mrIid,
+        iid: mrIid,
+        project_id: parseInt(req.params.projectId),
+        title: `Test MR ${mrIid}`,
+        state: 'opened',
+        created_at: '2024-01-01T00:00:00Z',
+        changes: [
+          {
+            old_path: 'src/index.ts',
+            new_path: 'src/index.ts',
+            a_mode: '100644',
+            b_mode: '100644',
+            diff: '@@ -1,1 +1,2 @@\n-line 1\n+line 1 modified\n+new line 2\n',
+            new_file: false,
+            renamed_file: false,
+            deleted_file: false
+          },
+          {
+            old_path: 'vendor/package/file.js',
+            new_path: 'vendor/package/file.js',
+            a_mode: '100644',
+            b_mode: '100644',
+            diff: '@@ -1,1 +1,1 @@\n-vendor content old\n+vendor content new\n',
+            new_file: false,
+            renamed_file: false,
+            deleted_file: false
+          },
+          {
+            old_path: 'README.md',
+            new_path: 'README.md',
+            a_mode: '100644',
+            b_mode: '100644',
+            diff: '@@ -1,1 +1,1 @@\n-old readme\n+new readme\n',
+            new_file: false,
+            renamed_file: false,
+            deleted_file: false
+          },
+          {
+            old_path: 'package-lock.json',
+            new_path: 'package-lock.json',
+            a_mode: '100644',
+            b_mode: '100644',
+            diff: '{\n- "version": "1.0.0"\n+ "version": "1.0.1"\n}\n',
+            new_file: false,
+            renamed_file: false,
+            deleted_file: false
+          }
+        ]
+      });
+    });
+
     // Health check endpoint
     this.app.get('/health', (req: Request, res: Response) => {
       res.json({ status: 'ok', message: 'Mock GitLab API is running' });


### PR DESCRIPTION
### Summary

  - Add excluded_file_patterns parameter to get_merge_request_diffs tool
  - Filter out unwanted files from MR diffs using regex patterns (e.g., vendor/, lock files)
  - Add comprehensive tests for the new filtering functionality

### Description

  The get_merge_request_diffs tool now supports an optional excluded_file_patterns parameter that accepts an array of regex patterns to exclude specific files from the diff results. This is essential for automated code review workflows where AI assistants need to focus on actual code changes without noise from:

  - Vendor directories (^vendor/)
  - Lock files (package-lock\.json, composer.lock)
  - Generated files
  - Build artifacts
  - Any other unwanted paths

  The implementation is copied from get_branch_diffs to maintain consistency across diff-related tools in the codebase.

  Example usage:
```
{
  "name": "get_merge_request_diffs",
  "arguments": {
    "project_id": "group/project",
    "merge_request_iid": "123",
    "excluded_file_patterns": ["^vendor/", "package-lock\\.json"]
  }
}
```

### Test plan

  - Added test/test-mr-diffs-filter.ts with 4 test cases covering:
    - No filtering (returns all diffs)
    - Single pattern filtering (vendor folder)
    - Single pattern filtering (specific file)
    - Multiple patterns filtering
  - All tests passing
  - TypeScript compilation successful