### PR TITLE
feat(list-mrs): support approved_by_usernames filter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1933,6 +1933,11 @@ async function listMergeRequests(
       if (key === "labels" && Array.isArray(value)) {
         // Handle array of labels
         url.searchParams.append(key, value.join(","));
+      } else if (key === "approved_by_usernames" && Array.isArray(value)) {
+        // GitLab expects array-bracket form: approved_by_usernames[]=alice&approved_by_usernames[]=bob
+        for (const v of value) {
+          url.searchParams.append(`${key}[]`, String(v));
+        }
       } else {
         url.searchParams.append(key, String(value));
       }

--- a/schemas.ts
+++ b/schemas.ts
@@ -2037,6 +2037,9 @@ export const ListMergeRequestsSchema = z
       .string()
       .optional()
       .describe("Returns merge requests which have the user as a reviewer by username. Mutually exclusive with reviewer_id."),
+    approved_by_usernames: coerceStringArray
+      .optional()
+      .describe("Returns merge requests approved by the given usernames (array)."),
     created_after: z
       .string()
       .optional()

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -1104,6 +1104,79 @@ function runLabelsCoercionSchemaTests(): { passed: number; failed: number } {
   return { passed, failed };
 }
 
+function runApprovedByUsernamesSchemaTests(): { passed: number; failed: number } {
+  console.log('\n=== ListMergeRequestsSchema approved_by_usernames Tests ===');
+
+  const cases: {
+    name: string;
+    input: Record<string, any>;
+    expected?: string[];
+    shouldFail?: boolean;
+  }[] = [
+    {
+      name: 'schema:list_merge_requests:approved_by_usernames-native-array',
+      input: { approved_by_usernames: ['alice', 'bob'] },
+      expected: ['alice', 'bob'],
+    },
+    {
+      name: 'schema:list_merge_requests:approved_by_usernames-stringified-array',
+      input: { approved_by_usernames: '["alice","bob"]' },
+      expected: ['alice', 'bob'],
+    },
+    {
+      name: 'schema:list_merge_requests:approved_by_usernames-omitted',
+      input: {},
+      expected: undefined,
+    },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  cases.forEach(testCase => {
+    const result: TestResult = { name: testCase.name, status: 'failed' };
+    const parsed = ListMergeRequestsSchema.safeParse(testCase.input);
+
+    if (testCase.shouldFail) {
+      if (parsed.success) {
+        result.error = 'Expected schema validation to fail';
+      } else {
+        result.status = 'passed';
+      }
+    } else if (!parsed.success) {
+      result.error = parsed.error?.message || 'Schema validation failed';
+    } else {
+      const actual = (parsed.data as Record<string, unknown>)['approved_by_usernames'];
+      if (testCase.expected === undefined) {
+        result.status = actual === undefined ? 'passed' : 'failed';
+        if (actual !== undefined) {
+          result.error = `Expected approved_by_usernames to be undefined, got ${JSON.stringify(actual)}`;
+        }
+      } else {
+        const match =
+          Array.isArray(actual) &&
+          actual.length === testCase.expected.length &&
+          testCase.expected.every((v, i) => (actual as string[])[i] === v);
+        result.status = match ? 'passed' : 'failed';
+        if (!match) {
+          result.error = `Expected ${JSON.stringify(testCase.expected)}, got ${JSON.stringify(actual)}`;
+        }
+      }
+    }
+
+    if (result.status === 'passed') {
+      passed++;
+      console.log(`✅ ${result.name}`);
+    } else {
+      failed++;
+      console.log(`❌ ${result.name}: ${result.error}`);
+    }
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed`);
+  return { passed, failed };
+}
+
 function runListLabelsSchemaTests(): { passed: number; failed: number } {
   console.log('\n=== List Labels Schema Tests ===');
 
@@ -1453,14 +1526,15 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const emojiReactionResult = runEmojiReactionSchemaTests();
   const repositorySchemaResult = runGitLabRepositorySchemaTests();
   const labelsCoercionResult = runLabelsCoercionSchemaTests();
+  const approvedByUsernamesResult = runApprovedByUsernamesSchemaTests();
   const listLabelsResult = runListLabelsSchemaTests();
   const treeItemResult = runGitLabTreeItemSchemaTests();
   const repositoryTreeResult = runGetRepositoryTreeSchemaTests();
   const gitLabUserFullResult = runGitLabUserFullSchemaTests();
   const gitLabMarkdownUploadResult = runGitLabMarkdownUploadSchemaTests();
 
-  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + commitStatusResult.passed + createIssueNoteResult.passed + getMergeRequestResult.passed + listMergeRequestPipelinesResult.passed + gitLabMergeRequestResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + listLabelsResult.passed + treeItemResult.passed + repositoryTreeResult.passed + gitLabUserFullResult.passed + gitLabMarkdownUploadResult.passed;
-  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + commitStatusResult.failed + createIssueNoteResult.failed + getMergeRequestResult.failed + listMergeRequestPipelinesResult.failed + gitLabMergeRequestResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + listLabelsResult.failed + treeItemResult.failed + repositoryTreeResult.failed + gitLabUserFullResult.failed + gitLabMarkdownUploadResult.failed;
+  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + commitStatusResult.passed + createIssueNoteResult.passed + getMergeRequestResult.passed + listMergeRequestPipelinesResult.passed + gitLabMergeRequestResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + approvedByUsernamesResult.passed + listLabelsResult.passed + treeItemResult.passed + repositoryTreeResult.passed + gitLabUserFullResult.passed + gitLabMarkdownUploadResult.passed;
+  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + commitStatusResult.failed + createIssueNoteResult.failed + getMergeRequestResult.failed + listMergeRequestPipelinesResult.failed + gitLabMergeRequestResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + approvedByUsernamesResult.failed + listLabelsResult.failed + treeItemResult.failed + repositoryTreeResult.failed + gitLabUserFullResult.failed + gitLabMarkdownUploadResult.failed;
 
   console.log(`\nTotal Results: ${totalPassed} passed, ${totalFailed} failed`);
 

--- a/test/test-list-merge-requests.ts
+++ b/test/test-list-merge-requests.ts
@@ -109,8 +109,40 @@ describe('list_merge_requests', () => {
       GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
       GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN
     });
-    
+
     assert.ok(Array.isArray(mrs), 'Response should be an array');
     assert.strictEqual(mrs.length, 2, 'Should return 2 mock MRs');
+  });
+
+  test('forwards approved_by_usernames in bracket-array form', async () => {
+    let capturedUrl: string | undefined;
+    mockGitLab.addMockHandler('get', '/merge_requests', (req, res) => {
+      capturedUrl = req.originalUrl;
+      res.json([]);
+    });
+
+    try {
+      await callListMergeRequests(
+        { approved_by_usernames: ['alice', 'bob'] },
+        {
+          GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+          GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        }
+      );
+
+      assert.ok(capturedUrl, 'Mock handler should have received a request');
+      assert.match(
+        capturedUrl!,
+        /approved_by_usernames%5B%5D=alice/,
+        'Request URL should contain approved_by_usernames[]=alice (URL-encoded)'
+      );
+      assert.match(
+        capturedUrl!,
+        /approved_by_usernames%5B%5D=bob/,
+        'Request URL should contain approved_by_usernames[]=bob (URL-encoded)'
+      );
+    } finally {
+      mockGitLab.clearCustomHandlers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `list_merge_requests` did not declare `approved_by_usernames` on `ListMergeRequestsSchema`, so Zod silently stripped the value before it reached the HTTP layer — the filter had no effect.
- Even if the value made it through, the existing query-string builder in `listMergeRequests` only special-cased `labels` and would have serialized an array as `alice,bob` via `String(value)`, which GitLab does not accept for this filter (it expects bracket-array form).

Fixes #488

### Changes

1. `schemas.ts` — declare the field using the existing `coerceStringArray` helper so the value is preserved and LLM-sent stringified arrays are coerced (consistent with how `labels` is handled on the same schema):

   ```ts
   approved_by_usernames: coerceStringArray
     .optional()
     .describe("Returns merge requests approved by the given usernames (array).")
   ```

2. `index.ts` — forward in bracket-array form:

   ```ts
   else if (key === "approved_by_usernames" && Array.isArray(value)) {
     for (const v of value) {
       url.searchParams.append(`${key}[]`, String(v));
     }
   }
   ```

### Tests

- `test/schema-tests.ts` — new `runApprovedByUsernamesSchemaTests` covering native array, JSON-stringified array, and omitted field. (`npm run test:schema` → 92 passed, 0 failed.)
- `test/test-list-merge-requests.ts` — new integration test that registers a custom mock handler to capture the outgoing request URL and asserts it contains `approved_by_usernames[]=alice&approved_by_usernames[]=bob` (URL-encoded). (4/4 passing.)

## Test plan

- [x] `npm run test:schema` passes
- [x] `npx tsx test/test-list-merge-requests.ts` passes, including the bracket-form assertion
- [x] Manual: call `list_merge_requests` against a real GitLab instance with `{ "approved_by_usernames": ["alice"] }` and confirm only MRs approved by `alice` are returned.