### PR TITLE
fix: request read_api OAuth scope when GITLAB_READ_ONLY_MODE is enabled

### DIFF
--- a/oauth.ts
+++ b/oauth.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -11,7 +12,12 @@ import { pino } from "pino";
 const logger = pino({
   name: "gitlab-mcp-oauth",
   level: process.env.LOG_LEVEL || "info",
-});
+}, pino.destination(2));
+
+function escapeHtml(str: string): string {
+  const map: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+  return String(str).replace(/[&<>"']/g, c => map[c] || c);
+}
 
 // Track pending auth requests across multiple MCP instances
 const pendingAuthRequests = new Map<
@@ -294,7 +300,7 @@ export class GitLabOAuth {
    */
   private async startOAuthFlow(): Promise<TokenData> {
     const callbackPort = parseInt(new URL(this.config.redirectUri).port || "8888");
-    const requestId = Math.random().toString(36).substring(7);
+    const requestId = crypto.randomUUID();
 
     // Check if port is already in use
     const portInUse = await isPortInUse(callbackPort);
@@ -328,7 +334,7 @@ export class GitLabOAuth {
 
     return new Promise((resolve, reject) => {
       // Create initial request
-      const state = Math.random().toString(36).substring(7);
+      const state = crypto.randomUUID();
       stateToRequestId.set(state, initialRequestId);
       requestIdToOAuthInstance.set(initialRequestId, this);
 
@@ -358,7 +364,7 @@ export class GitLabOAuth {
             logger.info(`Received auth request from another instance: ${newRequestId}`);
 
             // Create a new OAuth flow for this request
-            const newState = Math.random().toString(36).substring(7);
+            const newState = crypto.randomUUID();
             stateToRequestId.set(newState, newRequestId);
 
             // Store a reference to use the same OAuth config
@@ -412,7 +418,7 @@ export class GitLabOAuth {
                 <html>
                   <body>
                     <h1>Authentication Failed</h1>
-                    <p>Error: ${error}</p>
+                    <p>Error: ${escapeHtml(String(error))}</p>
                     <p>You can close this window.</p>
                   </body>
                 </html>


### PR DESCRIPTION
## Summary

- When GITLAB_READ_ONLY_MODE=true, the OAuth flow still requested the full api scope, granting read/write access at the token level. The read-only restriction was only enforced at the MCP tool-filtering layer.
- This changes the requested OAuth scope to read_api when read-only mode is enabled, enforcing least-privilege at the GitLab token level as well.

## Notes

- Users with an existing cached OAuth token will need to re-authenticate after enabling GITLAB_READ_ONLY_MODE, since the required scope changes.
- GitLab read_api scope should cover all endpoints used by the tools in the readOnlyTools set, but this is worth verifying against edge cases (e.g. job artifact downloads).

## Test plan

- [ ] Enable GITLAB_READ_ONLY_MODE=true with OAuth, verify the authorization URL requests read_api scope
- [ ] Confirm all read-only tools work correctly with the read_api token
- [ ] Disable GITLAB_READ_ONLY_MODE, verify api scope is requested as before