### PR TITLE
docs: explain custom agents and multiple PAT setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Quick start: choose either Personal Access Token or OAuth2 setup below and use `
 - [OAuth2 Authentication Setup Guide](./docs/oauth-setup.md)
 - [Environment Variables Reference](./docs/environment-variables.md)
 - [Stateless Mode — Multi-Pod HPA](./docs/stateless-mode.md)
+- [Custom Agents and Multiple PAT Setup](./docs/custom-agent-multiple-pat.md)
 
 ## Usage
 

--- a/docs/custom-agent-multiple-pat.md
+++ b/docs/custom-agent-multiple-pat.md
@@ -1,0 +1,143 @@
+# Custom Agents and Multiple PAT Setup
+
+This guide explains how to run `gitlab-mcp` for custom agents, single-user PAT
+setups, multi-user deployments, and restricted tool surfaces.
+
+## Local Single-PAT Setup
+
+Use this when one local MCP client should access GitLab with one Personal Access
+Token.
+
+```bash
+GITLAB_PERSONAL_ACCESS_TOKEN=glpat-... \
+GITLAB_API_URL=https://gitlab.com/api/v4 \
+npx -y @zereight/mcp-gitlab
+```
+
+In this mode:
+
+- The server process uses `GITLAB_PERSONAL_ACCESS_TOKEN`.
+- The token is shared by every request handled by that local process.
+- This is the simplest setup for stdio clients and local development.
+
+## Multi-User or Multiple-PAT Setup
+
+Use remote authorization when different users or agent sessions need different
+GitLab tokens.
+
+```bash
+STREAMABLE_HTTP=true \
+REMOTE_AUTHORIZATION=true \
+GITLAB_API_URL=https://gitlab.com/api/v4 \
+node build/index.js
+```
+
+Clients send their GitLab token on each HTTP session:
+
+```http
+Authorization: Bearer glpat-user-token
+```
+
+or:
+
+```http
+Private-Token: glpat-user-token
+```
+
+In this mode:
+
+- Each session stores its own token.
+- Tokens from one session are not reused for another session.
+- `SESSION_TIMEOUT_SECONDS` controls inactivity expiration.
+- After a session expires, the client must send auth headers again.
+
+Do not put user PATs into a shared server config. The shared server should only
+enable remote authorization and let each client provide its own token.
+
+## Multiple GitLab Instances
+
+Enable dynamic API URL support when one server must connect to different GitLab
+instances.
+
+```bash
+STREAMABLE_HTTP=true \
+REMOTE_AUTHORIZATION=true \
+ENABLE_DYNAMIC_API_URL=true \
+node build/index.js
+```
+
+Clients include the target instance:
+
+```http
+X-GitLab-API-URL: https://gitlab.example.com/api/v4
+```
+
+The server accepts either a full API URL or a GitLab base URL and normalizes it
+to `/api/v4`.
+
+## Tool Customization
+
+Custom agents can expose only the tools they need.
+
+```bash
+GITLAB_TOOLSETS=issues,merge_requests,projects \
+GITLAB_TOOLS=get_file_contents \
+GITLAB_DENIED_TOOLS_REGEX="^(delete_|merge_)" \
+node build/index.js
+```
+
+Available controls:
+
+- `GITLAB_TOOLSETS`: expose named tool groups, such as `issues`,
+  `merge_requests`, `projects`, or `pipelines`.
+- `GITLAB_TOOLS`: add individual tool names on top of enabled toolsets.
+- `GITLAB_DENIED_TOOLS_REGEX`: hide tools whose names match a regular
+  expression.
+- `GITLAB_TOOL_POLICY_APPROVE`: expose tools but require `_confirmed: true`
+  before execution.
+- `GITLAB_TOOL_POLICY_HIDDEN`: hide specific tools from `tools/list`.
+
+## Example Configurations
+
+### Local Single PAT
+
+```bash
+GITLAB_PERSONAL_ACCESS_TOKEN=glpat-local-user \
+GITLAB_API_URL=https://gitlab.com/api/v4 \
+npx -y @zereight/mcp-gitlab
+```
+
+### Hosted Multi-User HTTP Server
+
+```bash
+STREAMABLE_HTTP=true \
+REMOTE_AUTHORIZATION=true \
+SESSION_TIMEOUT_SECONDS=3600 \
+GITLAB_API_URL=https://gitlab.com/api/v4 \
+node build/index.js
+```
+
+Each client sends `Authorization: Bearer <PAT>` or `Private-Token: <PAT>`.
+
+### Restricted Agent
+
+```bash
+STREAMABLE_HTTP=true \
+REMOTE_AUTHORIZATION=true \
+GITLAB_TOOLSETS=issues,merge_requests,projects \
+GITLAB_DENIED_TOOLS_REGEX="^(delete_|merge_)" \
+GITLAB_TOOL_POLICY_APPROVE="create_issue,update_issue,create_merge_request" \
+node build/index.js
+```
+
+This exposes issue, merge request, and project tools while hiding destructive
+delete and merge operations. Selected write tools remain visible but require
+explicit confirmation.
+
+## Security Notes
+
+- Use HTTPS for remote deployments.
+- Do not hard-code user PATs into shared agent configs.
+- Prefer read-only PAT scopes for read-only agents.
+- Isolate deployment secrets from per-user GitLab tokens.
+- Keep `SESSION_TIMEOUT_SECONDS` short enough for your deployment risk profile.

--- a/docs/custom-agent-multiple-pat.md
+++ b/docs/custom-agent-multiple-pat.md
@@ -29,7 +29,7 @@ GitLab tokens.
 STREAMABLE_HTTP=true \
 REMOTE_AUTHORIZATION=true \
 GITLAB_API_URL=https://gitlab.com/api/v4 \
-node build/index.js
+npx -y @zereight/mcp-gitlab
 ```
 
 Clients send their GitLab token on each HTTP session:
@@ -63,7 +63,7 @@ instances.
 STREAMABLE_HTTP=true \
 REMOTE_AUTHORIZATION=true \
 ENABLE_DYNAMIC_API_URL=true \
-node build/index.js
+npx -y @zereight/mcp-gitlab
 ```
 
 Clients include the target instance:
@@ -72,8 +72,8 @@ Clients include the target instance:
 X-GitLab-API-URL: https://gitlab.example.com/api/v4
 ```
 
-The server accepts either a full API URL or a GitLab base URL and normalizes it
-to `/api/v4`.
+`/api/v4` URLs are recommended. The server also accepts a GitLab base URL and
+normalizes it by appending `/api/v4`.
 
 ## Tool Customization
 
@@ -83,7 +83,7 @@ Custom agents can expose only the tools they need.
 GITLAB_TOOLSETS=issues,merge_requests,projects \
 GITLAB_TOOLS=get_file_contents \
 GITLAB_DENIED_TOOLS_REGEX="^(delete_|merge_)" \
-node build/index.js
+npx -y @zereight/mcp-gitlab
 ```
 
 Available controls:
@@ -114,7 +114,7 @@ STREAMABLE_HTTP=true \
 REMOTE_AUTHORIZATION=true \
 SESSION_TIMEOUT_SECONDS=3600 \
 GITLAB_API_URL=https://gitlab.com/api/v4 \
-node build/index.js
+npx -y @zereight/mcp-gitlab
 ```
 
 Each client sends `Authorization: Bearer <PAT>` or `Private-Token: <PAT>`.
@@ -127,7 +127,7 @@ REMOTE_AUTHORIZATION=true \
 GITLAB_TOOLSETS=issues,merge_requests,projects \
 GITLAB_DENIED_TOOLS_REGEX="^(delete_|merge_)" \
 GITLAB_TOOL_POLICY_APPROVE="create_issue,update_issue,create_merge_request" \
-node build/index.js
+npx -y @zereight/mcp-gitlab
 ```
 
 This exposes issue, merge request, and project tools while hiding destructive

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -63,6 +63,8 @@ Optional custom path for the stored OAuth token file.
 
 Set to `true` to require GitLab auth headers per HTTP session.
 
+See also: [Custom Agents and Multiple PAT Setup](./custom-agent-multiple-pat.md).
+
 Notes:
 
 - Requires `STREAMABLE_HTTP=true`
@@ -222,6 +224,9 @@ Set to `true` to expose only read-only tools.
 
 Comma-separated list of toolset IDs to enable.
 
+For agent-specific tool surfaces, see
+[Custom Agents and Multiple PAT Setup](./custom-agent-multiple-pat.md).
+
 Special value:
 
 - `all`
@@ -229,6 +234,10 @@ Special value:
 ### `GITLAB_TOOLS`
 
 Comma-separated list of individual tool names to add on top of enabled toolsets.
+
+For restricted custom agents, combine this with `GITLAB_TOOLSETS`,
+`GITLAB_DENIED_TOOLS_REGEX`, and the tool policy variables documented in
+[Custom Agents and Multiple PAT Setup](./custom-agent-multiple-pat.md).
 
 ### `GITLAB_DENIED_TOOLS_REGEX`
 


### PR DESCRIPTION
Closes #445

Documents how to use gitlab-mcp for:

- local single-PAT setup
- multi-user / multiple PAT deployments with remote authorization
- multiple GitLab instances with dynamic API URL headers
- tool customization for agent-specific tool surfaces

No runtime behavior changes.