### PR TITLE
fix: defensive guards for project_id coercion, labels query, and null MR response

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1281,6 +1281,22 @@ async function handleGitLabError(response: import("node-fetch").Response): Promi
  * @throws {Error} If GITLAB_ALLOWED_PROJECT_IDS is set and the requested project is not in the whitelist
  */
 function getEffectiveProjectId(projectId: string): string {
+  // Guard against z.coerce.string() converting undefined/null to literal strings
+  if (!projectId || projectId === "undefined" || projectId === "null") {
+    if (GITLAB_ALLOWED_PROJECT_IDS.length === 1) {
+      return GITLAB_ALLOWED_PROJECT_IDS[0];
+    }
+    if (GITLAB_ALLOWED_PROJECT_IDS.length > 1) {
+      throw new Error(
+        `Multiple projects allowed (${GITLAB_ALLOWED_PROJECT_IDS.join(", ")}). Please specify a project ID.`
+      );
+    }
+    if (GITLAB_PROJECT_ID) {
+      return GITLAB_PROJECT_ID;
+    }
+    throw new Error("No project ID provided and GITLAB_PROJECT_ID is not set");
+  }
+
   if (GITLAB_ALLOWED_PROJECT_IDS.length > 0) {
     // If there's only one allowed project, use it as default
     if (GITLAB_ALLOWED_PROJECT_IDS.length === 1 && !projectId) {
@@ -1509,16 +1525,10 @@ async function listIssues(
   // Add all query parameters
   Object.entries(options).forEach(([key, value]) => {
     if (value !== undefined) {
-      const keys = ["labels", "assignee_username"];
-      if (keys.includes(key)) {
-        if (Array.isArray(value)) {
-          // Handle array of labels
-          value.forEach(label => {
-            url.searchParams.append(`${key}[]`, label.toString());
-          });
-        } else if (value) {
-          url.searchParams.append(`${key}[]`, value.toString());
-        }
+      if (key === "labels" && Array.isArray(value)) {
+        url.searchParams.append(key, value.join(","));
+      } else if (key === "assignee_username" && Array.isArray(value)) {
+        value.forEach(v => url.searchParams.append(`${key}[]`, v.toString()));
       } else {
         url.searchParams.append(key, String(value));
       }
@@ -9390,7 +9400,7 @@ async function handleToolCall(params: any) {
 
         const mergeRequests = await listMergeRequests(project_id, cleanedOptions);
         return {
-          content: [{ type: "text", text: JSON.stringify(mergeRequests, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(mergeRequests ?? [], null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Summary

Three defensive fixes for edge cases encountered in production:

### 1. Guard `getEffectiveProjectId` against coerced string literals

`z.coerce.string()` converts `undefined`/`null` to the literal strings `"undefined"`/`"null"`, which bypass the existing `!projectId` falsy check. This causes the function to treat them as real project IDs, leading to 404 errors from the GitLab API.

**Fix:** Early return when projectId is falsy or equals `"undefined"`/`"null"`, falling back to allowed project IDs or `GITLAB_PROJECT_ID`.

### 2. Fix labels query parameter format in `listIssues`

The GitLab API expects labels as a comma-separated string (`labels=bug,feature`), not array notation (`labels[]=bug&labels[]=feature`). The array format causes the API to ignore the filter silently.

Ref: https://docs.gitlab.com/api/issues.html#list-issues

**Fix:** Use `value.join(",")` for labels while keeping `[]` notation for `assignee_username` which does expect array format.

### 3. Null coalescing for `listMergeRequests` response

When `listMergeRequests` returns `null` (e.g., empty project or API edge case), `JSON.stringify(null)` produces the string `"null"` instead of a valid array.

**Fix:** `mergeRequests ?? []` ensures a valid JSON array is always returned.

## Testing

- TypeScript compilation passes (`tsc --noEmit`)
- Tested against self-hosted GitLab 17.x with multiple project configurations