### PR TITLE
Add cookie file reload and session warmup for proxy authenticationFix cookie warmup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -530,7 +530,7 @@ async function reloadCookiesIfChanged(): Promise<void> {
       if (mtime !== lastCookieMtime) {
         logger.info(
           { oldMtime: lastCookieMtime, newMtime: mtime },
-          "Cookie file changed, reloading"
+          lastCookieMtime === 0 ? "Loading cookie file" : "Cookie file changed, reloading"
         );
         lastCookieMtime = mtime;
         const newJar = await createCookieJar();
@@ -565,7 +565,7 @@ async function ensureSessionForRequest(): Promise<void> {
   if (!cookieJar || initialSessionRequestMade) return;
 
   try {
-    const response = await fetch(`${GITLAB_API_URL}/user`, {
+    const response = await fetch(`${getEffectiveApiUrl()}/user`, {
       ...getFetchConfig(),
       redirect: "follow",
     });


### PR DESCRIPTION


This PR addresses #314 and adds two features for cookie-based authentication (`GITLAB_AUTH_COOKIE_PATH`) when using a proxy that requires session establishment.

### Feature 1: Session warmup

When accessing GitLab through a proxy that requires cookie-based authentication, the first request can fail because the proxy session hasn't been established yet.

This adds a warmup request to `/api/v4/user` before the first real request, which establishes the session with the proxy. Subsequent requests reuse the warmed session.

### Feature 2: Cookie file reload on change

Cookies are loaded from file at MCP server startup. For authentication systems where cookies expire periodically (e.g., every 2 hours) and are refreshed by an external process, the MCP server previously required a restart to pick up new cookies.

Now the cookie file's mtime is checked before each request. If the file has been modified, cookies are reloaded and the session is re-warmed automatically.

## Changes

```typescript
// Resolve cookie path once at startup using os.homedir() for cross-platform support
const resolvedCookiePath = GITLAB_AUTH_COOKIE_PATH
  ? GITLAB_AUTH_COOKIE_PATH.startsWith("~/")
    ? path.join(os.homedir(), GITLAB_AUTH_COOKIE_PATH.slice(2))
    : GITLAB_AUTH_COOKIE_PATH
  : null;

// Cookie jar and fetch - reloaded when cookie file changes
let cookieJar: CookieJar | null = null;
let fetch: typeof nodeFetch = nodeFetch;
let lastCookieMtime = 0;
let cookieReloadLock: Promise<void> | null = null;
let initialSessionRequestMade = false;

// Cookie jar is loaded on first request via reloadCookiesIfChanged (lastCookieMtime=0 triggers load)

async function reloadCookiesIfChanged(): Promise<void> {
  if (!resolvedCookiePath) return;
  if (cookieReloadLock) return cookieReloadLock;

  cookieReloadLock = (async () => {
    try {
      const mtime = (await fs.promises.stat(resolvedCookiePath)).mtimeMs;
      if (mtime !== lastCookieMtime) {
        logger.info(
          { oldMtime: lastCookieMtime, newMtime: mtime },
          "Cookie file changed, reloading"
        );
        lastCookieMtime = mtime;
        const newJar = await createCookieJar();
        cookieJar = newJar;
        fetch = newJar ? fetchCookie(nodeFetch, newJar) : nodeFetch;
        initialSessionRequestMade = false;
      }
    } catch {
      // File deleted or inaccessible - clear cached cookies
      if (cookieJar) {
        logger.info("Cookie file removed, clearing cached cookies");
        cookieJar = null;
        fetch = nodeFetch;
        lastCookieMtime = 0;
        initialSessionRequestMade = false;
      }
    }
  })();

  try {
    await cookieReloadLock;
  } finally {
    cookieReloadLock = null;
  }
}

async function ensureSessionForRequest(): Promise<void> {
  if (!resolvedCookiePath) return;

  await reloadCookiesIfChanged();

  if (!cookieJar || initialSessionRequestMade) return;

  // Make warmup request to establish session cookies
  try {
    const response = await fetch(`${GITLAB_API_URL}/user`, {
      ...getFetchConfig(),
      redirect: "follow",
    });
    // Check if cookies were set by verifying we got a valid response
    initialSessionRequestMade = response.ok || response.status === 401;
  } catch {
    logger.debug("Session warmup request failed, will retry on next request");
  }
}
```

## Testing

1. Start MCP server with `GITLAB_AUTH_COOKIE_PATH` pointing to a cookie file
2. Make a GitLab request (should succeed after warmup)
3. Modify the cookie file externally (e.g., `touch ~/.cookies/gitlab`)
4. Make another request - server should log "Cookie file changed, reloading" and re-warm
5. Delete the cookie file - server should log "Cookie file removed, clearing cached cookies" and fall back to standard fetch

## Tradeoffs Considered

| Approach | Pros | Cons |
|----------|------|------|
| Reload cookies on every request | Always fresh | Doubles HTTP traffic + fs read per request |
| Reload on 401/403 | Only reload when needed | False positives - auth errors happen for other reasons |
| Time-based re-warm | Simple | Arbitrary interval, doesn't align with actual cookie refresh |
| **Mtime check per request** ✓ | Minimal overhead, reloads only when file changes | One stat() syscall per request when cookie auth is enabled (negligible) |

## Key Implementation Details

- **Lazy loading**: Cookies are loaded on first request (not at startup), avoiding race conditions with async initialization
- **Cache invalidation**: If the cookie file is deleted, cached cookies are cleared and fetch falls back to standard behavior
- **Cross-platform**: Uses `os.homedir()` instead of `process.env.HOME` for Windows compatibility
- **Async I/O**: Uses `fs.promises` for non-blocking file operations
- **Concurrency safe**: `cookieReloadLock` prevents parallel reload operations
- **Clock-skew tolerant**: Uses `!==` instead of `>` for mtime comparison
- **No arbitrary delays**: Removed 100ms sleep; `fetch-cookie` awaits `setCookie` before returning

## Impact

- First request no longer fails when using proxy authentication
- Users with short-lived auth cookies no longer need to restart the MCP server when cookies are refreshed externally
