### PR TITLE
feat: allow using job token auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 GITLAB_API_URL=https://gitlab.com
 GITLAB_TOKEN=your-gitlab-personal-access-token-here
 
+# CI/CD Job Token (alternative to Personal Access Token, for use in GitLab CI pipelines)
+# When set, the token is sent as the JOB-TOKEN header instead of Authorization: Bearer
+# GITLAB_JOB_TOKEN=$CI_JOB_TOKEN
+
 # OAuth Configuration (alternative to Personal Access Token)
 # GITLAB_USE_OAUTH=true
 # GITLAB_OAUTH_CLIENT_ID=your-oauth-client-id

--- a/index.ts
+++ b/index.ts
@@ -474,11 +474,12 @@ function validateConfiguration(): void {
   const remoteAuth = getConfig("remote-auth", "REMOTE_AUTHORIZATION") === "true";
   const useOAuth = getConfig("use-oauth", "GITLAB_USE_OAUTH") === "true";
   const hasToken = !!getConfig("token", "GITLAB_PERSONAL_ACCESS_TOKEN");
+  const hasJobToken = !!getConfig("job-token", "GITLAB_JOB_TOKEN");
   const hasCookie = !!getConfig("cookie-path", "GITLAB_AUTH_COOKIE_PATH");
 
-  if (!remoteAuth && !useOAuth && !hasToken && !hasCookie) {
+  if (!remoteAuth && !useOAuth && !hasToken && !hasJobToken && !hasCookie) {
     errors.push(
-      "Either --token, --cookie-path, --use-oauth=true, or --remote-auth=true must be set (or use environment variables)"
+      "Either --token, --job-token, --cookie-path, --use-oauth=true, or --remote-auth=true must be set (or use environment variables)"
     );
   }
 
@@ -498,6 +499,7 @@ function validateConfiguration(): void {
 }
 
 const GITLAB_PERSONAL_ACCESS_TOKEN = getConfig("token", "GITLAB_PERSONAL_ACCESS_TOKEN");
+const GITLAB_JOB_TOKEN = getConfig("job-token", "GITLAB_JOB_TOKEN");
 let OAUTH_ACCESS_TOKEN: string | null = null;
 let oauthClient: GitLabOAuth | null = null;
 /**
@@ -792,6 +794,11 @@ function buildAuthHeaders(): Record<string, string> {
       };
     }
     return {}; // No auth headers if no session context
+  }
+
+  // CI job tokens use a dedicated header (not Bearer/Private-Token)
+  if (GITLAB_JOB_TOKEN) {
+    return { "JOB-TOKEN": String(GITLAB_JOB_TOKEN) };
   }
 
   // Standard mode: prioritize OAuth token, then fall back to environment token


### PR DESCRIPTION
We want to use it as a CI component, we are aware that with the Job token not all APIs work (also due to permissions), but that's fine.
