### PR TITLE
ci: verify mcp-publisher release asset

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.2
+        with:
+          cosign-release: v3.0.6
 
       - name: Install mcp-publisher
         env:

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -32,9 +32,33 @@ jobs:
           node-version: "22.21.1"
           registry-url: "https://registry.npmjs.org/"
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
       - name: Install mcp-publisher
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MCP_PUBLISHER_VERSION: v1.7.8
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          asset="mcp-publisher_${os}_${arch}.tar.gz"
+          checksums="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
+
+          gh release download "$MCP_PUBLISHER_VERSION" \
+            --repo modelcontextprotocol/registry \
+            --pattern "$asset" \
+            --pattern "$checksums" \
+            --pattern "$checksums.sigstore.json" \
+            --dir .
+
+          cosign verify-blob "$checksums" \
+            --bundle "$checksums.sigstore.json" \
+            --certificate-identity "https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/${MCP_PUBLISHER_VERSION}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+          grep "  ${asset}$" "$checksums" | sha256sum -c -
+          tar xzf "$asset" mcp-publisher
           chmod +x mcp-publisher
           echo "$PWD" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
## Summary
- pin the mcp-publisher release used by the MCP registry publish workflow
- verify the upstream sigstore bundle for the checksums file before trusting it
- verify the downloaded mcp-publisher archive against the signed checksum entry before extraction

Closes #456

## Verification
- ruby YAML parse for .github/workflows/mcp-registry-publish.yml
- smoke-tested release asset download, checksum verification, extraction, and mcp-publisher --help locally