### PR TITLE
feat: add topic parameter to list_projects and list_group_projects

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5742,6 +5742,7 @@ async function listGroupProjects(
     url.searchParams.append("with_custom_attributes", options.with_custom_attributes.toString());
   if (options.with_security_reports !== undefined)
     url.searchParams.append("with_security_reports", options.with_security_reports.toString());
+  if (options.topic) url.searchParams.append("topic", options.topic);
 
   const response = await fetch(url.toString(), {
     ...getFetchConfig(),

--- a/schemas.ts
+++ b/schemas.ts
@@ -1890,6 +1890,7 @@ export const ListProjectsSchema = z
       .optional()
       .describe("Filter projects with merge requests feature enabled"),
     min_access_level: z.coerce.number().optional().describe("Filter by minimum access level"),
+    topic: z.string().optional().describe("Filter by topic (projects tagged with this topic)"),
   })
   .merge(PaginationOptionsSchema);
 
@@ -1967,6 +1968,7 @@ export const ListGroupProjectsSchema = z
     statistics: z.coerce.boolean().optional().describe("Include project statistics"),
     with_custom_attributes: z.coerce.boolean().optional().describe("Include custom attributes"),
     with_security_reports: z.coerce.boolean().optional().describe("Include security reports"),
+    topic: z.string().optional().describe("Filter by topic (projects tagged with this topic)"),
   })
   .merge(PaginationOptionsSchema);
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Adds optional `topic` parameter to `ListProjectsSchema` and `ListGroupProjectsSchema` in `schemas.ts`
- Adds the corresponding handler line in `listGroupProjects()` in `index.ts` (`listProjects()` already uses a generic loop that passes all schema fields through)
- The GitLab REST API supports `topic` on both `GET /projects` and `GET /groups/:id/projects` — this change simply exposes the existing API capability through the MCP tools

## Motivation

We tag internal documentation repositories with topics (e.g. `mkdocs`) on GitLab and need AI agents to discover them via `list_projects(topic: "mkdocs")`. Currently the only workaround is `execute_graphql`, which is heavier and harder to guide agents toward safely.

Closes #417

## Changes

**`schemas.ts`** — 2 lines added:
```typescript
// In ListProjectsSchema
topic: z.string().optional().describe("Filter by topic (projects tagged with this topic)"),

// In ListGroupProjectsSchema
topic: z.string().optional().describe("Filter by topic (projects tagged with this topic)"),
```

**`index.ts`** — 1 line added in `listGroupProjects()`:
```typescript
if (options.topic) url.searchParams.append("topic", options.topic);
```

## Testing

- `npm run build` passes (TypeScript compiles cleanly)
- No runtime behavior changes for existing callers — `topic` is optional and defaults to undefined