### PR TITLE
fix: add pagination to list_labels

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -2034,17 +2034,17 @@ export const ListProjectsSchema = z
   .merge(PaginationOptionsSchema);
 
 // Label operation schemas
-export const ListLabelsSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
-  with_counts: z
-    .coerce.boolean()
-    .optional()
-    .describe("Whether or not to include issue and merge request counts"),
-  include_ancestor_groups: z.coerce.boolean().optional().describe("Include ancestor groups"),
-  search: z.string().optional().describe("Keyword to filter labels by"),
-  page: z.coerce.number().optional().describe("Page number for pagination"),
-  per_page: z.coerce.number().optional().describe("Number of labels per page"),
-});
+export const ListLabelsSchema = z
+  .object({
+    project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+    with_counts: z
+      .coerce.boolean()
+      .optional()
+      .describe("Whether or not to include issue and merge request counts"),
+    include_ancestor_groups: z.coerce.boolean().optional().describe("Include ancestor groups"),
+    search: z.string().optional().describe("Keyword to filter labels by"),
+  })
+  .merge(PaginationOptionsSchema);
 
 export const GetLabelSchema = z.object({
   project_id: z.coerce.string().describe("Project ID or URL-encoded path"),

--- a/schemas.ts
+++ b/schemas.ts
@@ -2042,6 +2042,8 @@ export const ListLabelsSchema = z.object({
     .describe("Whether or not to include issue and merge request counts"),
   include_ancestor_groups: z.coerce.boolean().optional().describe("Include ancestor groups"),
   search: z.string().optional().describe("Keyword to filter labels by"),
+  page: z.coerce.number().optional().describe("Page number for pagination"),
+  per_page: z.coerce.number().optional().describe("Number of labels per page"),
 });
 
 export const GetLabelSchema = z.object({

--- a/test/dynamic-routing-tests.ts
+++ b/test/dynamic-routing-tests.ts
@@ -466,7 +466,7 @@ async function validateToolCalls(client: CustomHeaderClient, mockServer: MockGit
     { name: 'get_merge_request', params: { project_id: '1', merge_request_iid: '1' } },
     { name: 'list_merge_requests', params: { project_id: '1' } },
     { name: 'get_repository_tree', params: { project_id: '1' } },
-    { name: 'list_labels', params: { project_id: '1' } },
+    { name: 'list_labels', params: { project_id: '1', page: 2, per_page: 50 } },
     { name: 'list_pipelines', params: { project_id: '1' } },
     { name: 'list_commits', params: { project_id: '1' } },
   ];
@@ -519,6 +519,10 @@ async function validateToolCalls(client: CustomHeaderClient, mockServer: MockGit
         assert.strictEqual(req.headers['authorization'], `Bearer ${expectedToken}`);
       } else {
         assert.strictEqual(req.headers['private-token'], expectedToken);
+      }
+      if (tool.name === 'list_labels') {
+        assert.strictEqual(req.query.page, '2');
+        assert.strictEqual(req.query.per_page, '50');
       }
       res.json(mockResponse);
     });

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -23,6 +23,7 @@ import {
   CreateIssueSchema,
   ListIssuesSchema,
   ListMergeRequestsSchema,
+  ListLabelsSchema,
   GitLabMergeRequestSchema,
   GitLabTreeItemSchema,
   GetMergeRequestSchema,
@@ -1019,6 +1020,56 @@ function runLabelsCoercionSchemaTests(): { passed: number; failed: number } {
   return { passed, failed };
 }
 
+function runListLabelsSchemaTests(): { passed: number; failed: number } {
+  console.log('\n=== List Labels Schema Tests ===');
+
+  const cases = [
+    {
+      name: 'schema:list_labels:pagination-coercion',
+      input: { project_id: 'my/project', page: '2', per_page: '100' },
+      expected: { project_id: 'my/project', page: 2, per_page: 100 },
+    },
+    {
+      name: 'schema:list_labels:filters-with-pagination',
+      input: { project_id: 'my/project', search: 'backend', with_counts: 'true', page: 3, per_page: 50 },
+      expected: { project_id: 'my/project', search: 'backend', with_counts: true, page: 3, per_page: 50 },
+    },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  cases.forEach(testCase => {
+    const result: TestResult = { name: testCase.name, status: 'failed' };
+    const parsed = ListLabelsSchema.safeParse(testCase.input);
+
+    if (!parsed.success) {
+      result.error = parsed.error?.message || 'Schema validation failed';
+    } else {
+      const matches = Object.entries(testCase.expected).every(([key, value]) => {
+        const actual = (parsed.data as Record<string, unknown>)[key];
+        return actual === value;
+      });
+      if (matches) {
+        result.status = 'passed';
+      } else {
+        result.error = `Unexpected parsed result: ${JSON.stringify(parsed.data)}`;
+      }
+    }
+
+    if (result.status === 'passed') {
+      passed++;
+      console.log(`✅ ${result.name}`);
+    } else {
+      failed++;
+      console.log(`❌ ${result.name}: ${result.error}`);
+    }
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed`);
+  return { passed, failed };
+}
+
 function runGitLabTreeItemSchemaTests(): { passed: number; failed: number } {
   console.log('\n=== GitLabTreeItem Schema Tests ===');
 
@@ -1156,11 +1207,12 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const emojiReactionResult = runEmojiReactionSchemaTests();
   const repositorySchemaResult = runGitLabRepositorySchemaTests();
   const labelsCoercionResult = runLabelsCoercionSchemaTests();
+  const listLabelsResult = runListLabelsSchemaTests();
   const treeItemResult = runGitLabTreeItemSchemaTests();
   const repositoryTreeResult = runGetRepositoryTreeSchemaTests();
 
-  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + commitStatusResult.passed + createIssueNoteResult.passed + getMergeRequestResult.passed + gitLabMergeRequestResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + treeItemResult.passed + repositoryTreeResult.passed;
-  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + commitStatusResult.failed + createIssueNoteResult.failed + getMergeRequestResult.failed + gitLabMergeRequestResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + treeItemResult.failed + repositoryTreeResult.failed;
+  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + commitStatusResult.passed + createIssueNoteResult.passed + getMergeRequestResult.passed + gitLabMergeRequestResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + listLabelsResult.passed + treeItemResult.passed + repositoryTreeResult.passed;
+  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + commitStatusResult.failed + createIssueNoteResult.failed + getMergeRequestResult.failed + gitLabMergeRequestResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + listLabelsResult.failed + treeItemResult.failed + repositoryTreeResult.failed;
 
   console.log(`\nTotal Results: ${totalPassed} passed, ${totalFailed} failed`);
 


### PR DESCRIPTION
## Summary
- add page and per_page to ListLabelsSchema
- keep list_labels forwarding parsed pagination options to the GitLab labels API
- add schema coverage and dynamic routing assertions for list_labels pagination

Closes #450

## Verification
- npm run build
- npm run test:schema
- targeted dynamic routing scenario with list_labels query assertions

Note: full dynamic-routing-tests still has an unrelated local Scenario 1 startup failure in this environment.