### PR TITLE
feat: add get_user and whoami tools

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -160,6 +160,10 @@ import {
   type GetRepositoryTreeOptions,
   GetRepositoryTreeSchema,
   GetUsersSchema,
+  GetUserSchema,
+  GitLabUserFullSchema,
+  WhoAmISchema,
+  GitLabCurrentUserSchema,
   GetWikiPageSchema,
   type GitLabCommit,
   GitLabCommitSchema,
@@ -9130,6 +9134,42 @@ async function handleToolCall(params: any) {
 
         return {
           content: [{ type: "text", text: JSON.stringify(usersMap, null, 2) }],
+        };
+      }
+
+      case "get_user": {
+        const args = GetUserSchema.parse(params.arguments);
+        const url = new URL(
+          `${getEffectiveApiUrl()}/users/${encodeURIComponent(args.user_id)}`
+        );
+
+        const response = await fetch(url.toString(), {
+          ...getFetchConfig(),
+        });
+
+        await handleGitLabError(response);
+        const data = await response.json();
+        const user = GitLabUserFullSchema.parse(data);
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(user, null, 2) }],
+        };
+      }
+
+      case "whoami": {
+        WhoAmISchema.parse(params.arguments ?? {});
+        const url = new URL(`${getEffectiveApiUrl()}/user`);
+
+        const response = await fetch(url.toString(), {
+          ...getFetchConfig(),
+        });
+
+        await handleGitLabError(response);
+        const data = await response.json();
+        const user = GitLabCurrentUserSchema.parse(data);
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(user, null, 2) }],
         };
       }
 

--- a/schemas.ts
+++ b/schemas.ts
@@ -562,6 +562,80 @@ export const GitLabUsersResponseSchema = z.record(
     .nullable()
 );
 
+export const GetUserSchema = z.object({
+  user_id: z.coerce.string().describe("The ID of the user"),
+});
+
+export const GitLabUserFullSchema = z.object({
+  id: z.coerce.string(),
+  username: z.string(),
+  name: z.string(),
+  state: z.string(),
+  avatar_url: z.string().nullable(),
+  web_url: z.string(),
+  created_at: z.string(),
+  bio: z.string().nullable(),
+  location: z.string().nullable(),
+  public_email: z.string().nullable(),
+  website_url: z.string().nullable(),
+  organization: z.string().nullable(),
+  job_title: z.string().nullable(),
+  pronouns: z.string().nullable(),
+  bot: z.boolean().optional(),
+  work_information: z.string().nullable(),
+  followers: z.number().optional(),
+  following: z.number().optional(),
+  is_followed: z.boolean().optional(),
+  local_time: z.string().nullable().optional(),
+  last_sign_in_at: z.string().nullable().optional(),
+  confirmed_at: z.string().nullable().optional(),
+  last_activity_on: z.string().nullable().optional(),
+  email: z.string().nullable().optional(),
+  theme_id: z.number().nullable().optional(),
+  color_scheme_id: z.number().nullable().optional(),
+  projects_limit: z.number().nullable().optional(),
+  current_sign_in_at: z.string().nullable().optional(),
+  identities: z.array(z.object({
+    provider: z.string(),
+    extern_uid: z.string(),
+  })).optional(),
+  can_create_group: z.boolean().nullable().optional(),
+  can_create_project: z.boolean().nullable().optional(),
+  two_factor_enabled: z.boolean().nullable().optional(),
+  external: z.boolean().nullable().optional(),
+  private_profile: z.boolean().nullable().optional(),
+  is_admin: z.boolean().nullable().optional(),
+}).passthrough();
+
+export const WhoAmISchema = z.object({});
+
+export const GitLabCurrentUserSchema = z.object({
+  id: z.coerce.string(),
+  username: z.string(),
+  name: z.string(),
+  state: z.string(),
+  avatar_url: z.string().nullable(),
+  web_url: z.string(),
+  created_at: z.string(),
+  bio: z.string().nullable(),
+  location: z.string().nullable(),
+  public_email: z.string().nullable(),
+  website_url: z.string().nullable(),
+  organization: z.string().nullable(),
+  job_title: z.string().nullable(),
+  email: z.string().nullable(),
+  last_sign_in_at: z.string().nullable(),
+  confirmed_at: z.string().nullable(),
+  last_activity_on: z.string().nullable(),
+  is_admin: z.boolean().optional(),
+  can_create_group: z.boolean().optional(),
+  can_create_project: z.boolean().optional(),
+  identities: z.array(z.object({
+    provider: z.string(),
+    extern_uid: z.string(),
+  })).optional(),
+}).passthrough();
+
 // Namespace related schemas
 
 // Base schema for project-related operations

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -28,7 +28,8 @@ import {
   GitLabTreeItemSchema,
   GetMergeRequestSchema,
   ListMergeRequestPipelinesSchema,
-  GetRepositoryTreeSchema
+  GetRepositoryTreeSchema,
+  GitLabUserFullSchema
 } from '../schemas.js';
 
 interface TestResult {
@@ -1278,6 +1279,91 @@ function runGetRepositoryTreeSchemaTests(): { passed: number; failed: number } {
   return { passed, failed };
 }
 
+function runGitLabUserFullSchemaTests(): { passed: number; failed: number } {
+  console.log('🧪 Testing GitLabUserFullSchema...');
+
+  const adminResponse = {
+    id: 1,
+    username: 'root',
+    name: 'Administrator',
+    state: 'active',
+    avatar_url: 'https://gitlab.example.com/uploads/-/system/user/avatar/1/avatar.png',
+    web_url: 'https://gitlab.example.com/root',
+    created_at: '2012-09-22T16:50:56.000Z',
+    bio: null,
+    location: null,
+    public_email: '',
+    website_url: '',
+    organization: null,
+    job_title: null,
+    pronouns: null,
+    work_information: null,
+    followers: 0,
+    following: 0,
+    is_followed: false,
+    local_time: null,
+    last_sign_in_at: null,
+    confirmed_at: '2012-09-22T16:50:56.000Z',
+    last_activity_on: '2026-05-12',
+    email: 'admin@example.com',
+    theme_id: 1,
+    color_scheme_id: 1,
+    projects_limit: 100000,
+    current_sign_in_at: '2026-05-12T08:14:22.885Z',
+    identities: [],
+    can_create_group: true,
+    can_create_project: true,
+    two_factor_enabled: false,
+    external: false,
+    private_profile: false,
+    is_admin: true,
+  };
+
+  const cases = [
+    {
+      name: 'schema:user_full:admin-response-no-bot',
+      input: { ...adminResponse },
+      shouldFail: false,
+    },
+    {
+      name: 'schema:user_full:admin-response-with-bot',
+      input: { ...adminResponse, bot: false },
+      shouldFail: false,
+    },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  cases.forEach(testCase => {
+    const result: TestResult = { name: testCase.name, status: 'failed' };
+    const parsed = GitLabUserFullSchema.safeParse(testCase.input);
+
+    if (testCase.shouldFail) {
+      if (parsed.success) {
+        result.error = 'Expected schema validation to fail';
+      } else {
+        result.status = 'passed';
+      }
+    } else if (parsed.success) {
+      result.status = 'passed';
+    } else {
+      result.error = parsed.error?.message || 'Schema validation failed';
+    }
+
+    if (result.status === 'passed') {
+      passed++;
+      console.log(`✅ ${result.name}`);
+    } else {
+      failed++;
+      console.log(`❌ ${result.name}: ${result.error}`);
+    }
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed`);
+  return { passed, failed };
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
   const getFileContentsResult = runGetFileContentsSchemaTests();
   const fileContentResult = runGitLabFileContentSchemaTests();
@@ -1293,9 +1379,10 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const listLabelsResult = runListLabelsSchemaTests();
   const treeItemResult = runGitLabTreeItemSchemaTests();
   const repositoryTreeResult = runGetRepositoryTreeSchemaTests();
+  const gitLabUserFullResult = runGitLabUserFullSchemaTests();
 
-  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + commitStatusResult.passed + createIssueNoteResult.passed + getMergeRequestResult.passed + listMergeRequestPipelinesResult.passed + gitLabMergeRequestResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + listLabelsResult.passed + treeItemResult.passed + repositoryTreeResult.passed;
-  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + commitStatusResult.failed + createIssueNoteResult.failed + getMergeRequestResult.failed + listMergeRequestPipelinesResult.failed + gitLabMergeRequestResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + listLabelsResult.failed + treeItemResult.failed + repositoryTreeResult.failed;
+  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + commitStatusResult.passed + createIssueNoteResult.passed + getMergeRequestResult.passed + listMergeRequestPipelinesResult.passed + gitLabMergeRequestResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + listLabelsResult.passed + treeItemResult.passed + repositoryTreeResult.passed + gitLabUserFullResult.passed;
+  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + commitStatusResult.failed + createIssueNoteResult.failed + getMergeRequestResult.failed + listMergeRequestPipelinesResult.failed + gitLabMergeRequestResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + listLabelsResult.failed + treeItemResult.failed + repositoryTreeResult.failed + gitLabUserFullResult.failed;
 
   console.log(`\nTotal Results: ${totalPassed} passed, ${totalFailed} failed`);
 

--- a/test/test-toolset-filtering.ts
+++ b/test/test-toolset-filtering.ts
@@ -42,7 +42,7 @@ const TOOLSET_TOOL_COUNTS: Record<string, number> = {
   wiki: 10,
   releases: 7,
   tags: 5,
-  users: 5,
+  users: 7,
   search: 3,
   workitems: 18,
   webhooks: 3,

--- a/tools/registry.ts
+++ b/tools/registry.ts
@@ -110,6 +110,8 @@ import {
   GetTagSignatureSchema,
   GetTimelineEventsSchema,
   GetUsersSchema,
+  GetUserSchema,
+  WhoAmISchema,
   GetWebhookEventSchema,
   GetWikiPageSchema,
   GetWorkItemSchema,
@@ -817,6 +819,16 @@ export const allTools = [
     inputSchema: toJSONSchema(GetUsersSchema),
   },
   {
+    name: "get_user",
+    description: "Get user details by ID",
+    inputSchema: toJSONSchema(GetUserSchema),
+  },
+  {
+    name: "whoami",
+    description: "Get current authenticated user details",
+    inputSchema: toJSONSchema(WhoAmISchema),
+  },
+  {
     name: "list_commits",
     description: "List repository commits with filtering options",
     inputSchema: toJSONSchema(ListCommitsSchema),
@@ -1139,6 +1151,8 @@ export const readOnlyTools = new Set([
   "list_group_wiki_pages",
   "get_group_wiki_page",
   "get_users",
+  "get_user",
+  "whoami",
   "list_commits",
   "get_commit",
   "get_commit_diff",
@@ -1493,6 +1507,8 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
     isDefault: true,
     tools: new Set([
       "get_users",
+      "get_user",
+      "whoami",
       "list_events",
       "get_project_events",
       "upload_markdown",


### PR DESCRIPTION
Adds two user-related MCP tools:

- `get_user` - Get user details by ID
- `whoami` - Get current authenticated user details