### PR TITLE
fix(issues): make discussion_id optional in create_issue_note

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1212,7 +1212,7 @@ const allTools = [
   },
   {
     name: "create_issue_note",
-    description: "Add a new note to an existing issue thread",
+    description: "Add a note to an issue. Creates a top-level comment, or replies to a discussion thread if discussion_id is provided",
     inputSchema: toJSONSchema(CreateIssueNoteSchema),
   },
   {
@@ -5012,7 +5012,7 @@ async function updateIssueNote(
  * Create a note in an issue discussion
  * @param {string} projectId - The ID or URL-encoded path of the project
  * @param {number} issueIid - The IID of an issue
- * @param {string} discussionId - The ID of a thread
+ * @param {string} [discussionId] - The ID of a thread (omit for top-level note)
  * @param {string} body - The content of the new note
  * @param {string} [createdAt] - The creation date of the note (ISO 8601 format)
  * @returns {Promise<GitLabDiscussionNote>} The created note
@@ -5020,15 +5020,18 @@ async function updateIssueNote(
 async function createIssueNote(
   projectId: string,
   issueIid: number | string,
-  discussionId: string,
+  discussionId: string | undefined,
   body: string,
   createdAt?: string
 ): Promise<GitLabDiscussionNote> {
   projectId = decodeURIComponent(projectId); // Decode project ID
+  const basePath = `${getEffectiveApiUrl()}/projects/${encodeURIComponent(
+    getEffectiveProjectId(projectId)
+  )}/issues/${issueIid}`;
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(
-      getEffectiveProjectId(projectId)
-    )}/issues/${issueIid}/discussions/${discussionId}/notes`
+    discussionId
+      ? `${basePath}/discussions/${discussionId}/notes`
+      : `${basePath}/notes`
   );
 
   const payload: { body: string; created_at?: string } = { body };

--- a/schemas.ts
+++ b/schemas.ts
@@ -1241,10 +1241,10 @@ export const UpdateIssueNoteSchema = ProjectParamsSchema.extend({
     message: "Only one of 'body' or 'resolved' can be provided, not both",
   });
 
-// Input schema for adding a note to an existing issue discussion
+// Input schema for adding a note to an issue (top-level comment or discussion reply)
 export const CreateIssueNoteSchema = ProjectParamsSchema.extend({
   issue_iid: z.coerce.string().describe("The IID of an issue"),
-  discussion_id: z.coerce.string().describe("The ID of a thread"),
+  discussion_id: z.coerce.string().optional().describe("The ID of a thread. If provided, replies to that thread; otherwise creates a top-level note"),
   body: z.string().describe("The content of the note or reply"),
   created_at: z.string().optional().describe("Date the note was created at (ISO 8601 format)"),
 });

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ts-node
 
-import { GetFileContentsSchema, GitLabFileContentSchema, CreatePipelineSchema } from '../schemas.js';
+import { GetFileContentsSchema, GitLabFileContentSchema, CreatePipelineSchema, CreateIssueNoteSchema } from '../schemas.js';
 
 interface TestResult {
   name: string;
@@ -355,13 +355,98 @@ function runCreatePipelineSchemaTests(): { passed: number; failed: number } {
   return { passed, failed };
 }
 
+interface CreateIssueNoteSchemaTestCase {
+  name: string;
+  input: Record<string, any>;
+  expected?: Record<string, any>;
+  shouldFail?: boolean;
+}
+
+function runCreateIssueNoteSchemaTests(): { passed: number; failed: number } {
+  console.log('\n🧪 Testing CreateIssueNoteSchema...');
+
+  const cases: CreateIssueNoteSchemaTestCase[] = [
+    {
+      name: 'schema:create_issue_note:top-level-note-without-discussion-id',
+      input: { project_id: 'my/project', issue_iid: '42', body: 'A comment' },
+      expected: { project_id: 'my/project', issue_iid: '42', body: 'A comment', discussion_id: undefined }
+    },
+    {
+      name: 'schema:create_issue_note:reply-with-discussion-id',
+      input: { project_id: 'my/project', issue_iid: '42', discussion_id: 'abc123', body: 'A reply' },
+      expected: { project_id: 'my/project', issue_iid: '42', discussion_id: 'abc123', body: 'A reply' }
+    },
+    {
+      name: 'schema:create_issue_note:with-created-at',
+      input: { project_id: 'my/project', issue_iid: '7', body: 'Note', created_at: '2025-01-01T00:00:00Z' },
+      expected: { project_id: 'my/project', issue_iid: '7', body: 'Note', created_at: '2025-01-01T00:00:00Z' }
+    },
+    {
+      name: 'schema:create_issue_note:numeric-issue-iid-coerced',
+      input: { project_id: 'my/project', issue_iid: 99, body: 'Coerced' },
+      expected: { project_id: 'my/project', issue_iid: '99', body: 'Coerced' }
+    },
+    {
+      name: 'schema:create_issue_note:reject-missing-body',
+      input: { project_id: 'my/project', issue_iid: '1' },
+      shouldFail: true
+    }
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  cases.forEach(testCase => {
+    const result: TestResult = {
+      name: testCase.name,
+      status: 'failed'
+    };
+
+    const parsed = CreateIssueNoteSchema.safeParse(testCase.input);
+
+    if (testCase.shouldFail) {
+      if (parsed.success) {
+        result.error = 'Expected schema validation to fail';
+      } else {
+        result.status = 'passed';
+      }
+    } else if (parsed.success) {
+      const expected = testCase.expected || {};
+      const matches = Object.entries(expected).every(([key, value]) => {
+        const actual = (parsed.data as Record<string, unknown>)[key];
+        return actual === value;
+      });
+      if (matches) {
+        result.status = 'passed';
+      } else {
+        result.error = `Unexpected parsed result: ${JSON.stringify(parsed.data)}`;
+      }
+    } else {
+      result.error = parsed.error?.message || 'Schema validation failed';
+    }
+
+    if (result.status === 'passed') {
+      passed++;
+      console.log(`✅ ${result.name}`);
+    } else {
+      failed++;
+      console.log(`❌ ${result.name}: ${result.error}`);
+    }
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed`);
+
+  return { passed, failed };
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
   const getFileContentsResult = runGetFileContentsSchemaTests();
   const fileContentResult = runGitLabFileContentSchemaTests();
   const createPipelineResult = runCreatePipelineSchemaTests();
+  const createIssueNoteResult = runCreateIssueNoteSchemaTests();
 
-  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed;
-  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed;
+  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + createIssueNoteResult.passed;
+  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + createIssueNoteResult.failed;
 
   console.log(`\nTotal Results: ${totalPassed} passed, ${totalFailed} failed`);
 


### PR DESCRIPTION
## Problem

`create_issue_note` **always returns 404** ("Discussion Not Found") because `discussion_id` is a required parameter, which routes all requests to the discussions-reply endpoint (`POST /projects/:id/issues/:iid/discussions/:did/notes`).

Most callers — especially AI agents — want to create a **top-level comment** on an issue, not reply to a thread. They don't have a `discussion_id` to provide.

This was a primary source of failed tool calls in my agentic workflow. Every agent picks `create_issue_note` first (natural name match for "add a comment to an issue"), gets a 404, then wastes tokens falling back to `create_note`.

**Affected tool:** `create_issue_note`
**Not affected:** `create_merge_request_note` (correctly calls top-level endpoint without requiring `discussion_id`)

## Fix

Make `discussion_id` optional. When omitted, route to the top-level notes endpoint. When provided, preserve existing discussion-reply behavior.

| `discussion_id` | Endpoint | Behavior |
|-----------------|----------|----------|
| Omitted | `POST /projects/:id/issues/:iid/notes` | Creates top-level comment (new) |
| Provided | `POST /projects/:id/issues/:iid/discussions/:did/notes` | Replies to thread (existing) |

### Changes

- **`schemas.ts`**: `discussion_id` is now `.optional()` in `CreateIssueNoteSchema`
- **`index.ts`**: `createIssueNote()` routes to the correct endpoint based on whether `discussion_id` is present; tool description updated to explain both modes
- **`test/schema-tests.ts`**: 5 new test cases covering both modes

### Backwards Compatibility

Fully backwards compatible — existing callers who provide `discussion_id` get identical behavior. Only callers who *omitted* `discussion_id` (and got a schema validation error or 404) are affected, and they now get the correct behavior.

Fixes #403