### PR TITLE
fix: harden OAuth security (CSRF, XSS, stdio log leak)

### DIFF
--- a/oauth.ts
+++ b/oauth.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -11,7 +12,12 @@ import { pino } from "pino";
 const logger = pino({
   name: "gitlab-mcp-oauth",
   level: process.env.LOG_LEVEL || "info",
-});
+}, pino.destination(2));
+
+function escapeHtml(str: string): string {
+  const map: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+  return String(str).replace(/[&<>"']/g, c => map[c] || c);
+}
 
 // Track pending auth requests across multiple MCP instances
 const pendingAuthRequests = new Map<
@@ -294,7 +300,7 @@ export class GitLabOAuth {
    */
   private async startOAuthFlow(): Promise<TokenData> {
     const callbackPort = parseInt(new URL(this.config.redirectUri).port || "8888");
-    const requestId = Math.random().toString(36).substring(7);
+    const requestId = crypto.randomUUID();
 
     // Check if port is already in use
     const portInUse = await isPortInUse(callbackPort);
@@ -328,7 +334,7 @@ export class GitLabOAuth {
 
     return new Promise((resolve, reject) => {
       // Create initial request
-      const state = Math.random().toString(36).substring(7);
+      const state = crypto.randomUUID();
       stateToRequestId.set(state, initialRequestId);
       requestIdToOAuthInstance.set(initialRequestId, this);
 
@@ -358,7 +364,7 @@ export class GitLabOAuth {
             logger.info(`Received auth request from another instance: ${newRequestId}`);
 
             // Create a new OAuth flow for this request
-            const newState = Math.random().toString(36).substring(7);
+            const newState = crypto.randomUUID();
             stateToRequestId.set(newState, newRequestId);
 
             // Store a reference to use the same OAuth config
@@ -412,7 +418,7 @@ export class GitLabOAuth {
                 <html>
                   <body>
                     <h1>Authentication Failed</h1>
-                    <p>Error: ${error}</p>
+                    <p>Error: ${escapeHtml(String(error))}</p>
                     <p>You can close this window.</p>
                   </body>
                 </html>


### PR DESCRIPTION
## Summary

Addresses three security findings from a third-party review of the OAuth module:

- **Replace `Math.random()` with `crypto.randomUUID()`** for OAuth `state` parameters and request IDs (lines 297, 331, 361) — `Math.random()` is not a CSPRNG; OAuth state is a CSRF protection token that must be cryptographically unpredictable
- **HTML-encode error parameter in OAuth callback** (line 415) — the `error` query parameter was interpolated directly into HTML (`<p>Error: ${error}</p>`), enabling reflected XSS on the localhost callback page
- **Redirect pino to stderr in oauth.ts** — the logger wrote to stdout by default, polluting the MCP stdio transport with JSON log lines that the client parsed as invalid JSON-RPC messages. `index.ts` already uses `destination: 2`; this aligns `oauth.ts` to match

One file changed, no new dependencies.

## Test plan

- [x] `npm run test:oauth` — 18/18 passing
- [x] Manual test: OAuth browser flow completes successfully
- [x] Manual test: stdio transport works without log pollution
- [ ] Verify error page renders safely with special characters in the error param

🤖 Generated with [Claude Code](https://claude.com/claude-code)