### PR TITLE
feat(create_repository): support namespace_id for group/user targeting

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4295,6 +4295,7 @@ async function createRepository(
       initialize_with_readme: options.initialize_with_readme,
       default_branch: "main",
       path: options.name.toLowerCase().replaceAll(/\s+/g, "-"),
+      ...(options.namespace_id !== undefined && { namespace_id: options.namespace_id }),
     }),
   });
 

--- a/schemas.ts
+++ b/schemas.ts
@@ -746,6 +746,12 @@ export const CreateRepositoryOptionsSchema = z.object({
   description: z.string().optional(),
   visibility: z.enum(["private", "internal", "public"]).optional(), // Changed from private to match GitLab API
   initialize_with_readme: z.coerce.boolean().optional(), // Changed from auto_init to match GitLab API
+  namespace_id: z
+    .union([z.coerce.number(), z.string()])
+    .optional()
+    .describe(
+      "Namespace ID (numeric) or full path for the group/user to create the project under. Omit to use the authenticated user's personal namespace."
+    ),
 });
 
 export const CreateIssueOptionsSchema = z.object({
@@ -1294,6 +1300,12 @@ export const CreateRepositorySchema = z.object({
     .optional()
     .describe("Repository visibility level"),
   initialize_with_readme: z.coerce.boolean().optional().describe("Initialize with README.md"),
+  namespace_id: z
+    .union([z.coerce.number(), z.string()])
+    .optional()
+    .describe(
+      "Namespace ID (numeric) or full path to create the project under. Omit to use the authenticated user's personal namespace."
+    ),
 });
 
 export const GetFileContentsSchema = z


### PR DESCRIPTION
## Summary

`create_repository` currently always creates projects in the authenticated user's personal namespace — there is no way to create a project under a group, or under another user (for admins). This PR adds an optional `namespace_id` field that passes straight through to `POST /projects`, so agents can target groups like `gitlab.example.com/my-team/<repo>` in one call.

When `namespace_id` is omitted, behavior is unchanged (defaults to the authed user's personal namespace).

Accepts either a numeric namespace ID or a full path string, matching the GitLab REST API's own flexibility for this field.

## Changes

- `schemas.ts`
  - Add `namespace_id` (optional, `number | string`) to `CreateRepositorySchema` (the MCP tool input schema exposed via `tools/registry.ts`).
  - Add the same field to `CreateRepositoryOptionsSchema` (the internal function param type).
- `index.ts` — include `namespace_id` in the `POST /projects` body only when it is provided (conditional spread, so the payload shape is untouched for the default case).

## Test plan

- [x] `npm install` (which runs `prepare` → `tsc`) succeeds with no type errors.
- [ ] Call `create_repository` without `namespace_id` → project is created in the authed user's personal namespace (existing behavior).
- [ ] Call `create_repository` with `namespace_id: <group_id>` → project is created under that group.
- [ ] Call `create_repository` with `namespace_id: "my-group/sub-group"` → project is created under that path.
- [ ] Call with a namespace the user doesn't have write permission to → GitLab returns 403; the MCP surfaces the error (no change to error handling).

## Motivation

Came up while using the MCP against a self-hosted GitLab: the agent needed to create projects under a dedicated group (e.g. `github/<repo>` for GitHub-mirrored projects), and the only workaround was to shell out to `glab api` with `-f namespace_id=<id>`. One-line addition on the server side removes the need for that workaround entirely.