### PR TITLE
Add pagination parameters (per_page and page) to get_merge_request_notes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2363,7 +2363,9 @@ async function getMergeRequestNotes(
   projectId: string,
   mergeRequestIid: string,
   sort?: "asc" | "desc",
-  order_by?: "created_at" | "updated_at"
+  order_by?: "created_at" | "updated_at",
+  per_page?: number,
+  page?: number
 ): Promise<GitLabDiscussionNote[]> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
@@ -2378,6 +2380,14 @@ async function getMergeRequestNotes(
 
   if (order_by) {
     url.searchParams.append("order_by", order_by);
+  }
+
+  if (per_page) {
+    url.searchParams.append("per_page", per_page.toString());
+  }
+
+  if (page) {
+    url.searchParams.append("page", page.toString());
   }
 
   const response = await fetch(url.toString(), {
@@ -5701,7 +5711,9 @@ async function handleToolCall(params: any) {
           args.project_id,
           args.merge_request_iid,
           args.sort,
-          args.order_by
+          args.order_by,
+          args.per_page,
+          args.page
         );
 
         return {

--- a/schemas.ts
+++ b/schemas.ts
@@ -958,6 +958,8 @@ export const GetMergeRequestNotesSchema = ProjectParamsSchema.extend({
   merge_request_iid: z.coerce.string().describe("The IID of a merge request"),
   sort: z.enum(["asc", "desc"]).optional().describe("The sort order of the notes"),
   order_by: z.enum(["created_at", "updated_at"]).optional().describe("The field to sort the notes by"),
+  per_page: z.coerce.number().optional().describe("Number of items per page"),
+  page: z.coerce.number().optional().describe("Page number for pagination"),
 });
 
 export const GetMergeRequestNoteSchema = ProjectParamsSchema.extend({


### PR DESCRIPTION
### Problem
get_merge_request_notes returns a maximum of 20 notes and there is no pagination

### Solution
Add pagination parameters (per_page and page). For some reason they are not described in the documentation, but they work.

### Testing
`node build/index.js --token=xxx --api-url=https://gitlab.example.com/api/v4`