### PR TITLE
feat: add full-text search tool via GitLab Search API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -241,6 +241,9 @@ import {
   RetryPipelineJobSchema,
   RetryPipelineSchema,
   SearchRepositoriesSchema,
+  ALL_SEARCH_SCOPES,
+  SEARCH_SCOPE_TOOLSET_MAP,
+  createSearchSchema,
   UpdateDraftNoteSchema,
   UpdateIssueNoteSchema,
   UpdateIssueSchema,
@@ -1520,6 +1523,7 @@ const allTools = [
 
 // Define which tools are read-only
 const readOnlyTools = new Set([
+  "search",
   "search_repositories",
   "execute_graphql",
   "get_file_contents",
@@ -1716,6 +1720,7 @@ const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
     id: "repositories",
     isDefault: true,
     tools: new Set([
+      "search",
       "search_repositories",
       "create_repository",
       "get_file_contents",
@@ -1935,6 +1940,26 @@ function isToolInEnabledToolset(
 const enabledToolsets = parseEnabledToolsets(GITLAB_TOOLSETS_RAW);
 const individuallyEnabledTools = parseIndividualTools(GITLAB_TOOLS_RAW);
 const featureFlagOverrides = buildFeatureFlagOverrides();
+
+// Build search schema dynamically based on enabled toolsets
+const allowedSearchScopes = ALL_SEARCH_SCOPES.filter((scope) => {
+  const toolset = SEARCH_SCOPE_TOOLSET_MAP[scope];
+  return toolset === null || enabledToolsets.has(toolset as ToolsetId);
+});
+
+// Only register the search tool if at least one scope is available
+let SearchSchema: ReturnType<typeof createSearchSchema> | undefined;
+if (allowedSearchScopes.length > 0) {
+  SearchSchema = createSearchSchema(
+    allowedSearchScopes as [string, ...string[]]
+  );
+
+  allTools.push({
+    name: "search",
+    description: `Search across GitLab using the Search API. Supports: ${allowedSearchScopes.join(", ")}. Can search globally, within a group, or within a project.`,
+    inputSchema: toJSONSchema(SearchSchema),
+  });
+}
 
 // Warn about potentially confusing configuration
 if (GITLAB_TOOLSETS_RAW && (USE_PIPELINE || USE_MILESTONE || USE_GITLAB_WIKI)) {
@@ -3343,6 +3368,54 @@ async function searchProjects(
     current_page: page,
     items: projects,
   });
+}
+
+/**
+ * Search across GitLab using the Search API
+ * GitLab Search APIを使用した検索
+ *
+ * @param {object} options - Search options
+ * @returns {Promise<unknown[]>} The search results (shape varies by scope)
+ */
+async function search(options: {
+  search: string;
+  scope: string;
+  project_id?: string;
+  group_id?: string;
+  ref?: string;
+  page?: number;
+  per_page?: number;
+}): Promise<unknown[]> {
+  let basePath: string;
+
+  if (options.project_id) {
+    const decoded = decodeURIComponent(options.project_id);
+    const effectiveId = getEffectiveProjectId(decoded);
+    basePath = `/projects/${encodeURIComponent(effectiveId)}/search`;
+  } else if (options.group_id) {
+    const decoded = decodeURIComponent(options.group_id);
+    basePath = `/groups/${encodeURIComponent(decoded)}/search`;
+  } else {
+    basePath = `/search`;
+  }
+
+  const url = new URL(`${getEffectiveApiUrl()}${basePath}`);
+  url.searchParams.append("scope", options.scope);
+  url.searchParams.append("search", options.search);
+
+  if (options.ref && options.scope === "blobs" && options.project_id) {
+    url.searchParams.append("ref", options.ref);
+  }
+  if (options.page) {
+    url.searchParams.append("page", options.page.toString());
+  }
+  if (options.per_page) {
+    url.searchParams.append("per_page", options.per_page.toString());
+  }
+
+  const response = await fetch(url.toString(), { ...getFetchConfig() });
+  await handleGitLabError(response);
+  return (await response.json()) as unknown[];
 }
 
 /**
@@ -6924,6 +6997,17 @@ async function handleToolCall(params: any) {
       case "search_repositories": {
         const args = SearchRepositoriesSchema.parse(params.arguments);
         const results = await searchProjects(args.search, args.page, args.per_page);
+        return {
+          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        };
+      }
+
+      case "search": {
+        if (!SearchSchema) {
+          throw new Error("Search tool is not available: no search scopes are enabled");
+        }
+        const args = SearchSchema.parse(params.arguments);
+        const results = await search(args);
         return {
           content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
         };

--- a/schemas.ts
+++ b/schemas.ts
@@ -1214,6 +1214,62 @@ export const SearchRepositoriesSchema = z
   })
   .merge(PaginationOptionsSchema);
 
+export const ALL_SEARCH_SCOPES = [
+  "blobs",
+  "commits",
+  "issues",
+  "merge_requests",
+  "wiki_blobs",
+  "milestones",
+  "users",
+  "notes",
+  "snippet_titles",
+] as const;
+
+export const SEARCH_SCOPE_TOOLSET_MAP: Record<string, string | null> = {
+  blobs: "repositories",
+  commits: "branches",
+  issues: "issues",
+  merge_requests: "merge_requests",
+  wiki_blobs: "wiki",
+  milestones: "milestones",
+  users: "users",
+  notes: "issues",
+  snippet_titles: null, // always available
+};
+
+export function createSearchSchema(allowedScopes: [string, ...string[]]) {
+  return z
+    .object({
+      search: z.string().min(2).describe("Search query string (minimum 2 characters)"),
+      scope: z.enum(allowedScopes).describe(
+        "What to search: blobs (code), commits, issues, merge_requests, wiki_blobs, milestones, users, notes, snippet_titles"
+      ),
+      project_id: z.coerce
+        .string()
+        .optional()
+        .describe(
+          "Project ID or URL-encoded path. Scopes search to a project. Cannot be used with group_id."
+        ),
+      group_id: z.coerce
+        .string()
+        .optional()
+        .describe(
+          "Group ID or URL-encoded path. Scopes search to a group. Cannot be used with project_id."
+        ),
+      ref: z
+        .string()
+        .optional()
+        .describe(
+          "Branch or tag name to search in. Only applicable when scope is 'blobs' and project_id is provided."
+        ),
+    })
+    .merge(PaginationOptionsSchema)
+    .refine((data) => !(data.project_id && data.group_id), {
+      message: "Provide at most one of project_id or group_id, not both",
+    });
+}
+
 export const CreateRepositorySchema = z.object({
   name: z.string().describe("Repository name"),
   description: z.string().optional().describe("Repository description"),

--- a/test/test-toolset-filtering.ts
+++ b/test/test-toolset-filtering.ts
@@ -30,17 +30,18 @@ const MCP_PORT_BASE = 3200;
 
 // Known tool counts per toolset (from TOOLSET_DEFINITIONS)
 const TOOLSET_TOOL_COUNTS: Record<string, number> = {
-  merge_requests: 31,
+  merge_requests: 32,
   issues: 14,
-  repositories: 7,
+  repositories: 8,
   branches: 4,
   projects: 8,
   labels: 5,
-  pipelines: 12,
+  pipelines: 19,
   milestones: 9,
   wiki: 5,
   releases: 7,
   users: 5,
+  webhooks: 3,
 };
 
 const DEFAULT_TOOLSETS = [
@@ -71,7 +72,7 @@ const ALL_TOOLSET_TOOL_COUNT = Object.values(TOOLSET_TOOL_COUNTS).reduce(
 const TOOLSET_SAMPLE_TOOLS: Record<string, string[]> = {
   merge_requests: ["merge_merge_request", "create_merge_request_thread", "list_draft_notes"],
   issues: ["create_issue", "list_issues", "create_note"],
-  repositories: ["search_repositories", "get_file_contents", "push_files"],
+  repositories: ["search", "search_repositories", "get_file_contents", "push_files"],
   branches: ["create_branch", "list_commits"],
   projects: ["get_project", "list_namespaces", "list_group_iterations"],
   labels: ["list_labels", "create_label"],
@@ -174,9 +175,9 @@ describe("Toolset Filtering", () => {
       }
     });
 
-    test("includes all toolsets by default (no non-default toolsets)", () => {
-      // All toolsets are now default, so default count equals all toolset count
-      assert.strictEqual(tools.length, ALL_TOOLSET_TOOL_COUNT);
+    test("excludes non-default toolsets (webhooks)", () => {
+      // webhooks is the only non-default toolset, so its tools should be absent
+      assertContainsNone(tools, ["list_webhooks", "list_webhook_events", "get_webhook_event"], "webhooks");
     });
 
     test("excludes execute_graphql (not in any toolset)", () => {
@@ -260,19 +261,22 @@ describe("Toolset Filtering", () => {
 
     after(() => cleanupServers([server]));
 
-    test("returns default tools plus the two individual tools", () => {
-      assert.strictEqual(tools.length, DEFAULT_TOOL_COUNT + 2);
+    test("returns default tools plus execute_graphql", () => {
+      // list_pipelines is already in the default pipelines toolset,
+      // so only execute_graphql is truly additive
+      assert.strictEqual(tools.length, DEFAULT_TOOL_COUNT + 1);
     });
 
     test("includes the individually added tools", () => {
       assertContainsAll(tools, ["list_pipelines", "execute_graphql"], "individual");
     });
 
-    test("does not include other pipeline tools", () => {
-      assertContainsNone(
+    test("includes other pipeline tools from default pipelines toolset", () => {
+      // pipelines is a default toolset, so all pipeline tools are present
+      assertContainsAll(
         tools,
         ["create_pipeline", "cancel_pipeline"],
-        "other pipelines"
+        "default pipeline tools"
       );
     });
   });
@@ -353,11 +357,9 @@ describe("Toolset Filtering", () => {
 
     after(() => cleanupServers([server]));
 
-    test("returns default tools + wiki tools", () => {
-      assert.strictEqual(
-        tools.length,
-        DEFAULT_TOOL_COUNT + TOOLSET_TOOL_COUNTS.wiki
-      );
+    test("returns default tool count (wiki is already a default toolset)", () => {
+      // wiki is a default toolset, so USE_GITLAB_WIKI=true adds no extra tools
+      assert.strictEqual(tools.length, DEFAULT_TOOL_COUNT);
     });
 
     test("includes wiki tools", () => {
@@ -574,8 +576,9 @@ describe("Toolset Filtering", () => {
       assertContainsAll(tools, ["list_pipelines", "execute_graphql"], "case-insensitive tools");
     });
 
-    test("returns default tools plus the two individual tools", () => {
-      assert.strictEqual(tools.length, DEFAULT_TOOL_COUNT + 2);
+    test("returns default tools plus execute_graphql", () => {
+      // list_pipelines is already in the default pipelines toolset
+      assert.strictEqual(tools.length, DEFAULT_TOOL_COUNT + 1);
     });
   });
 


### PR DESCRIPTION
## Why

The MCP server has no way to search code, issues, commits, or other content across GitLab. The only search tool (`search_repositories`) matches project names and descriptions only. GitLab exposes full-text search via its `/search` endpoints (global, group-scoped, project-scoped), but none of these are wired up.

This blocks LLM agents that need to find code patterns, locate issues by content, or discover merge requests across a GitLab instance.

## Changes

- Adds a `search` tool covering global, group-scoped, and project-scoped search via the GitLab Search API
- `scope` parameter selects what to search: blobs (code), commits, issues, merge_requests, wiki_blobs, milestones, users, notes, snippet_titles
- Available scopes are dynamically filtered based on enabled toolsets (e.g. disabling the `issues` toolset removes the `issues` and `notes` scopes from the enum and tool description)
- Tool is not registered at all if no search scopes are available
- Search query requires minimum 2 characters (matching GitLab API constraint)
- Fixes stale tool counts in `test/test-toolset-filtering.ts` (merge_requests 31->32, pipelines 12->19, added missing webhooks count, corrected assertions that contradicted default toolset behavior) -- these were pre-existing failures on main

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npx tsx test/test-toolset-filtering.ts` passes 36/36 (was 27/36 on main before test fixes)
- [x] Global code search: `scope=blobs, search=IOException` returns code matches across multiple projects
- [x] Project-scoped search: same query with `project_id` returns only results from that project
- [x] MR search: `scope=merge_requests, search=deploy` returns matching merge requests
- [x] Min-length validation: single-character search correctly rejected with Zod error
- [x] Dynamic description reflects enabled scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)