### PR TITLE
fix: amend fetch calls that missing default config and fix tool "markdown upload" returns 406

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4090,7 +4090,8 @@ async function getDraftNote(
   draft_note_id: string
 ): Promise<GitLabDraftNote> {
   const response = await fetch(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(project_id)}/merge_requests/${merge_request_iid}/draft_notes/${draft_note_id}`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(project_id)}/merge_requests/${merge_request_iid}/draft_notes/${draft_note_id}`,
+    { ...getFetchConfig() }
   );
 
   if (!response.ok) {
@@ -5608,11 +5609,8 @@ async function createPipeline(
   }
 
   const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
     method: "POST",
-    headers: {
-      ...BASE_HEADERS,
-      ...buildAuthHeaders(),
-    },
     body: JSON.stringify(body),
   });
 
@@ -5638,11 +5636,8 @@ async function retryPipeline(
   );
 
   const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
     method: "POST",
-    headers: {
-      ...BASE_HEADERS,
-      ...buildAuthHeaders(),
-    },
   });
 
   await handleGitLabError(response);
@@ -5667,11 +5662,8 @@ async function cancelPipeline(
   );
 
   const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
     method: "POST",
-    headers: {
-      ...BASE_HEADERS,
-      ...buildAuthHeaders(),
-    },
   });
 
   await handleGitLabError(response);
@@ -5787,17 +5779,11 @@ async function getRepositoryTree(options: GetRepositoryTreeOptions): Promise<Git
   if (options.page_token) queryParams.append("page_token", options.page_token);
   if (options.pagination) queryParams.append("pagination", options.pagination);
 
-  const headers: Record<string, string> = {
-    ...BASE_HEADERS,
-    ...buildAuthHeaders(),
-  };
   const response = await fetch(
     `${getEffectiveApiUrl()}/projects/${encodeURIComponent(
       getEffectiveProjectId(options.project_id)
     )}/repository/tree?${queryParams.toString()}`,
-    {
-      headers,
-    }
+    { ...getFetchConfig() }
   );
 
   if (response.status === 404) {
@@ -6379,15 +6365,13 @@ async function markdownUpload(projectId: string, filePath: string): Promise<GitL
     `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}/uploads`
   );
 
+  const defaultFetchConfig = getFetchConfig();
+  delete defaultFetchConfig.headers["Content-Type"]; // Let form-data set the correct Content-Type with boundary
+    
   const response = await fetch(url.toString(), {
+    ...defaultFetchConfig,
     method: "POST",
-    headers: {
-      ...BASE_HEADERS,
-      ...buildAuthHeaders(),
-      // Remove Content-Type header to let form-data set it with boundary
-      "Content-Type": undefined as any,
-    },
-    body: form,
+    body: form
   });
 
   if (!response.ok) {
@@ -6434,11 +6418,8 @@ async function downloadAttachment(
   );
 
   const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
     method: "GET",
-    headers: {
-      ...BASE_HEADERS,
-      ...buildAuthHeaders(),
-    },
   });
 
   if (!response.ok) {
@@ -6493,13 +6474,7 @@ async function listEvents(options: z.infer<typeof ListEventsSchema> = {}): Promi
     }
   });
 
-  const response = await fetch(url.toString(), {
-    method: "GET",
-    headers: {
-      ...BASE_HEADERS,
-      ...buildAuthHeaders(),
-    },
-  });
+  const response = await fetch(url.toString(), { ...getFetchConfig() });
 
   if (!response.ok) {
     await handleGitLabError(response);
@@ -6531,13 +6506,7 @@ async function getProjectEvents(
     }
   });
 
-  const response = await fetch(url.toString(), {
-    method: "GET",
-    headers: {
-      ...BASE_HEADERS,
-      ...buildAuthHeaders(),
-    },
-  });
+  const response = await fetch(url.toString(), { ...getFetchConfig() });
 
   if (!response.ok) {
     await handleGitLabError(response);

--- a/test/test-upload-markdown.ts
+++ b/test/test-upload-markdown.ts
@@ -1,0 +1,206 @@
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { MockGitLabServer, findMockServerPort } from './utils/mock-gitlab-server.js';
+
+const MOCK_TOKEN = 'glpat-mock-token-12345';
+const TEST_PROJECT_ID = '123';
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+}
+
+interface JsonRpcResponse {
+  result?: { content?: ContentBlock[] };
+  error?: { message: string; code?: number };
+}
+
+function callUploadMarkdown(
+  args: Record<string, unknown>,
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 15_000,
+): Promise<JsonRpcResponse> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['build/index.js'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...env },
+    });
+
+    const timer = setTimeout(() => {
+      proc.kill();
+      reject(new Error(`Process timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout?.on('data', (d: Buffer) => (stdout += d.toString()));
+    proc.stderr?.on('data', (d: Buffer) => (stderr += d.toString()));
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`Failed to spawn process: ${err.message}`));
+    });
+
+    proc.on('close', () => {
+      clearTimeout(timer);
+      const lines = stdout.split('\n').filter(l => l.trim().startsWith('{'));
+      for (const line of lines) {
+        try {
+          const parsed = JSON.parse(line);
+          if (parsed.id === 1) { resolve(parsed); return; }
+        } catch { /* try next line */ }
+      }
+      reject(new Error(`No matching JSON-RPC response found.\nstdout: ${stdout}\nstderr: ${stderr}`));
+    });
+
+    proc.stdin?.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'upload_markdown', arguments: args },
+      }) + '\n'
+    );
+  });
+}
+
+const MOCK_UPLOAD_RESPONSE = {
+  id: 42,
+  alt: 'test-file.txt',
+  url: '/uploads/abc123secret/test-file.txt',
+  full_path: '/test-group/test-project/uploads/abc123secret/test-file.txt',
+  markdown: '[test-file.txt](/uploads/abc123secret/test-file.txt)',
+};
+
+describe('upload_markdown', () => {
+  let mockGitLab: MockGitLabServer;
+  let env: NodeJS.ProcessEnv;
+
+  // Captured per-request state, reset before each invocation via the handler
+  let lastContentType: string | undefined;
+  let lastRawBody: string | undefined;
+
+  before(async () => {
+    const port = await findMockServerPort(9200);
+    mockGitLab = new MockGitLabServer({ port, validTokens: [MOCK_TOKEN] });
+    await mockGitLab.start();
+
+    env = {
+      GITLAB_API_URL: `${mockGitLab.getUrl()}/api/v4`,
+      GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+    };
+
+    mockGitLab.addMockHandler(
+      'post',
+      `/projects/${TEST_PROJECT_ID}/uploads`,
+      (req, res) => {
+        lastContentType = req.headers['content-type'];
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        req.on('end', () => {
+          lastRawBody = Buffer.concat(chunks).toString('binary');
+          res.status(201).json(MOCK_UPLOAD_RESPONSE);
+        });
+      }
+    );
+  });
+
+  after(async () => {
+    await mockGitLab.stop();
+  });
+
+  test('Content-Type is multipart/form-data with a boundary', async () => {
+    const tmpFile = path.join(os.tmpdir(), 'mcp-upload-ct-test.txt');
+    fs.writeFileSync(tmpFile, 'content-type test');
+    try {
+      await callUploadMarkdown({ project_id: TEST_PROJECT_ID, file_path: tmpFile }, env);
+
+      assert.ok(lastContentType, 'Content-Type header must be present');
+      assert.ok(
+        lastContentType!.startsWith('multipart/form-data'),
+        `Expected multipart/form-data, got: ${lastContentType}`
+      );
+      assert.ok(
+        lastContentType!.includes('boundary='),
+        `Content-Type must include boundary, got: ${lastContentType}`
+      );
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  test('multipart body contains a "file" field with the file content', async () => {
+    const tmpFile = path.join(os.tmpdir(), 'mcp-upload-body-test.txt');
+    const fileContent = 'hello from multipart upload test';
+    fs.writeFileSync(tmpFile, fileContent);
+    try {
+      await callUploadMarkdown({ project_id: TEST_PROJECT_ID, file_path: tmpFile }, env);
+
+      assert.ok(lastRawBody, 'Request body must be captured');
+      assert.ok(
+        lastRawBody!.includes('name="file"'),
+        'Multipart body should include a field named "file"'
+      );
+      assert.ok(
+        lastRawBody!.includes(fileContent),
+        'Multipart body should contain the uploaded file content'
+      );
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  test('multipart body includes the original filename', async () => {
+    const tmpFile = path.join(os.tmpdir(), 'mcp-upload-filename-check.txt');
+    fs.writeFileSync(tmpFile, 'filename check');
+    try {
+      await callUploadMarkdown({ project_id: TEST_PROJECT_ID, file_path: tmpFile }, env);
+
+      assert.ok(lastRawBody, 'Request body must be captured');
+      assert.ok(
+        lastRawBody!.includes('mcp-upload-filename-check.txt'),
+        'Multipart body should include the original filename'
+      );
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  test('returns markdown, url, alt, and full_path from upload response', async () => {
+    const tmpFile = path.join(os.tmpdir(), 'mcp-upload-response-test.txt');
+    fs.writeFileSync(tmpFile, 'response field test');
+    try {
+      const raw = await callUploadMarkdown({ project_id: TEST_PROJECT_ID, file_path: tmpFile }, env);
+
+      assert.ok(!raw.error, `Unexpected RPC error: ${raw.error?.message}`);
+      const text = raw.result?.content?.[0]?.text;
+      assert.ok(text, 'Result should contain a text content block');
+
+      const parsed = JSON.parse(text);
+      assert.strictEqual(parsed.markdown, MOCK_UPLOAD_RESPONSE.markdown);
+      assert.strictEqual(parsed.url, MOCK_UPLOAD_RESPONSE.url);
+      assert.strictEqual(parsed.alt, MOCK_UPLOAD_RESPONSE.alt);
+      assert.strictEqual(parsed.full_path, MOCK_UPLOAD_RESPONSE.full_path);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  test('returns an error when the file does not exist', async () => {
+    const raw = await callUploadMarkdown(
+      { project_id: TEST_PROJECT_ID, file_path: '/nonexistent/no-such-file.txt' },
+      env
+    );
+
+    const hasError =
+      typeof raw.error?.message === 'string' ||
+      raw.result?.content?.some(
+        c => c.text && (c.text.toLowerCase().includes('not found') || c.text.toLowerCase().includes('error'))
+      );
+    assert.ok(hasError, 'Should return an error for a nonexistent file path');
+  });
+});


### PR DESCRIPTION
## Summary

  This PR addresses three related issues discovered during a systematic audit of all `fetch()` calls in `index.ts`.

  ---

  ### 1. 9 tool functions bypassed `getFetchConfig()`, silently ignoring proxy settings

  `getFetchConfig()` is the central function that returns both auth headers **and** the HTTP agent from `GitLabClientPool` (which handles `HTTP_PROXY`, `HTTPS_PROXY`, `SOCKS_PROXY`, and connection pooling). Any `fetch()` call that doesn't spread `getFetchConfig()`    
  silently ignores proxy configuration.

  The following functions were affected:

  | Tool | Function | Severity |
  |------|----------|----------|
  | `get_draft_note` | `getDraftNote` | **Critical** — bare `fetch(url)` with no headers and no agent; requests sent with no authentication |
  | `create_pipeline` | `createPipeline` | Missing agent |
  | `retry_pipeline` | `retryPipeline` | Missing agent |
  | `cancel_pipeline` | `cancelPipeline` | Missing agent |
  | `get_repository_tree` | `getRepositoryTree` | Missing agent |
  | `upload_markdown` | `markdownUpload` | Missing agent |
  | `download_attachment` | `downloadAttachment` | Missing agent |
  | `list_events` | `listEvents` | Missing agent |
  | `get_project_events` | `getProjectEvents` | Missing agent |

  **Fix:** All 9 functions now spread `getFetchConfig()` as the base config, with method/body overrides applied on top.

  ---

  ### 2. `upload_markdown` returned 406 Not Acceptable due to incorrect Content-Type

  The previous code attempted to clear the `Content-Type` header by setting it to `undefined as any`:

  ```ts
  // Before — broken
  headers: {
    ...BASE_HEADERS,
    ...buildAuthHeaders(),
    "Content-Type": undefined as any,  // does NOT remove the header
  },

  This left Content-Type in an undefined/missing state. GitLab's upload endpoint requires a multipart/form-data Content-Type with a valid boundary parameter, causing it to respond with 406 Not Acceptable.

  Fix: The header is now deleted from defaultFetchConfig.headers so form-data's own headers (with the correct boundary) take over cleanly:

  // After — correct
  const defaultFetchConfig = getFetchConfig();
  delete defaultFetchConfig.headers["Content-Type"];

  const response = await fetch(url.toString(), {
    ...defaultFetchConfig,
    method: "POST",
    body: form,
  });

  ---
  3. Unit tests for upload_markdown

  Added test/test-upload-markdown.ts covering:

  - Content-Type header is multipart/form-data with a boundary= parameter
  - Multipart body contains a field named "file" with the correct file content
  - Multipart body includes the original filename
  - Response fields (markdown, url, alt, full_path) are correctly parsed and returned
  - Returns an error when the file path does not exist

  All 5 tests pass against the existing mock server infrastructure.