### PR TITLE
fix(schemas): accept label objects in GitLabMergeRequestSchema response

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -1197,7 +1197,7 @@ export const GitLabMergeRequestSchema = z.object({
     .describe("Whether rebase is currently in progress for this merge request"),
   merge_when_pipeline_succeeds: z.coerce.boolean().optional(),
   squash: z.coerce.boolean().optional(),
-  labels: z.array(z.string()).optional(),
+  labels: z.array(GitLabLabelSchema).or(z.array(z.string())).optional(), // Support both label objects and strings
 });
 
 export const LineRangeSchema = z

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -846,6 +846,56 @@ function runGitLabMergeRequestSchemaTests(): { passed: number; failed: number } 
       },
       validate: (data: Record<string, any>) => data.milestone === undefined,
     },
+    {
+      name: 'schema:gitlab_merge_request:labels-string-array',
+      input: {
+        ...baseMergeRequest,
+        labels: ['bug', 'enhancement'],
+      },
+      validate: (data: Record<string, any>) =>
+        Array.isArray(data.labels) &&
+        data.labels.length === 2 &&
+        data.labels[0] === 'bug' &&
+        data.labels[1] === 'enhancement',
+    },
+    {
+      name: 'schema:gitlab_merge_request:labels-object-array',
+      input: {
+        ...baseMergeRequest,
+        labels: [
+          {
+            id: 1,
+            name: 'bug',
+            color: '#ff0000',
+            text_color: '#ffffff',
+            description: null,
+            description_html: null,
+          },
+          {
+            id: 2,
+            name: 'enhancement',
+            color: '#00ff00',
+            text_color: '#000000',
+            description: 'Improvements',
+            description_html: '<p>Improvements</p>',
+          },
+        ],
+      },
+      validate: (data: Record<string, any>) =>
+        Array.isArray(data.labels) &&
+        data.labels.length === 2 &&
+        data.labels[0].name === 'bug' &&
+        data.labels[0].id === '1' &&
+        data.labels[1].name === 'enhancement' &&
+        data.labels[1].id === '2',
+    },
+    {
+      name: 'schema:gitlab_merge_request:labels-omitted',
+      input: {
+        ...baseMergeRequest,
+      },
+      validate: (data: Record<string, any>) => data.labels === undefined,
+    },
   ];
 
   let passed = 0;


### PR DESCRIPTION
## Summary

- `list_merge_requests` / `get_merge_request` were failing with `0.labels.0: Expected string, received object` when GitLab returned labels as full label objects (with `id`, `name`, `color`, …) instead of plain strings.
- Mirror the pattern already used by `GitLabIssueSchema` (`schemas.ts:1096`) so the MR response schema accepts both shapes.
- Add regression tests in `runGitLabMergeRequestSchemaTests` covering string-array, label-object-array, and omitted labels.

Fixes #485

### Change

```diff
-  labels: z.array(z.string()).optional(),
+  labels: z.array(GitLabLabelSchema).or(z.array(z.string())).optional(), // Support both label objects and strings
```

## Test plan

- [x] `npm run test:schema` — 92 passed, 0 failed (3 new MR label cases included)
- [x] Manual: call `list_merge_requests` against a project whose GitLab instance returns labels as objects; confirm no Zod error and labels are preserved.