### PR TITLE
fix(oauth-callback-proxy): serve at static route

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10837,11 +10837,10 @@ async function startStreamableHTTPServer(): Promise<void> {
 
     // Mount /callback route for callback proxy mode
     if (GITLAB_OAUTH_CALLBACK_PROXY) {
-      const callbackPath = `${issuerUrl.pathname.replace(/\/$/, "")}/callback`;
-      app.get(callbackPath, (req: Request, res: Response, next: NextFunction) => {
+      app.get("/callback", (req: Request, res: Response, next: NextFunction) => {
         oauthProvider.handleCallback(req, res).catch(next);
       });
-      logger.info(`Callback proxy mode enabled — ${callbackPath} route mounted`);
+      logger.info(`Callback proxy mode enabled — /callback route mounted`);
     }
   }
 


### PR DESCRIPTION
All the other routes like /mcp, /register, ... are served statically at root, making the only path it can be deployed on the root or with a proxy that strips the path in front (which we have). /callback for some reason is served at a dynamic route, which breaks with a proxy stripping the path. Either all paths should be dynamic or more easily all paths should be static
