### PR TITLE
feat: add inputs support to create_pipeline for GitLab CI/CD

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4694,12 +4694,14 @@ async function getPipelineJobOutput(
  * @param {string} projectId - The ID or URL-encoded path of the project
  * @param {string} ref - The branch or tag to run the pipeline on
  * @param {Array} variables - Optional variables for the pipeline
+ * @param {Record<string, string>} inputs - Optional input parameters for the pipeline
  * @returns {Promise<GitLabPipeline>} The created pipeline
  */
 async function createPipeline(
   projectId: string,
   ref: string,
-  variables?: Array<{ key: string; value: string }>
+  variables?: Array<{ key: string; value: string }>,
+  inputs?: Record<string, string>
 ): Promise<GitLabPipeline> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
@@ -4709,6 +4711,9 @@ async function createPipeline(
   const body: any = { ref };
   if (variables && variables.length > 0) {
     body.variables = variables;
+  }
+  if (inputs && Object.keys(inputs).length > 0) {
+    body.inputs = inputs;
   }
 
   const response = await fetch(url.toString(), {
@@ -6898,8 +6903,8 @@ async function handleToolCall(params: any) {
       }
 
       case "create_pipeline": {
-        const { project_id, ref, variables } = CreatePipelineSchema.parse(params.arguments);
-        const pipeline = await createPipeline(project_id, ref, variables);
+        const { project_id, ref, variables, inputs } = CreatePipelineSchema.parse(params.arguments);
+        const pipeline = await createPipeline(project_id, ref, variables, inputs);
         return {
           content: [
             {

--- a/schemas.ts
+++ b/schemas.ts
@@ -271,6 +271,10 @@ export const CreatePipelineSchema = z.object({
     )
     .optional()
     .describe("An array of variables to use for the pipeline"),
+  inputs: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Input parameters for the pipeline (key-value pairs for spec:inputs)"),
 });
 
 // Schema for retrying a pipeline


### PR DESCRIPTION
Add support for the `inputs` parameter when creating pipelines, enabling use of GitLab's spec:inputs feature for parameterized pipelines.