### PR TITLE
fix: use getConfig for all GITLAB_API_URL usages to support --api-url CLI argument

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -557,7 +557,7 @@ httpAgent = httpAgent || new Agent();
 
 // Initialize the client pool for managing multiple GitLab instances
 const clientPool = new GitLabClientPool({
-  apiUrls: (process.env.GITLAB_API_URL || "https://gitlab.com")
+  apiUrls: (getConfig("api-url", "GITLAB_API_URL") || "https://gitlab.com")
     .split(",")
     .map(normalizeGitLabApiUrl),
   httpProxy: HTTP_PROXY,
@@ -1498,7 +1498,7 @@ function normalizeGitLabApiUrl(url: string): string {
 }
 
 // Use the normalizeGitLabApiUrl function to handle various URL formats
-const GITLAB_API_URLS = (process.env.GITLAB_API_URL || "https://gitlab.com")
+const GITLAB_API_URLS = (getConfig("api-url", "GITLAB_API_URL") || "https://gitlab.com")
   .split(",")
   .map(normalizeGitLabApiUrl);
 const GITLAB_API_URL = GITLAB_API_URLS[0];


### PR DESCRIPTION
## Problem

`GITLAB_API_URL` was reading directly from `process.env.GITLAB_API_URL` in two places, ignoring the `--api-url` CLI argument.

## Solution

Replace both `process.env.GITLAB_API_URL` references with `getConfig("api-url", "GITLAB_API_URL")`, consistent with how all other configuration options are handled.

**Fixed locations:**
- `index.ts:560` — `clientPool` initialization (missing from #327)
- `index.ts:1501` — `GITLAB_API_URLS` constant (originally proposed in #327)

## Testing

```bash
node build/index.js --token=xxx --api-url=https://gitlab.example.com/api/v4
```

Both `clientPool` and `GITLAB_API_URLS` now correctly use the CLI argument.

## Note

This supersedes #327 with a complete fix covering both affected locations.