### PR TITLE
fix(tree): return next_page_token from keyset pagination response headers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6835,7 +6835,9 @@ async function cancelPipelineJob(
  * @param {GetRepositoryTreeOptions} options - Options for the tree
  * @returns {Promise<GitLabTreeItem[]>}
  */
-async function getRepositoryTree(options: GetRepositoryTreeOptions): Promise<GitLabTreeItem[]> {
+async function getRepositoryTree(
+  options: GetRepositoryTreeOptions
+): Promise<{ items: GitLabTreeItem[]; next_page_token?: string }> {
   options.project_id = decodeURIComponent(options.project_id); // Decode project_id within options
   const queryParams = new URLSearchParams();
   if (options.path) queryParams.append("path", options.path);
@@ -6861,7 +6863,9 @@ async function getRepositoryTree(options: GetRepositoryTreeOptions): Promise<Git
   }
 
   const data = await response.json();
-  return z.array(GitLabTreeItemSchema).parse(data);
+  const items = z.array(GitLabTreeItemSchema).parse(data);
+  const next_page_token = response.headers.get("x-next-page-token") ?? undefined;
+  return { items, next_page_token };
 }
 
 /**
@@ -9127,9 +9131,15 @@ async function handleToolCall(params: any) {
 
       case "get_repository_tree": {
         const args = GetRepositoryTreeSchema.parse(params.arguments);
-        const tree = await getRepositoryTree(args);
+        const { items, next_page_token } = await getRepositoryTree(args);
+        const result: Record<string, unknown> = { items };
+        if (next_page_token) {
+          result.next_page_token = next_page_token;
+          result.pagination_note =
+            "Pass next_page_token as page_token with pagination=keyset to retrieve the next page.";
+        }
         return {
-          content: [{ type: "text", text: JSON.stringify(tree, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };
       }
 

--- a/index.ts
+++ b/index.ts
@@ -6831,9 +6831,8 @@ async function cancelPipelineJob(
 
 /**
  * Get the repository tree for a project
- * @param {string} projectId - The ID or URL-encoded path of the project
  * @param {GetRepositoryTreeOptions} options - Options for the tree
- * @returns {Promise<GitLabTreeItem[]>}
+ * @returns Parsed tree items plus optional keyset pagination metadata.
  */
 async function getRepositoryTree(
   options: GetRepositoryTreeOptions
@@ -6864,7 +6863,10 @@ async function getRepositoryTree(
 
   const data = await response.json();
   const items = z.array(GitLabTreeItemSchema).parse(data);
-  const next_page_token = response.headers.get("x-next-page-token") ?? undefined;
+  const next_page_token =
+    response.headers.get("x-next-page-token") ||
+    (options.pagination === "keyset" ? response.headers.get("x-next-page") : null) ||
+    undefined;
   return { items, next_page_token };
 }
 
@@ -9132,12 +9134,16 @@ async function handleToolCall(params: any) {
       case "get_repository_tree": {
         const args = GetRepositoryTreeSchema.parse(params.arguments);
         const { items, next_page_token } = await getRepositoryTree(args);
-        const result: Record<string, unknown> = { items };
-        if (next_page_token) {
-          result.next_page_token = next_page_token;
-          result.pagination_note =
-            "Pass next_page_token as page_token with pagination=keyset to retrieve the next page.";
-        }
+        const result =
+          args.pagination === "keyset" || next_page_token
+            ? {
+                items,
+                ...(next_page_token ? { next_page_token } : {}),
+                pagination_note: next_page_token
+                  ? "Pass next_page_token as page_token with pagination=keyset to retrieve the next page."
+                  : "No next_page_token was returned; this is the final keyset page.",
+              }
+            : items;
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };

--- a/schemas.ts
+++ b/schemas.ts
@@ -691,7 +691,7 @@ export const GetRepositoryTreeSchema = z.object({
     .string()
     .optional()
     .describe(
-      "Pagination method. Use 'keyset' for keyset-based pagination (required for repositories with many files). When using keyset pagination, the response includes next_page_token if more pages are available."
+      "Pagination method. Use 'keyset' for keyset-based pagination (required for repositories with many files). Non-keyset calls keep the legacy array response for backward compatibility; that legacy response shape is deprecated and may be removed in a future major release. Keyset calls return a structured response with items and next_page_token when more pages are available."
     ),
 });
 

--- a/schemas.ts
+++ b/schemas.ts
@@ -681,8 +681,18 @@ export const GetRepositoryTreeSchema = z.object({
     .describe("The name of a repository branch or tag. Defaults to the default branch."),
   recursive: z.coerce.boolean().optional().describe("Boolean value to get a recursive tree"),
   per_page: z.coerce.number().optional().describe("Number of results to show per page"),
-  page_token: z.string().optional().describe("The tree record ID for pagination"),
-  pagination: z.string().optional().describe("Pagination method (keyset)"),
+  page_token: z
+    .string()
+    .optional()
+    .describe(
+      "Token for keyset pagination. Use the next_page_token value returned in the previous response to retrieve the next page."
+    ),
+  pagination: z
+    .string()
+    .optional()
+    .describe(
+      "Pagination method. Use 'keyset' for keyset-based pagination (required for repositories with many files). When using keyset pagination, the response includes next_page_token if more pages are available."
+    ),
 });
 
 export const GitLabTreeSchema = z.object({

--- a/test/dynamic-routing-tests.ts
+++ b/test/dynamic-routing-tests.ts
@@ -262,6 +262,63 @@ describe('Dynamic Routing and Authentication Scenarios', () => {
 
       await client.disconnect();
     });
+
+    test('should preserve legacy tree array response and return keyset metadata when requested', async () => {
+      const client = new CustomHeaderClient({
+        headers: {
+          'authorization': `Bearer ${MOCK_TOKEN_HEADER}`,
+          'X-GitLab-API-URL': `${headerMockServer.getUrl()}/api/v4`,
+        }
+      });
+      await client.connect(mcpUrl);
+
+      headerMockServer.clearCustomHandlers();
+      headerMockServer.addMockHandler('get', '/projects/4/repository/tree', (req: Request, res: Response) => {
+        assert.strictEqual(req.headers['authorization'], `Bearer ${MOCK_TOKEN_HEADER}`);
+        assert.strictEqual(req.query.pagination, undefined);
+        res.json([createMockTreeItem('legacy-blob')]);
+      });
+
+      const legacyResult = await client.callTool('get_repository_tree', { project_id: '4' });
+      const legacyContent = JSON.parse((legacyResult.content[0] as any).text);
+      assert.ok(Array.isArray(legacyContent));
+      assert.strictEqual(legacyContent[0].id, 'legacy-blob');
+
+      headerMockServer.clearCustomHandlers();
+      headerMockServer.addMockHandler('get', '/projects/4/repository/tree', (req: Request, res: Response) => {
+        assert.strictEqual(req.headers['authorization'], `Bearer ${MOCK_TOKEN_HEADER}`);
+        assert.strictEqual(req.query.pagination, 'keyset');
+        res.set('x-next-page-token', 'token-blob');
+        res.json([createMockTreeItem('keyset-blob')]);
+      });
+
+      const keysetResult = await client.callTool('get_repository_tree', {
+        project_id: '4',
+        pagination: 'keyset',
+      });
+      const keysetContent = JSON.parse((keysetResult.content[0] as any).text);
+      assert.ok(!Array.isArray(keysetContent));
+      assert.strictEqual(keysetContent.items[0].id, 'keyset-blob');
+      assert.strictEqual(keysetContent.next_page_token, 'token-blob');
+
+      headerMockServer.clearCustomHandlers();
+      headerMockServer.addMockHandler('get', '/projects/4/repository/tree', (req: Request, res: Response) => {
+        assert.strictEqual(req.headers['authorization'], `Bearer ${MOCK_TOKEN_HEADER}`);
+        assert.strictEqual(req.query.pagination, 'keyset');
+        res.set('x-next-page', 'fallback-token');
+        res.json([createMockTreeItem('fallback-blob')]);
+      });
+
+      const fallbackResult = await client.callTool('get_repository_tree', {
+        project_id: '4',
+        pagination: 'keyset',
+      });
+      const fallbackContent = JSON.parse((fallbackResult.content[0] as any).text);
+      assert.strictEqual(fallbackContent.items[0].id, 'fallback-blob');
+      assert.strictEqual(fallbackContent.next_page_token, 'fallback-token');
+
+      await client.disconnect();
+    });
   });
 });
 

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -21,7 +21,8 @@ import {
   CreateIssueSchema,
   ListIssuesSchema,
   ListMergeRequestsSchema,
-  GitLabTreeItemSchema
+  GitLabTreeItemSchema,
+  GetRepositoryTreeSchema
 } from '../schemas.js';
 
 interface TestResult {
@@ -742,6 +743,80 @@ function runGitLabTreeItemSchemaTests(): { passed: number; failed: number } {
   return { passed, failed };
 }
 
+function runGetRepositoryTreeSchemaTests(): { passed: number; failed: number } {
+  console.log('\n=== GetRepositoryTree Schema Tests ===');
+
+  const cases: { name: string; input: Record<string, unknown>; expected?: Record<string, unknown>; shouldFail?: boolean }[] = [
+    {
+      name: 'schema:get_repository_tree:minimal-project-id',
+      input: { project_id: 'my/project' },
+      expected: { project_id: 'my/project', path: undefined, ref: undefined, recursive: undefined, per_page: undefined, page_token: undefined, pagination: undefined },
+    },
+    {
+      name: 'schema:get_repository_tree:with-keyset-pagination',
+      input: { project_id: 'my/project', pagination: 'keyset', per_page: 100 },
+      expected: { project_id: 'my/project', pagination: 'keyset', per_page: 100 },
+    },
+    {
+      name: 'schema:get_repository_tree:page-token-for-next-page',
+      input: { project_id: 'my/project', pagination: 'keyset', per_page: 100, page_token: 'eyJpZCI6IjEyMyJ9' },
+      expected: { project_id: 'my/project', pagination: 'keyset', per_page: 100, page_token: 'eyJpZCI6IjEyMyJ9' },
+    },
+    {
+      name: 'schema:get_repository_tree:per-page-coerces-from-string',
+      input: { project_id: 'my/project', per_page: '50' },
+      expected: { project_id: 'my/project', per_page: 50 },
+    },
+    {
+      name: 'schema:get_repository_tree:recursive-coerces-from-string',
+      input: { project_id: 'my/project', recursive: 'true' },
+      expected: { project_id: 'my/project', recursive: true },
+    },
+    {
+      name: 'schema:get_repository_tree:with-path-and-ref',
+      input: { project_id: 'my/project', path: 'src/', ref: 'main' },
+      expected: { project_id: 'my/project', path: 'src/', ref: 'main' },
+    },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  cases.forEach(testCase => {
+    const result: TestResult = { name: testCase.name, status: 'failed' };
+    const parsed = GetRepositoryTreeSchema.safeParse(testCase.input);
+
+    if (testCase.shouldFail) {
+      result.status = parsed.success ? 'failed' : 'passed';
+      if (parsed.success) result.error = 'Expected schema validation to fail';
+    } else if (parsed.success) {
+      const expected = testCase.expected || {};
+      const matches = Object.entries(expected).every(([key, value]) => {
+        const actual = (parsed.data as Record<string, unknown>)[key];
+        return JSON.stringify(actual) === JSON.stringify(value);
+      });
+      if (matches) {
+        result.status = 'passed';
+      } else {
+        result.error = `Unexpected parsed result: ${JSON.stringify(parsed.data)}`;
+      }
+    } else {
+      result.error = parsed.error?.message || 'Schema validation failed';
+    }
+
+    if (result.status === 'passed') {
+      passed++;
+      console.log(`✅ ${result.name}`);
+    } else {
+      failed++;
+      console.log(`❌ ${result.name}: ${result.error}`);
+    }
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed`);
+  return { passed, failed };
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
   const getFileContentsResult = runGetFileContentsSchemaTests();
   const fileContentResult = runGitLabFileContentSchemaTests();
@@ -751,9 +826,10 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const repositorySchemaResult = runGitLabRepositorySchemaTests();
   const labelsCoercionResult = runLabelsCoercionSchemaTests();
   const treeItemResult = runGitLabTreeItemSchemaTests();
+  const repositoryTreeResult = runGetRepositoryTreeSchemaTests();
 
-  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + createIssueNoteResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + treeItemResult.passed;
-  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + createIssueNoteResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + treeItemResult.failed;
+  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + createIssueNoteResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + treeItemResult.passed + repositoryTreeResult.passed;
+  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + createIssueNoteResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + treeItemResult.failed + repositoryTreeResult.failed;
 
   console.log(`\nTotal Results: ${totalPassed} passed, ${totalFailed} failed`);
 


### PR DESCRIPTION
## Problem

The `get_repository_tree` tool always returned the same first page of results regardless of the `page_token` value passed. GitLab's keyset pagination returns the next page token via the `X-Next-Page-Token` response header, but this header was silently discarded.

## Fix

- Return `{ items, next_page_token? }` from `getRepositoryTree` instead of the raw items array
- Read `x-next-page-token` response header and include it in the result
- When `next_page_token` is present, include a `pagination_note` in the tool output explaining how to use it
- Improve `page_token` and `pagination` parameter descriptions in the schema

## Usage After Fix

First call:
```json
{ "project_id": "mygroup/myproject", "per_page": 100, "pagination": "keyset" }
```

Response:
```json
{
  "items": [...],
  "next_page_token": "eyJpZCI6IjEyMyJ9",
  "pagination_note": "Pass next_page_token as page_token with pagination=keyset to retrieve the next page."
}
```

Next call:
```json
{ "project_id": "mygroup/myproject", "per_page": 100, "pagination": "keyset", "page_token": "eyJpZCI6IjEyMyJ9" }
```

Fixes #390