### PR TITLE
fix: parse approve/unapprove response with correct schema

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3860,7 +3860,7 @@ async function approveMergeRequest(
   });
 
   await handleGitLabError(response);
-  return GitLabMergeRequestApprovalStateSchema.parse(await response.json());
+  return parseApprovalsResponse(await response.json());
 }
 
 /**
@@ -3886,7 +3886,7 @@ async function unapproveMergeRequest(
   });
 
   await handleGitLabError(response);
-  return GitLabMergeRequestApprovalStateSchema.parse(await response.json());
+  return parseApprovalsResponse(await response.json());
 }
 
 /**
@@ -3946,9 +3946,17 @@ async function getMergeRequestApprovalsFallback(
   });
 
   await handleGitLabError(approvalsResponse);
-  const parsedApprovals = GitLabMergeRequestApprovalsResponseSchema.parse(
-    await approvalsResponse.json()
-  );
+  return parseApprovalsResponse(await approvalsResponse.json());
+}
+
+/**
+ * Parse the response from POST /approve and POST /unapprove endpoints.
+ * These endpoints return the approvals format (approved_by contains nested
+ * { user: {...} } objects), which must be converted to the flat format
+ * used by GitLabMergeRequestApprovalStateSchema.
+ */
+function parseApprovalsResponse(responseJson: unknown): GitLabMergeRequestApprovalState {
+  const parsedApprovals = GitLabMergeRequestApprovalsResponseSchema.parse(responseJson);
   const approvedByUsers = getUniqueApprovalUsers(
     (parsedApprovals.approved_by || []).map(approvedByEntry => approvedByEntry.user)
   );


### PR DESCRIPTION
## Problem

`approve_merge_request` and `unapprove_merge_request` fail with:

```
MCP error -32603: Invalid arguments: approved_by.0.username: Required,
approved_by.0.name: Required, approved_by.0.state: Required,
approved_by.0.web_url: Required
```

## Root Cause

The GitLab `POST /approve` and `POST /unapprove` endpoints return the **approvals format** where `approved_by` contains nested objects:

```json
{ "approved_by": [{ "user": { "username": "X", "name": "Y", ... } }] }
```

But `approveMergeRequest()` and `unapproveMergeRequest()` parse the response with `GitLabMergeRequestApprovalStateSchema`, which expects **flat** user objects:

```json
{ "approved_by": [{ "username": "X", "name": "Y", ... }] }
```

This worked before because the schema didn't include `approved_by`. After bfc49de added `approved_by` to the schema, Zod validation fails on the nested structure.

## Fix

Extract a shared `parseApprovalsResponse()` helper that:
1. Parses with `GitLabMergeRequestApprovalsResponseSchema` (correct nested format)
2. Flattens `{ user: {...} }` to `{...}`
3. Returns the unified `GitLabMergeRequestApprovalState` format

This is the same conversion that `getMergeRequestApprovalsFallback()` already does correctly — the fix reuses it for `approveMergeRequest()`, `unapproveMergeRequest()`, and the fallback itself.

## Changes

- `index.ts`: 3 call sites updated, 1 new helper function, net +13/-5 lines