### PR TITLE
feat: add OAuth callback proxy mode (GITLAB_OAUTH_CALLBACK_PROXY)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -82,6 +82,8 @@ export const GITLAB_OAUTH_SCOPES =
   GITLAB_OAUTH_SCOPES_RAW
     ? GITLAB_OAUTH_SCOPES_RAW.split(",").map((s) => s.trim()).filter(Boolean)
     : undefined;
+export const GITLAB_OAUTH_CALLBACK_PROXY =
+  getConfig("oauth-callback-proxy", "GITLAB_OAUTH_CALLBACK_PROXY") === "true";
 export const ENABLE_DYNAMIC_API_URL =
   getConfig("enable-dynamic-api-url", "ENABLE_DYNAMIC_API_URL") === "true";
 

--- a/docs/oauth-callback-proxy.md
+++ b/docs/oauth-callback-proxy.md
@@ -1,0 +1,107 @@
+# GitLab MCP OAuth Callback Proxy
+
+## Problem
+
+The current OAuth flow requires each MCP client's callback URL to be pre-registered in the GitLab OAuth Application settings. This means GitLab admin involvement for every new client deployment.
+
+## Passthrough Mode (Default — GITLAB_OAUTH_CALLBACK_PROXY=false)
+
+GitLab redirects **directly back to the MCP client**. The MCP server only proxies the client_id and token exchange — it never receives the callback.
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Server as MCP Server
+    participant GitLab as GitLab
+
+    Client->>Server: POST /register<br/>{redirect_uris: [client.com/cb]}
+    Server-->>Client: {client_id: virtual-uuid}
+
+    Client->>Server: GET /authorize<br/>{redirect_uri=client.com/cb, code_challenge, state}
+    Server->>GitLab: 302 → /oauth/authorize<br/>{client_id=REAL_APP_ID,<br/>redirect_uri=client.com/cb,<br/>code_challenge, state}
+
+    Note over GitLab: User logs in & authorizes
+
+    GitLab->>Client: 302 → client.com/cb?code=GITLAB_CODE&state=...
+    Note right of Client: ⚠️ GitLab redirects directly<br/>to the MCP client.<br/>This URL must be registered<br/>in GitLab OAuth App settings.
+
+    Client->>Server: POST /token<br/>{code=GITLAB_CODE, code_verifier}
+    Server->>GitLab: POST /oauth/token<br/>{code=GITLAB_CODE, code_verifier,<br/>client_id=REAL_APP_ID}
+    GitLab-->>Server: {access_token, refresh_token}
+    Server-->>Client: {access_token, refresh_token}
+
+    Client->>Server: POST /mcp<br/>Authorization: Bearer access_token
+    Server->>GitLab: Validate token & make API calls
+```
+
+**Problem**: Every MCP client needs its callback URL registered in GitLab Admin → Applications. New client = new URL = GitLab admin involvement.
+
+## Callback Proxy Mode (GITLAB_OAUTH_CALLBACK_PROXY=true)
+
+The MCP server **intercepts the callback itself**, exchanges the code with GitLab, stores the tokens server-side, and redirects to the client with a proxy code. Only ONE fixed URL needs to be registered with GitLab.
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Server as MCP Server
+    participant GitLab as GitLab
+
+    Client->>Server: POST /register<br/>{redirect_uris: [client.com/cb]}
+    Server-->>Client: {client_id: virtual-uuid}
+
+    Client->>Server: GET /authorize<br/>{redirect_uri=client.com/cb,<br/>code_challenge=CLIENT_CC, state=CLIENT_STATE}
+
+    Note over Server: Stores client's redirect_uri,<br/>state, and code_challenge.<br/>Generates proxy PKCE pair.
+
+    Server->>GitLab: 302 → /oauth/authorize<br/>{client_id=REAL_APP_ID,<br/>redirect_uri=mcp-server.com/callback,<br/>code_challenge=PROXY_CC,<br/>state=PROXY_STATE}
+
+    Note over GitLab: User logs in & authorizes
+
+    GitLab->>Server: 302 → mcp-server.com/callback?code=GITLAB_CODE&state=PROXY_STATE
+    Note right of Server: ✅ GitLab redirects to the<br/>MCP server's fixed /callback.<br/>Only THIS URL is registered<br/>in GitLab OAuth App settings.
+
+    Server->>GitLab: POST /oauth/token<br/>{code=GITLAB_CODE,<br/>code_verifier=PROXY_CV,<br/>redirect_uri=mcp-server.com/callback}
+    GitLab-->>Server: {access_token, refresh_token}
+
+    Note over Server: Stores tokens server-side.<br/>Generates proxy auth code.
+
+    Server->>Client: 302 → client.com/cb?code=PROXY_CODE&state=CLIENT_STATE
+
+    Client->>Server: POST /token<br/>{code=PROXY_CODE, code_verifier=CLIENT_CV}
+
+    Note over Server: Verifies client PKCE.<br/>Looks up stored tokens<br/>by proxy code (one-time use).
+
+    Server-->>Client: {access_token, refresh_token}
+
+    Client->>Server: POST /mcp<br/>Authorization: Bearer access_token
+    Server->>GitLab: Validate token & make API calls
+```
+
+**Result**: Only `https://mcp-server.example.com/callback` needs to be registered in GitLab. Works with any number of MCP clients without GitLab admin changes.
+
+## Security
+
+| Property | How It's Enforced |
+|----------|------------------|
+| Dual PKCE | Separate pairs for client↔server and server↔GitLab legs |
+| Proxy codes are one-time use | Deleted from store after first `/token` exchange |
+| Proxy codes expire | 10-minute TTL, checked before returning tokens |
+| Client PKCE is verified | `code_verifier` is mandatory when `code_challenge` was stored |
+| State is not replayable | Deleted from pending store after `/callback` consumes it |
+| Error responses are sanitized | Generic messages to clients, details in server logs only |
+| Bounded memory | In-memory LRU cache, max 1000 entries |
+
+## Configuration
+
+```bash
+# Enable callback proxy mode
+GITLAB_MCP_OAUTH=true
+GITLAB_OAUTH_CALLBACK_PROXY=true
+MCP_SERVER_URL=https://mcp-server.example.com
+GITLAB_OAUTH_APP_ID=<app-id>
+```
+
+In GitLab Admin → Applications:
+- Set the redirect URI to `https://mcp-server.example.com/callback`
+- Ensure Confidential is **unchecked** (public client, PKCE replaces client_secret)
+- Enable the required scopes (e.g. `api`, `read_api`, `read_user`)

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import {
   GITLAB_MCP_OAUTH,
   GITLAB_OAUTH_APP_ID,
   GITLAB_OAUTH_SCOPES,
+  GITLAB_OAUTH_CALLBACK_PROXY,
   GITLAB_PERSONAL_ACCESS_TOKEN,
   GITLAB_POOL_MAX_SIZE,
   GITLAB_READ_ONLY_MODE,
@@ -10041,7 +10042,10 @@ async function startStreamableHTTPServer(): Promise<void> {
     app.set("trust proxy", 1);
     const gitlabBaseUrl = GITLAB_API_URL.replace(/\/api\/v4\/?$/, "").replace(/\/$/, "");
     const issuerUrl = new URL(MCP_SERVER_URL!);
-    const oauthProvider = createGitLabOAuthProvider(gitlabBaseUrl, GITLAB_OAUTH_APP_ID!, "GitLab MCP Server", GITLAB_READ_ONLY_MODE, GITLAB_OAUTH_SCOPES);
+    const callbackUrl = GITLAB_OAUTH_CALLBACK_PROXY
+      ? `${issuerUrl.origin}${issuerUrl.pathname.replace(/\/$/, "")}/callback`
+      : undefined;
+    const oauthProvider = createGitLabOAuthProvider(gitlabBaseUrl, GITLAB_OAUTH_APP_ID!, "GitLab MCP Server", GITLAB_READ_ONLY_MODE, GITLAB_OAUTH_SCOPES, GITLAB_OAUTH_CALLBACK_PROXY, callbackUrl);
     const scopesSupported = GITLAB_OAUTH_SCOPES ?? ["api", "read_api", "read_user"];
 
     // When server URL has a path (e.g. behind Kong), the SDK's well-known metadata
@@ -10105,6 +10109,15 @@ async function startStreamableHTTPServer(): Promise<void> {
 
     // Expose provider so the /mcp route middleware can reference it
     (app as any)._mcpOAuthProvider = oauthProvider;
+
+    // Mount /callback route for callback proxy mode
+    if (GITLAB_OAUTH_CALLBACK_PROXY) {
+      const callbackPath = `${issuerUrl.pathname.replace(/\/$/, "")}/callback`;
+      app.get(callbackPath, (req: Request, res: Response, next: NextFunction) => {
+        oauthProvider.handleCallback(req, res).catch(next);
+      });
+      logger.info(`Callback proxy mode enabled — ${callbackPath} route mounted`);
+    }
   }
 
   // Build bearer-auth middleware — no-op unless GITLAB_MCP_OAUTH is enabled.

--- a/oauth-proxy.ts
+++ b/oauth-proxy.ts
@@ -13,7 +13,26 @@
  * and handles DCR locally — each MCP client gets a unique virtual client_id
  * mapped to the real GitLab app.
  *
- * ### Flow
+ * ### Flow (callback proxy mode — GITLAB_OAUTH_CALLBACK_PROXY=true)
+ *
+ * When callback proxy mode is enabled, the MCP server acts as a full OAuth
+ * intermediary, similar to the Atlassian MCP's OAuthProxy pattern. Only ONE
+ * fixed callback URL needs to be registered with GitLab, regardless of how
+ * many MCP clients connect.
+ *
+ * 1. MCP client calls POST /register (DCR) — proxy stores redirect_uris locally
+ *    and returns a virtual client_id.
+ * 2. MCP client redirects to /authorize — proxy stores the client's original
+ *    redirect_uri and state, generates its own PKCE pair, then redirects to
+ *    GitLab using the MCP server's fixed /callback URL as redirect_uri.
+ * 3. User authorizes on GitLab — GitLab redirects to the MCP server's /callback.
+ * 4. /callback handler exchanges the code with GitLab for tokens, stores them
+ *    server-side, generates a new proxy auth code, and redirects to the client's
+ *    original redirect_uri with the proxy code.
+ * 5. MCP client calls POST /token with the proxy code — proxy returns the
+ *    stored GitLab tokens.
+ *
+ * ### Flow (passthrough mode — default)
  *
  * 1. MCP client calls POST /register (DCR) — proxy stores redirect_uris locally
  *    and returns a virtual client_id.
@@ -37,8 +56,9 @@ import { OAuthTokensSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
 import type { AuthorizationParams, OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js";
 import type { Response } from "express";
-import { randomUUID } from "node:crypto";
+import { randomUUID, randomBytes, createHash } from "node:crypto";
 import { pino } from "pino";
+import type { Request } from "express";
 
 const logger = pino({ name: "gitlab-mcp-oauth-proxy" });
 
@@ -55,44 +75,6 @@ export interface GitLabTokenInfo {
 }
 
 // ---------------------------------------------------------------------------
-// Bounded LRU client cache
-// ---------------------------------------------------------------------------
-
-const CLIENT_CACHE_MAX_SIZE = 1000;
-
-class BoundedClientCache {
-  private readonly _map = new Map<string, OAuthClientInformationFull>();
-  private readonly _maxSize: number;
-
-  constructor(maxSize: number) {
-    this._maxSize = maxSize;
-  }
-
-  get(clientId: string): OAuthClientInformationFull | undefined {
-    const entry = this._map.get(clientId);
-    if (entry) {
-      this._map.delete(clientId);
-      this._map.set(clientId, entry);
-    }
-    return entry;
-  }
-
-  set(clientId: string, client: OAuthClientInformationFull): void {
-    if (this._map.has(clientId)) {
-      this._map.delete(clientId);
-    } else if (this._map.size >= this._maxSize) {
-      const lruKey = this._map.keys().next().value;
-      if (lruKey !== undefined) this._map.delete(lruKey);
-    }
-    this._map.set(clientId, client);
-  }
-
-  get size(): number {
-    return this._map.size;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // GitLab OAuth Server Provider
 // ---------------------------------------------------------------------------
 
@@ -103,9 +85,79 @@ class BoundedClientCache {
 const REQUIRED_GITLAB_SCOPES_RW = ["api"];
 const REQUIRED_GITLAB_SCOPES_RO = ["read_api"];
 
+// ---------------------------------------------------------------------------
+// Callback proxy mode — pending auth transactions
+// ---------------------------------------------------------------------------
+
+const PENDING_AUTH_MAX_SIZE = 1000;
+const PENDING_AUTH_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const CLIENT_CACHE_MAX_SIZE = 1000;
+
+/** Stored while user is on GitLab consent screen. Keyed by `state`. */
+interface PendingAuthTransaction {
+  clientRedirectUri: string;
+  clientState: string | undefined;
+  clientCodeChallenge: string;
+  proxyCodeVerifier: string;
+  createdAt: number;
+}
+
+/** Stored after /callback exchanges the code. Keyed by proxy auth code. */
+interface StoredTokenEntry {
+  tokens: OAuthTokens;
+  clientCodeChallenge: string; // for PKCE verification when client calls /token
+  redirectUri: string; // the fixed callback URI used with GitLab
+  createdAt: number;
+}
+
+class BoundedLRUMap<V> {
+  private readonly _map = new Map<string, V>();
+  private readonly _maxSize: number;
+
+  constructor(maxSize: number) {
+    this._maxSize = maxSize;
+  }
+
+  get(key: string): V | undefined {
+    const v = this._map.get(key);
+    if (v !== undefined) {
+      this._map.delete(key);
+      this._map.set(key, v);
+    }
+    return v;
+  }
+
+  /** Get and remove in one operation — for one-time-use entries. */
+  getAndDelete(key: string): V | undefined {
+    const v = this._map.get(key);
+    if (v !== undefined) this._map.delete(key);
+    return v;
+  }
+
+  set(key: string, value: V): void {
+    if (this._map.has(key)) this._map.delete(key);
+    else if (this._map.size >= this._maxSize) {
+      const lruKey = this._map.keys().next().value;
+      if (lruKey !== undefined) this._map.delete(lruKey);
+    }
+    this._map.set(key, value);
+  }
+
+  delete(key: string): boolean {
+    return this._map.delete(key);
+  }
+
+  get size(): number {
+    return this._map.size;
+  }
+}
+
 class GitLabOAuthServerProvider implements OAuthServerProvider {
   /**
-   * Tell the SDK not to validate PKCE locally — GitLab handles it.
+   * Tell the SDK not to validate PKCE locally.
+   * - Passthrough mode: GitLab handles PKCE validation.
+   * - Callback proxy mode: we verify the client's PKCE manually in
+   *   exchangeAuthorizationCode() after looking up stored tokens.
    */
   readonly skipLocalPkceValidation = true;
 
@@ -113,14 +165,22 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
   private readonly _gitlabAppId: string;
   private readonly _resourceName: string;
   private readonly _requiredScopes: string[];
-  private readonly _clientCache = new BoundedClientCache(CLIENT_CACHE_MAX_SIZE);
+  private readonly _clientCache = new BoundedLRUMap<OAuthClientInformationFull>(CLIENT_CACHE_MAX_SIZE);
+
+  // Callback proxy mode fields
+  private readonly _callbackProxyEnabled: boolean;
+  private readonly _callbackUrl: string;
+  private readonly _pendingAuth = new BoundedLRUMap<PendingAuthTransaction>(PENDING_AUTH_MAX_SIZE);
+  private readonly _storedTokens = new BoundedLRUMap<StoredTokenEntry>(PENDING_AUTH_MAX_SIZE);
 
   constructor(
     gitlabBaseUrl: string,
     gitlabAppId: string,
     resourceName: string,
     readOnly: boolean,
-    customScopes?: string[]
+    customScopes?: string[],
+    callbackProxyEnabled = false,
+    callbackUrl = ""
   ) {
     this._gitlabBaseUrl = gitlabBaseUrl;
     this._gitlabAppId = gitlabAppId;
@@ -131,6 +191,15 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
         : readOnly
           ? REQUIRED_GITLAB_SCOPES_RO
           : REQUIRED_GITLAB_SCOPES_RW;
+    this._callbackProxyEnabled = callbackProxyEnabled;
+    this._callbackUrl = callbackUrl;
+
+    if (callbackProxyEnabled && !callbackUrl) {
+      throw new Error("callbackUrl is required when callbackProxyEnabled is true");
+    }
+    if (callbackProxyEnabled) {
+      logger.info(`Callback proxy mode enabled — fixed callback URL: ${callbackUrl}`);
+    }
   }
 
   // ---- Client store (local DCR) ------------------------------------------
@@ -194,23 +263,65 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
 
     // Build the GitLab authorize URL with the REAL app client_id
     const targetUrl = new URL(`${this._gitlabBaseUrl}/oauth/authorize`);
-    const searchParams = new URLSearchParams({
-      client_id: this._gitlabAppId,
-      response_type: "code",
-      redirect_uri: params.redirectUri,
-      code_challenge: params.codeChallenge,
-      code_challenge_method: "S256",
-    });
 
-    if (params.state) searchParams.set("state", params.state);
-    if (effectiveScopes.length) searchParams.set("scope", effectiveScopes.join(" "));
-    if (params.resource) searchParams.set("resource", params.resource.href);
+    if (this._callbackProxyEnabled) {
+      // --- Callback proxy mode ---
+      // Generate a proxy PKCE pair (MCP server ↔ GitLab)
+      const proxyCodeVerifier = randomBytes(32).toString("base64url");
+      const proxyCodeChallenge = createHash("sha256")
+        .update(proxyCodeVerifier)
+        .digest("base64url");
 
-    targetUrl.search = searchParams.toString();
+      // Use a unique state to correlate the callback
+      const proxyState = randomUUID();
 
-    logger.info(
-      `authorize: redirecting to GitLab (app: ${this._gitlabAppId}, scopes: ${effectiveScopes.join(" ")})`
-    );
+      // Store the client's original params so /callback can redirect back
+      this._pendingAuth.set(proxyState, {
+        clientRedirectUri: params.redirectUri,
+        clientState: params.state,
+        clientCodeChallenge: params.codeChallenge,
+        proxyCodeVerifier,
+        createdAt: Date.now(),
+      });
+
+      const searchParams = new URLSearchParams({
+        client_id: this._gitlabAppId,
+        response_type: "code",
+        redirect_uri: this._callbackUrl,
+        code_challenge: proxyCodeChallenge,
+        code_challenge_method: "S256",
+        state: proxyState,
+      });
+
+      if (effectiveScopes.length) searchParams.set("scope", effectiveScopes.join(" "));
+      if (params.resource) searchParams.set("resource", params.resource.href);
+
+      targetUrl.search = searchParams.toString();
+
+      logger.info(
+        `authorize (callback proxy): redirecting to GitLab with fixed callback URL (app: ${this._gitlabAppId}, scopes: ${effectiveScopes.join(" ")})`
+      );
+    } else {
+      // --- Passthrough mode (original behavior) ---
+      const searchParams = new URLSearchParams({
+        client_id: this._gitlabAppId,
+        response_type: "code",
+        redirect_uri: params.redirectUri,
+        code_challenge: params.codeChallenge,
+        code_challenge_method: "S256",
+      });
+
+      if (params.state) searchParams.set("state", params.state);
+      if (effectiveScopes.length) searchParams.set("scope", effectiveScopes.join(" "));
+      if (params.resource) searchParams.set("resource", params.resource.href);
+
+      targetUrl.search = searchParams.toString();
+
+      logger.info(
+        `authorize: redirecting to GitLab (app: ${this._gitlabAppId}, scopes: ${effectiveScopes.join(" ")})`
+      );
+    }
+
     res.redirect(targetUrl.toString());
   }
 
@@ -232,6 +343,41 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
     redirectUri?: string,
     resource?: URL
   ): Promise<OAuthTokens> {
+    if (this._callbackProxyEnabled) {
+      // --- Callback proxy mode ---
+      // The authorizationCode is a proxy code we generated in handleCallback().
+      // Look up the stored tokens by proxy code.
+      const entry = this._storedTokens.get(authorizationCode);
+      if (!entry) {
+        throw new ServerError("Invalid or expired authorization code");
+      }
+
+      // Check TTL before consuming — expired entries can't be retried anyway,
+      // but we give a specific error so the client knows to restart the flow.
+      if (Date.now() - entry.createdAt > PENDING_AUTH_TTL_MS) {
+        this._storedTokens.delete(authorizationCode);
+        throw new ServerError("Authorization code expired — please restart the OAuth flow");
+      }
+
+      // One-time use: delete after validation
+      this._storedTokens.delete(authorizationCode);
+
+      // Verify client PKCE: the client's code_verifier must match the
+      // code_challenge stored during /authorize.
+      if (entry.clientCodeChallenge) {
+        if (!codeVerifier) {
+          throw new ServerError("PKCE code_verifier is required");
+        }
+        const computed = createHash("sha256").update(codeVerifier).digest("base64url");
+        if (computed !== entry.clientCodeChallenge) {
+          throw new ServerError("PKCE verification failed");
+        }
+      }
+
+      return entry.tokens;
+    }
+
+    // --- Passthrough mode (original behavior) ---
     const params = new URLSearchParams({
       grant_type: "authorization_code",
       client_id: this._gitlabAppId,
@@ -315,6 +461,100 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
     };
   }
 
+  // ---- Callback handler (callback proxy mode) ----------------------------
+
+  /**
+   * Handle the OAuth callback from GitLab.
+   * Exchanges the auth code for tokens, stores them, generates a proxy code,
+   * and redirects to the MCP client's original callback URL.
+   *
+   * Mount this as GET /callback in the Express app.
+   */
+  async handleCallback(req: Request, res: Response): Promise<void> {
+    if (!this._callbackProxyEnabled) {
+      res.status(404).send("Callback proxy mode is not enabled");
+      return;
+    }
+
+    const code = req.query.code as string | undefined;
+    const state = req.query.state as string | undefined;
+    const error = req.query.error as string | undefined;
+
+    if (error) {
+      logger.error(`GitLab OAuth error: ${error} — ${req.query.error_description ?? "(no description)"}`);
+      res.status(400).send("Authorization failed");
+      return;
+    }
+
+    if (!code || !state) {
+      res.status(400).send("Missing code or state parameter");
+      return;
+    }
+
+    // Look up the pending auth transaction
+    const pending = this._pendingAuth.getAndDelete(state);
+    if (!pending) {
+      res.status(400).send("Unknown or expired state parameter");
+      return;
+    }
+
+    // Check TTL
+    if (Date.now() - pending.createdAt > PENDING_AUTH_TTL_MS) {
+      res.status(400).send("Authorization request expired");
+      return;
+    }
+
+    // Exchange the GitLab auth code for tokens using the proxy's PKCE verifier
+    try {
+      const tokenParams = new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: this._gitlabAppId,
+        code,
+        redirect_uri: this._callbackUrl,
+        code_verifier: pending.proxyCodeVerifier,
+      });
+
+      const tokenResponse = await fetch(`${this._gitlabBaseUrl}/oauth/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: tokenParams.toString(),
+      });
+
+      if (!tokenResponse.ok) {
+        const body = await tokenResponse.text();
+        logger.error(`Callback token exchange failed (${tokenResponse.status}): ${body}`);
+        res.status(502).send("Token exchange with GitLab failed");
+        return;
+      }
+
+      const tokens = OAuthTokensSchema.parse(await tokenResponse.json());
+
+      // Generate a proxy auth code for the MCP client
+      const proxyCode = randomUUID();
+      this._storedTokens.set(proxyCode, {
+        tokens,
+        clientCodeChallenge: pending.clientCodeChallenge,
+        redirectUri: this._callbackUrl,
+        createdAt: Date.now(),
+      });
+
+      // Redirect to the MCP client's original callback URL
+      const clientCallback = new URL(pending.clientRedirectUri);
+      clientCallback.searchParams.set("code", proxyCode);
+      if (pending.clientState) {
+        clientCallback.searchParams.set("state", pending.clientState);
+      }
+
+      logger.info(
+        `callback: exchanged code with GitLab, redirecting to client callback`
+      );
+      res.redirect(clientCallback.toString());
+    } catch (err) {
+      logger.error({ err }, "Callback handler error");
+      res.status(500).send("Internal error during token exchange");
+    }
+  }
+
   // ---- Revoke token ------------------------------------------------------
 
   async revokeToken(
@@ -356,13 +596,19 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
  * @param resourceName   Human-readable name shown on the GitLab consent screen.
  * @param readOnly       When true and customScopes is not set, restricts to read_api scope.
  * @param customScopes   Explicit list of GitLab scopes to require. Overrides readOnly when set.
+ * @param callbackProxyEnabled  When true, the MCP server handles the OAuth callback internally.
+ *                              Only ONE fixed callback URL needs to be registered with GitLab.
+ * @param callbackUrl    The fixed callback URL (e.g. https://mcp.example.com/callback).
+ *                        Required when callbackProxyEnabled is true.
  */
 export function createGitLabOAuthProvider(
   gitlabBaseUrl: string,
   gitlabAppId: string,
   resourceName = "GitLab MCP Server",
   readOnly = false,
-  customScopes?: string[]
+  customScopes?: string[],
+  callbackProxyEnabled = false,
+  callbackUrl = ""
 ): GitLabOAuthServerProvider {
-  return new GitLabOAuthServerProvider(gitlabBaseUrl, gitlabAppId, resourceName, readOnly, customScopes);
+  return new GitLabOAuthServerProvider(gitlabBaseUrl, gitlabAppId, resourceName, readOnly, customScopes, callbackProxyEnabled, callbackUrl);
 }

--- a/test/callback-proxy-tests.ts
+++ b/test/callback-proxy-tests.ts
@@ -1,0 +1,415 @@
+/**
+ * Callback Proxy Mode Tests
+ *
+ * Tests for GITLAB_OAUTH_CALLBACK_PROXY=true — the mode where the MCP server
+ * intercepts the OAuth callback from GitLab, exchanges the code for tokens
+ * server-side, and redirects to the MCP client with a proxy code.
+ */
+
+import { describe, test, after, before } from "node:test";
+import assert from "node:assert";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  launchServer,
+  findAvailablePort,
+  cleanupServers,
+  ServerInstance,
+  TransportMode,
+  HOST,
+} from "./utils/server-launcher.js";
+import { MockGitLabServer, findMockServerPort } from "./utils/mock-gitlab-server.js";
+
+const MOCK_GITLAB_PORT_BASE = 9400;
+const MCP_SERVER_PORT_BASE = 3400;
+const MOCK_ACCESS_TOKEN = "ya29.mock-callback-proxy-token-123456";
+const MOCK_REFRESH_TOKEN = "mock-refresh-token-abcdef";
+const MOCK_APP_ID = "test-callback-proxy-app-id";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generatePKCE(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+/** Register a client via DCR and return the virtual client_id. */
+async function registerClient(
+  mcpBaseUrl: string,
+  redirectUri: string
+): Promise<string> {
+  const res = await fetch(`${mcpBaseUrl}/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      redirect_uris: [redirectUri],
+      client_name: "callback-proxy-test",
+    }),
+  });
+  assert.strictEqual(res.status, 201, `DCR failed: ${res.status}`);
+  const data = (await res.json()) as { client_id: string };
+  return data.client_id;
+}
+
+/** Hit /authorize and return the redirect Location without following it. */
+async function authorize(
+  mcpBaseUrl: string,
+  clientId: string,
+  redirectUri: string,
+  codeChallenge: string,
+  state: string
+): Promise<URL> {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    state,
+    scope: "api",
+  });
+  const res = await fetch(`${mcpBaseUrl}/authorize?${params}`, {
+    redirect: "manual",
+  });
+  assert.strictEqual(res.status, 302, `Expected 302, got ${res.status}`);
+  const location = res.headers.get("location");
+  assert.ok(location, "Missing Location header");
+  return new URL(location);
+}
+
+/** Simulate GitLab redirecting to the MCP server's /callback. */
+async function simulateGitLabCallback(
+  mcpBaseUrl: string,
+  code: string,
+  state: string
+): Promise<{ status: number; location: string | null; body: string }> {
+  const res = await fetch(
+    `${mcpBaseUrl}/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`,
+    { redirect: "manual" }
+  );
+  return {
+    status: res.status,
+    location: res.headers.get("location"),
+    body: await res.text(),
+  };
+}
+
+/** Exchange a proxy code for tokens via /token. */
+async function exchangeToken(
+  mcpBaseUrl: string,
+  clientId: string,
+  code: string,
+  codeVerifier: string,
+  redirectUri: string
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`${mcpBaseUrl}/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: clientId,
+      code,
+      code_verifier: codeVerifier,
+      redirect_uri: redirectUri,
+    }).toString(),
+  });
+  return {
+    status: res.status,
+    body: (await res.json()) as Record<string, unknown>,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("Callback Proxy Mode", () => {
+  let mcpBaseUrl: string;
+  let mockGitLab: MockGitLabServer;
+  let mockGitLabUrl: string;
+  let servers: ServerInstance[] = [];
+  const clientRedirectUri = "http://localhost:19999/oauth/callback";
+
+  // Track the last code+verifier GitLab received so we can verify the proxy PKCE
+  let lastTokenRequest: Record<string, string> = {};
+
+  before(async () => {
+    const mockPort = await findMockServerPort(MOCK_GITLAB_PORT_BASE);
+    mockGitLab = new MockGitLabServer({
+      port: mockPort,
+      validTokens: [MOCK_ACCESS_TOKEN],
+    });
+    await mockGitLab.start();
+    mockGitLabUrl = mockGitLab.getUrl();
+
+    // Mock GitLab token exchange — returns tokens and records the request
+    mockGitLab.addRootHandler("post", "/oauth/token", (req, res) => {
+      // Body may be URL-encoded (from handleCallback) — parse manually if needed
+      let body = req.body ?? {};
+      if (typeof body === "string") {
+        body = Object.fromEntries(new URLSearchParams(body));
+      } else if (!body.grant_type && req.headers["content-type"]?.includes("urlencoded")) {
+        // express.json() didn't parse it — collect raw body
+        let raw = "";
+        req.on("data", (chunk: Buffer) => { raw += chunk.toString(); });
+        req.on("end", () => {
+          lastTokenRequest = Object.fromEntries(new URLSearchParams(raw));
+          res.json({
+            access_token: MOCK_ACCESS_TOKEN,
+            token_type: "Bearer",
+            expires_in: 7200,
+            refresh_token: MOCK_REFRESH_TOKEN,
+            scope: "api",
+          });
+        });
+        return;
+      }
+      lastTokenRequest = body;
+      res.json({
+        access_token: MOCK_ACCESS_TOKEN,
+        token_type: "Bearer",
+        expires_in: 7200,
+        refresh_token: MOCK_REFRESH_TOKEN,
+        scope: "api",
+      });
+    });
+
+    // Mock token introspection
+    mockGitLab.addRootHandler("get", "/oauth/token/info", (req, res) => {
+      const auth = req.headers["authorization"] as string | undefined;
+      const token = auth?.replace(/^Bearer\s+/i, "");
+      if (token !== MOCK_ACCESS_TOKEN) {
+        res.status(401).json({ error: "invalid_token" });
+        return;
+      }
+      res.json({
+        resource_owner_id: 42,
+        scopes: ["api"],
+        expires_in_seconds: 7200,
+        application: { uid: MOCK_APP_ID },
+        created_at: Math.floor(Date.now() / 1000),
+      });
+    });
+
+    const mcpPort = await findAvailablePort(MCP_SERVER_PORT_BASE);
+    mcpBaseUrl = `http://${HOST}:${mcpPort}`;
+
+    const server = await launchServer({
+      mode: TransportMode.STREAMABLE_HTTP,
+      port: mcpPort,
+      timeout: 5000,
+      env: {
+        STREAMABLE_HTTP: "true",
+        GITLAB_MCP_OAUTH: "true",
+        GITLAB_OAUTH_CALLBACK_PROXY: "true",
+        GITLAB_OAUTH_APP_ID: MOCK_APP_ID,
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        MCP_SERVER_URL: mcpBaseUrl,
+        MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL: "true",
+      },
+    });
+    servers.push(server);
+  });
+
+  after(async () => {
+    cleanupServers(servers);
+    if (mockGitLab) await mockGitLab.stop();
+  });
+
+  // ---- Happy path --------------------------------------------------------
+
+  test("full flow: authorize → callback → token exchange", async () => {
+    const clientPKCE = generatePKCE();
+    const clientState = "test-state-123";
+
+    // 1. Register client
+    const clientId = await registerClient(mcpBaseUrl, clientRedirectUri);
+
+    // 2. Authorize — should redirect to GitLab with fixed callback URL
+    const gitlabUrl = await authorize(
+      mcpBaseUrl,
+      clientId,
+      clientRedirectUri,
+      clientPKCE.challenge,
+      clientState
+    );
+
+    assert.strictEqual(gitlabUrl.hostname, new URL(mockGitLabUrl).hostname);
+    assert.strictEqual(gitlabUrl.pathname, "/oauth/authorize");
+    // redirect_uri should be the MCP server's /callback, NOT the client's
+    assert.strictEqual(
+      gitlabUrl.searchParams.get("redirect_uri"),
+      `${mcpBaseUrl}/callback`
+    );
+    // State should be a proxy state, NOT the client's original state
+    const proxyState = gitlabUrl.searchParams.get("state");
+    assert.ok(proxyState);
+    assert.notStrictEqual(proxyState, clientState);
+
+    // 3. Simulate GitLab callback to MCP server
+    const callbackResult = await simulateGitLabCallback(
+      mcpBaseUrl,
+      "gitlab-auth-code-xyz",
+      proxyState
+    );
+
+    assert.strictEqual(callbackResult.status, 302);
+    assert.ok(callbackResult.location);
+    const clientCallbackUrl = new URL(callbackResult.location);
+    // Should redirect to the CLIENT's callback URL
+    assert.ok(clientCallbackUrl.href.startsWith(clientRedirectUri));
+    // Should include a proxy code (not the GitLab code)
+    const proxyCode = clientCallbackUrl.searchParams.get("code");
+    assert.ok(proxyCode);
+    assert.notStrictEqual(proxyCode, "gitlab-auth-code-xyz");
+    // Should restore the client's original state
+    assert.strictEqual(clientCallbackUrl.searchParams.get("state"), clientState);
+
+    // 4. Exchange proxy code for tokens
+    const tokenResult = await exchangeToken(
+      mcpBaseUrl,
+      clientId,
+      proxyCode,
+      clientPKCE.verifier,
+      clientRedirectUri
+    );
+
+    assert.strictEqual(tokenResult.status, 200);
+    assert.strictEqual(tokenResult.body.access_token, MOCK_ACCESS_TOKEN);
+    assert.strictEqual(tokenResult.body.refresh_token, MOCK_REFRESH_TOKEN);
+  });
+
+  // ---- One-time use proxy code -------------------------------------------
+
+  test("proxy code cannot be reused", async () => {
+    const clientPKCE = generatePKCE();
+    const clientId = await registerClient(mcpBaseUrl, clientRedirectUri);
+    const gitlabUrl = await authorize(
+      mcpBaseUrl, clientId, clientRedirectUri, clientPKCE.challenge, "state-reuse"
+    );
+    const proxyState = gitlabUrl.searchParams.get("state")!;
+
+    const cb = await simulateGitLabCallback(mcpBaseUrl, "code-reuse", proxyState);
+    const proxyCode = new URL(cb.location!).searchParams.get("code")!;
+
+    // First exchange succeeds
+    const first = await exchangeToken(
+      mcpBaseUrl, clientId, proxyCode, clientPKCE.verifier, clientRedirectUri
+    );
+    assert.strictEqual(first.status, 200);
+
+    // Second exchange with same code fails
+    const second = await exchangeToken(
+      mcpBaseUrl, clientId, proxyCode, clientPKCE.verifier, clientRedirectUri
+    );
+    assert.notStrictEqual(second.status, 200);
+  });
+
+  // ---- Unknown state parameter -------------------------------------------
+
+  test("callback with unknown state returns 400", async () => {
+    const result = await simulateGitLabCallback(
+      mcpBaseUrl,
+      "some-code",
+      "unknown-state-value"
+    );
+    assert.strictEqual(result.status, 400);
+    assert.ok(result.body.includes("Unknown or expired"));
+  });
+
+  // ---- PKCE verification failure -----------------------------------------
+
+  test("token exchange with wrong code_verifier fails", async () => {
+    const clientPKCE = generatePKCE();
+    const clientId = await registerClient(mcpBaseUrl, clientRedirectUri);
+    const gitlabUrl = await authorize(
+      mcpBaseUrl, clientId, clientRedirectUri, clientPKCE.challenge, "state-pkce"
+    );
+    const proxyState = gitlabUrl.searchParams.get("state")!;
+
+    const cb = await simulateGitLabCallback(mcpBaseUrl, "code-pkce", proxyState);
+    const proxyCode = new URL(cb.location!).searchParams.get("code")!;
+
+    // Exchange with WRONG verifier
+    const result = await exchangeToken(
+      mcpBaseUrl, clientId, proxyCode, "wrong-verifier-value", clientRedirectUri
+    );
+    assert.notStrictEqual(result.status, 200);
+  });
+
+  // ---- PKCE verifier omitted ---------------------------------------------
+
+  test("token exchange without code_verifier fails when challenge was stored", async () => {
+    const clientPKCE = generatePKCE();
+    const clientId = await registerClient(mcpBaseUrl, clientRedirectUri);
+    const gitlabUrl = await authorize(
+      mcpBaseUrl, clientId, clientRedirectUri, clientPKCE.challenge, "state-no-verifier"
+    );
+    const proxyState = gitlabUrl.searchParams.get("state")!;
+
+    const cb = await simulateGitLabCallback(mcpBaseUrl, "code-no-verifier", proxyState);
+    const proxyCode = new URL(cb.location!).searchParams.get("code")!;
+
+    // Exchange WITHOUT verifier — should fail
+    const res = await fetch(`${mcpBaseUrl}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: clientId,
+        code: proxyCode,
+        redirect_uri: clientRedirectUri,
+      }).toString(),
+    });
+    assert.notStrictEqual(res.status, 200);
+  });
+
+  // ---- Replayed state parameter ------------------------------------------
+
+  test("state cannot be replayed after callback", async () => {
+    const clientPKCE = generatePKCE();
+    const clientId = await registerClient(mcpBaseUrl, clientRedirectUri);
+    const gitlabUrl = await authorize(
+      mcpBaseUrl, clientId, clientRedirectUri, clientPKCE.challenge, "state-replay"
+    );
+    const proxyState = gitlabUrl.searchParams.get("state")!;
+
+    // First callback succeeds
+    const first = await simulateGitLabCallback(mcpBaseUrl, "code-replay-1", proxyState);
+    assert.strictEqual(first.status, 302);
+
+    // Second callback with same state fails
+    const second = await simulateGitLabCallback(mcpBaseUrl, "code-replay-2", proxyState);
+    assert.strictEqual(second.status, 400);
+  });
+
+  // ---- Dual PKCE verification --------------------------------------------
+
+  test("proxy uses its own PKCE pair with GitLab", async () => {
+    const clientPKCE = generatePKCE();
+    const clientId = await registerClient(mcpBaseUrl, clientRedirectUri);
+    const gitlabUrl = await authorize(
+      mcpBaseUrl, clientId, clientRedirectUri, clientPKCE.challenge, "state-dual-pkce"
+    );
+
+    // The code_challenge sent to GitLab should NOT be the client's challenge
+    const gitlabChallenge = gitlabUrl.searchParams.get("code_challenge");
+    assert.ok(gitlabChallenge);
+    assert.notStrictEqual(gitlabChallenge, clientPKCE.challenge);
+
+    // Complete the flow to verify the proxy verifier was sent to GitLab
+    const proxyState = gitlabUrl.searchParams.get("state")!;
+    await simulateGitLabCallback(mcpBaseUrl, "code-dual-pkce", proxyState);
+
+    // The token request to GitLab should have a code_verifier that matches
+    // the proxy challenge (not the client's verifier)
+    assert.ok(lastTokenRequest.code_verifier);
+    assert.notStrictEqual(lastTokenRequest.code_verifier, clientPKCE.verifier);
+    const computedChallenge = createHash("sha256")
+      .update(lastTokenRequest.code_verifier)
+      .digest("base64url");
+    assert.strictEqual(computedChallenge, gitlabChallenge);
+  });
+});


### PR DESCRIPTION
## Problem

When `GITLAB_MCP_OAUTH=true`, the MCP server passes the client's callback URL straight through to GitLab. Every MCP client's callback URL must be pre-registered in the GitLab OAuth Application settings, requiring GitLab admin involvement for each new client.

## Solution

New opt-in mode: `GITLAB_OAUTH_CALLBACK_PROXY=true`. The MCP server intercepts the OAuth callback from GitLab, exchanges the code for tokens server-side, and redirects to the client with a proxy code. Only one fixed callback URL (`${MCP_SERVER_URL}/callback`) needs to be registered in GitLab.

Disabled by default — existing passthrough behavior is unchanged.

## How it works

1. Client calls `/authorize` → server stores client params, generates its own PKCE pair, redirects to GitLab with the fixed callback URL
2. User authorizes on GitLab → GitLab redirects to the MCP server's `/callback`
3. Server exchanges the code with GitLab, stores tokens, generates a proxy code, redirects to the client
4. Client calls `/token` with the proxy code → server verifies client PKCE, returns stored tokens

See `docs/oauth-callback-proxy.md` for sequence diagrams and full documentation.

## Security

- Dual PKCE: separate pairs for client↔server and server↔GitLab
- Client PKCE verification: `code_verifier` mandatory when `code_challenge` was stored
- One-time-use proxy codes with 10-min TTL
- State replay protection
- Sanitized error responses
- Bounded in-memory LRU storage (max 1000 entries)

## Changes

- `oauth-proxy.ts`: callback proxy logic, `BoundedLRUMap<V>` replaces `BoundedClientCache`
- `config.ts`: new `GITLAB_OAUTH_CALLBACK_PROXY` env var
- `index.ts`: mounts path-aware `/callback` route
- `docs/oauth-callback-proxy.md`: documentation with Mermaid sequence diagrams
- `test/callback-proxy-tests.ts`: 7 tests (happy path, one-time-use, PKCE, state replay, dual PKCE)

## Testing

- All 7 new tests pass
- Tested end-to-end with `mcp-remote` and a Streamable HTTP client against a live GitLab instance
- Existing tests unaffected