### PR TITLE
chore(release): sync MCP registry metadata for v2.1.4

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/zereight/gitlab-mcp",
     "source": "github"
   },
-  "version": "2.1.3",
+  "version": "2.1.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@zereight/mcp-gitlab",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why
- v2.1.4 npm and Docker publish succeeded, but MCP Registry Publish failed because server.json still referenced 2.1.3.

## How
- Update server.json version and package version to 2.1.4.

## Tests
- npm run release:mcp-registry -- --check