### PR TITLE
fix: name change in dockerhub

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   gitlab-mcp:
-    image: zereight/gitlab-mcp:latest
+    image: zereight050/gitlab-mcp:latest
     ports:
       - 3002:3002
     environment:


### PR DESCRIPTION
Since v2.0.20, Docker hub username has been change, but not everywhere.