### PR TITLE
fix: prevent 400 errors from mutually exclusive params in list_merge_requests

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8016,8 +8016,22 @@ async function handleToolCall(params: any) {
       }
 
       case "list_merge_requests": {
-        const args = ListMergeRequestsSchema.parse(params.arguments);
-        const mergeRequests = await listMergeRequests(args.project_id, args);
+        const { project_id, ...options } = ListMergeRequestsSchema.parse(params.arguments);
+
+        // GitLab API treats _id and _username as mutually exclusive for these fields.
+        // When both are provided, prefer _username and remove _id to avoid 400 errors.
+        const cleanedOptions = { ...options } as Record<string, unknown>;
+        if (cleanedOptions.author_id && cleanedOptions.author_username) {
+          delete cleanedOptions.author_id;
+        }
+        if (cleanedOptions.assignee_id && cleanedOptions.assignee_username) {
+          delete cleanedOptions.assignee_id;
+        }
+        if (cleanedOptions.reviewer_id && cleanedOptions.reviewer_username) {
+          delete cleanedOptions.reviewer_id;
+        }
+
+        const mergeRequests = await listMergeRequests(project_id, cleanedOptions);
         return {
           content: [{ type: "text", text: JSON.stringify(mergeRequests, null, 2) }],
         };

--- a/schemas.ts
+++ b/schemas.ts
@@ -1599,27 +1599,27 @@ export const ListMergeRequestsSchema = z
     assignee_id: z.coerce
       .string()
       .optional()
-      .describe("Return issues assigned to the given user ID. user id or none or any"),
+      .describe("Return MRs assigned to the given user ID (integer), 'none', or 'any'. Mutually exclusive with assignee_username."),
     assignee_username: z
       .string()
       .optional()
-      .describe("Returns merge requests assigned to the given username"),
+      .describe("Returns merge requests assigned to the given username. Mutually exclusive with assignee_id."),
     author_id: z.coerce
       .string()
       .optional()
-      .describe("Returns merge requests created by the given user ID"),
+      .describe("Returns merge requests created by the given user ID (integer). Mutually exclusive with author_username."),
     author_username: z
       .string()
       .optional()
-      .describe("Returns merge requests created by the given username"),
+      .describe("Returns merge requests created by the given username. Mutually exclusive with author_id."),
     reviewer_id: z.coerce
       .string()
       .optional()
-      .describe("Returns merge requests which have the user as a reviewer. user id or none or any"),
+      .describe("Returns merge requests which have the user as a reviewer. Must be an integer, 'none', or 'any'. Mutually exclusive with reviewer_username."),
     reviewer_username: z
       .string()
       .optional()
-      .describe("Returns merge requests which have the user as a reviewer"),
+      .describe("Returns merge requests which have the user as a reviewer by username. Mutually exclusive with reviewer_id."),
     created_after: z
       .string()
       .optional()


### PR DESCRIPTION
Fixes #383