### PR TITLE
fix: bind callback proxy codes to clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,14 @@ exchanging credentials with GitLab on behalf of the client.
 | `GITLAB_OAUTH_APP_ID` | ✅       | GitLab OAuth Application ID                                |
 | `MCP_SERVER_URL`      | ✅       | Public HTTPS URL of this MCP server                        |
 | `STREAMABLE_HTTP`     | ✅       | Must be `true`                                             |
+| `GITLAB_OAUTH_CALLBACK_PROXY` | optional | Set to `true` to use the MCP server's fixed `/callback` URL |
 | `GITLAB_OAUTH_SCOPES` | optional | Comma-separated scopes (default: `api,read_api,read_user`) |
 
 ```shell
 docker run -i --rm \
   -e HOST=0.0.0.0 \
   -e GITLAB_MCP_OAUTH=true \
+  -e GITLAB_OAUTH_CALLBACK_PROXY=true \
   -e STREAMABLE_HTTP=true \
   -e MCP_SERVER_URL=https://your-server.example.com \
   -e GITLAB_API_URL="https://gitlab.com/api/v4" \
@@ -249,6 +251,7 @@ Commonly referenced variables:
 - `GITLAB_USE_OAUTH`
 - `REMOTE_AUTHORIZATION`
 - `GITLAB_MCP_OAUTH`
+- `GITLAB_OAUTH_CALLBACK_PROXY`
 
 The reference document also covers:
 
@@ -258,6 +261,8 @@ The reference document also covers:
 - dynamic tool discovery via `discover_tools` (on-demand toolset activation)
 - transport and session variables
 - proxy and TLS variables
+
+For callback proxy mode details, see [GitLab MCP OAuth Callback Proxy](./docs/oauth-callback-proxy.md).
 
 ### Remote Authorization Setup (Multi-User Support)
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -72,6 +72,14 @@ Default:
 
 Enables the server-side MCP OAuth proxy mode for remote MCP clients.
 
+### `GITLAB_OAUTH_CALLBACK_PROXY`
+
+Set to `true` to make the MCP server handle GitLab's OAuth callback at
+`{MCP_SERVER_URL}/callback`, then redirect the client with a proxy authorization
+code. This keeps the GitLab OAuth Application redirect URI fixed to one MCP
+server callback URL instead of requiring each MCP client's callback URL to be
+registered in GitLab.
+
 ### `MCP_SERVER_URL`
 
 Public HTTPS MCP server base URL required for MCP OAuth mode.
@@ -256,6 +264,7 @@ Maximum GitLab client pool size.
 ## Related Guides
 
 - [OAuth2 Authentication Setup Guide](./oauth-setup.md)
+- [GitLab MCP OAuth Callback Proxy](./oauth-callback-proxy.md)
 - [Claude Code Setup Guide](./claude-code-setup.md)
 - [VS Code Setup Guide](./vscode-setup.md)
 - [GitHub Copilot Setup Guide](./copilot-setup.md)

--- a/oauth-proxy.ts
+++ b/oauth-proxy.ts
@@ -95,6 +95,7 @@ const CLIENT_CACHE_MAX_SIZE = 1000;
 
 /** Stored while user is on GitLab consent screen. Keyed by `state`. */
 interface PendingAuthTransaction {
+  clientId: string;
   clientRedirectUri: string;
   clientState: string | undefined;
   clientCodeChallenge: string;
@@ -105,8 +106,9 @@ interface PendingAuthTransaction {
 /** Stored after /callback exchanges the code. Keyed by proxy auth code. */
 interface StoredTokenEntry {
   tokens: OAuthTokens;
+  clientId: string;
   clientCodeChallenge: string; // for PKCE verification when client calls /token
-  redirectUri: string; // the fixed callback URI used with GitLab
+  clientRedirectUri: string;
   createdAt: number;
 }
 
@@ -251,7 +253,7 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
   // ---- Authorize ---------------------------------------------------------
 
   async authorize(
-    _client: OAuthClientInformationFull,
+    client: OAuthClientInformationFull,
     params: AuthorizationParams,
     res: Response
   ): Promise<void> {
@@ -277,6 +279,7 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
 
       // Store the client's original params so /callback can redirect back
       this._pendingAuth.set(proxyState, {
+        clientId: client.client_id,
         clientRedirectUri: params.redirectUri,
         clientState: params.state,
         clientCodeChallenge: params.codeChallenge,
@@ -337,7 +340,7 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
   // ---- Token exchange ----------------------------------------------------
 
   async exchangeAuthorizationCode(
-    _client: OAuthClientInformationFull,
+    client: OAuthClientInformationFull,
     authorizationCode: string,
     codeVerifier?: string,
     redirectUri?: string,
@@ -361,6 +364,15 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
 
       // One-time use: delete after validation
       this._storedTokens.delete(authorizationCode);
+
+      // Bind the proxy code to the client and redirect_uri that initiated
+      // /authorize, preserving the normal OAuth authorization-code invariant.
+      if (client.client_id !== entry.clientId) {
+        throw new ServerError("Invalid client for authorization code");
+      }
+      if (redirectUri !== entry.clientRedirectUri) {
+        throw new ServerError("Invalid redirect_uri for authorization code");
+      }
 
       // Verify client PKCE: the client's code_verifier must match the
       // code_challenge stored during /authorize.
@@ -533,8 +545,9 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
       const proxyCode = randomUUID();
       this._storedTokens.set(proxyCode, {
         tokens,
+        clientId: pending.clientId,
         clientCodeChallenge: pending.clientCodeChallenge,
-        redirectUri: this._callbackUrl,
+        clientRedirectUri: pending.clientRedirectUri,
         createdAt: Date.now(),
       });
 

--- a/test/callback-proxy-tests.ts
+++ b/test/callback-proxy-tests.ts
@@ -307,6 +307,50 @@ describe("Callback Proxy Mode", () => {
     assert.notStrictEqual(second.status, 200);
   });
 
+  // ---- Client binding -----------------------------------------------------
+
+  test("proxy code cannot be redeemed by a different client_id", async () => {
+    const clientPKCE = generatePKCE();
+    const clientId = await registerClient(mcpBaseUrl, clientRedirectUri);
+    const otherClientId = await registerClient(
+      mcpBaseUrl,
+      "http://localhost:19998/oauth/callback"
+    );
+    const gitlabUrl = await authorize(
+      mcpBaseUrl, clientId, clientRedirectUri, clientPKCE.challenge, "state-client-binding"
+    );
+    const proxyState = gitlabUrl.searchParams.get("state")!;
+
+    const cb = await simulateGitLabCallback(mcpBaseUrl, "code-client-binding", proxyState);
+    const proxyCode = new URL(cb.location!).searchParams.get("code")!;
+
+    const result = await exchangeToken(
+      mcpBaseUrl, otherClientId, proxyCode, clientPKCE.verifier, clientRedirectUri
+    );
+    assert.notStrictEqual(result.status, 200);
+  });
+
+  test("proxy code cannot be redeemed with a different redirect_uri", async () => {
+    const clientPKCE = generatePKCE();
+    const clientId = await registerClient(mcpBaseUrl, clientRedirectUri);
+    const gitlabUrl = await authorize(
+      mcpBaseUrl, clientId, clientRedirectUri, clientPKCE.challenge, "state-redirect-binding"
+    );
+    const proxyState = gitlabUrl.searchParams.get("state")!;
+
+    const cb = await simulateGitLabCallback(mcpBaseUrl, "code-redirect-binding", proxyState);
+    const proxyCode = new URL(cb.location!).searchParams.get("code")!;
+
+    const result = await exchangeToken(
+      mcpBaseUrl,
+      clientId,
+      proxyCode,
+      clientPKCE.verifier,
+      "http://localhost:19998/oauth/callback"
+    );
+    assert.notStrictEqual(result.status, 200);
+  });
+
   // ---- Unknown state parameter -------------------------------------------
 
   test("callback with unknown state returns 400", async () => {


### PR DESCRIPTION
## Why
- Harden callback proxy mode by binding proxy authorization codes to the client and redirect URI that initiated authorization.
- Document the newly added GITLAB_OAUTH_CALLBACK_PROXY setting in the README and env reference.

## How
- Store client_id and client redirect_uri with pending and stored proxy-code entries.
- Reject token exchanges when the redeeming client_id or redirect_uri does not match.
- Add negative tests for wrong client_id and wrong redirect_uri redemption.

## Tests
- npm ci with npm_config_cache=/tmp/npm-cache-gitlab-mcp
- node --import tsx/esm --test test/callback-proxy-tests.ts