### PR TITLE
fix: add tldts as direct dependency for ESM compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "pino-pretty": "^13.0.0",
         "pkce-challenge": "^5.0.0",
         "socks-proxy-agent": "^8.0.5",
+        "tldts": "^6.1.86",
         "tough-cookie": "^5.1.2",
         "zod": "^3.24.2",
         "zod-to-json-schema": "3.24.5"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\""
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.24.2",
     "@types/node-fetch": "^2.6.12",
     "express": "^5.1.0",
     "fetch-cookie": "^3.1.0",
@@ -53,9 +54,9 @@
     "pino-pretty": "^13.0.0",
     "pkce-challenge": "^5.0.0",
     "socks-proxy-agent": "^8.0.5",
+    "tldts": "^6.1.86",
     "tough-cookie": "^5.1.2",
     "zod": "^3.24.2",
-    "@modelcontextprotocol/sdk": "^1.24.2",
     "zod-to-json-schema": "3.24.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem
When using `npx` with Node.js 22+, the package fails with:
```
Error: Cannot find package 'tldts' imported from tough-cookie/dist/index.js
```

## Cause
The dependency chain `fetch-cookie -> tough-cookie -> tldts` causes ESM module resolution issues when `tldts` is only a transitive dependency.

## Solution
Add `tldts` as a direct dependency to ensure proper ESM resolution.

## Testing
```bash
npx -y @zereight/mcp-gitlab --token=xxx --api-url=https://gitlab.example.com/api/v4
```