### PR TITLE
feat: return inline base64 images from download_attachment

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5127,7 +5127,25 @@ async function downloadAttachment(
   // For non-image files, always save to disk.
   // For image files, only save to disk if local_path is explicitly provided.
   if (!mimeType || localPath) {
-    const savePath = localPath ? path.join(localPath, filename) : filename;
+    let savePath: string;
+    if (localPath) {
+      const normalizedLocalPath = path.normalize(localPath);
+      if (
+        path.isAbsolute(normalizedLocalPath) ||
+        normalizedLocalPath === ".." ||
+        normalizedLocalPath.startsWith(".." + path.sep) ||
+        normalizedLocalPath.includes(path.sep + ".." + path.sep)
+      ) {
+        throw new Error("Invalid local_path: directory traversal is not allowed.");
+      }
+      savePath = path.join(normalizedLocalPath, filename);
+    } else {
+      savePath = filename;
+    }
+    const dir = path.dirname(savePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
     fs.writeFileSync(savePath, buffer);
     return { buffer, filename, mimeType, savedPath: savePath };
   }


### PR DESCRIPTION
## Problem

When an AI reads a GitLab issue containing inline images like `![Screenshot](/uploads/<secret>/image.png)`, it can call `download_attachment` to fetch them — but the tool only saves files to disk and returns a path. The AI cannot actually *see* the image content.

## Solution

Detect image files in `download_attachment` and return them as MCP `image` content blocks (base64-encoded) so the AI can view them directly. Non-image files keep the existing save-to-disk behavior.

### Changes

- Added image MIME type detection for common formats (png, jpg, gif, webp, svg, bmp, ico)
- `downloadAttachment` now returns a structured result with the buffer, filename, and detected MIME type
- Image files are returned inline as base64 `{ type: "image" }` content blocks
- Non-image files still save to disk and return the file path (no behavior change)
- Providing `local_path` forces any file (including images) to be saved to disk
- Updated tool description to document the new behavior

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` — all existing tests pass