### PR TITLE
fix: group-level work items returning 404

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2894,10 +2894,21 @@ async function resolveProjectPath(projectId: string): Promise<string> {
   const projectResponse = await fetch(projectUrl.toString(), {
     ...getFetchConfig(),
   });
-  // If the path resolves to a group rather than a project (404), use it directly —
-  // the GraphQL `namespace(fullPath: ...)` field accepts both project and group paths.
+  // If the project lookup returned 404, check whether the path is a real group
+  // before falling through to GraphQL. This prevents typos, deleted projects, and
+  // permission-scoped 404s from silently producing empty GraphQL results.
   if (projectResponse.status === 404) {
-    return effectiveProjectId;
+    const groupUrl = new URL(
+      `${getEffectiveApiUrl()}/groups/${encodeURIComponent(effectiveProjectId)}`
+    );
+    const groupResponse = await fetch(groupUrl.toString(), {
+      ...getFetchConfig(),
+    });
+    if (groupResponse.ok) {
+      const group: any = await groupResponse.json();
+      return group.full_path as string;
+    }
+    // Not a group either — fall through to the outer error handler below
   }
   await handleGitLabError(projectResponse);
   const project: any = await projectResponse.json();

--- a/index.ts
+++ b/index.ts
@@ -2894,6 +2894,11 @@ async function resolveProjectPath(projectId: string): Promise<string> {
   const projectResponse = await fetch(projectUrl.toString(), {
     ...getFetchConfig(),
   });
+  // If the path resolves to a group rather than a project (404), use it directly —
+  // the GraphQL `namespace(fullPath: ...)` field accepts both project and group paths.
+  if (projectResponse.status === 404) {
+    return effectiveProjectId;
+  }
   await handleGitLabError(projectResponse);
   const project: any = await projectResponse.json();
   return project.path_with_namespace;

--- a/index.ts
+++ b/index.ts
@@ -2081,19 +2081,9 @@ async function resolveWorkItemGID(
   projectId: string,
   issueIid: number
 ): Promise<{ workItemGID: string; projectPath: string }> {
-  projectId = decodeURIComponent(projectId);
-  const effectiveProjectId = getEffectiveProjectId(projectId);
-
-  // First get the project path via REST (needed for GraphQL namespace query)
-  const projectUrl = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}`
-  );
-  const projectResponse = await fetch(projectUrl.toString(), {
-    ...getFetchConfig(),
-  });
-  await handleGitLabError(projectResponse);
-  const project: any = await projectResponse.json();
-  const projectPath: string = project.path_with_namespace;
+  // resolveProjectPath handles both project and group paths (including the
+  // group fallback), so work item tools work for group-level namespaces too.
+  const projectPath = await resolveProjectPath(projectId);
 
   // Resolve work item GID via GraphQL
   const data = await executeGraphQL<{
@@ -2286,19 +2276,7 @@ async function listIssueStatuses(
   projectId: string,
   workItemType: string = "issue"
 ): Promise<any> {
-  projectId = decodeURIComponent(projectId);
-  const effectiveProjectId = getEffectiveProjectId(projectId);
-
-  // Get project path
-  const projectUrl = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}`
-  );
-  const projectResponse = await fetch(projectUrl.toString(), {
-    ...getFetchConfig(),
-  });
-  await handleGitLabError(projectResponse);
-  const project: any = await projectResponse.json();
-
+  const projectPath = await resolveProjectPath(projectId);
   const typeName = WORK_ITEM_TYPE_NAMES[workItemType] || "Issue";
 
   const data = await executeGraphQL<{
@@ -2340,7 +2318,7 @@ async function listIssueStatuses(
         }
       }
     }`,
-    { path: project.path_with_namespace, typeName: typeName.replace(/ /g, "_").toUpperCase() }
+    { path: projectPath, typeName: typeName.replace(/ /g, "_").toUpperCase() }
   );
 
   const typeNodes = data.namespace?.workItemTypes?.nodes;
@@ -2894,10 +2872,12 @@ async function resolveProjectPath(projectId: string): Promise<string> {
   const projectResponse = await fetch(projectUrl.toString(), {
     ...getFetchConfig(),
   });
-  // If the project lookup returned 404, check whether the path is a real group
-  // before falling through to GraphQL. This prevents typos, deleted projects, and
-  // permission-scoped 404s from silently producing empty GraphQL results.
-  if (projectResponse.status === 404) {
+
+  // On project 404, fall back to groups — but only for path-like identifiers.
+  // Numeric IDs must not fall back: group and project IDs share no namespace,
+  // so a numeric project 404 should fail immediately rather than silently
+  // resolving to an unrelated group with the same integer ID.
+  if (projectResponse.status === 404 && !/^\d+$/.test(effectiveProjectId)) {
     const groupUrl = new URL(
       `${getEffectiveApiUrl()}/groups/${encodeURIComponent(effectiveProjectId)}`
     );
@@ -2908,8 +2888,10 @@ async function resolveProjectPath(projectId: string): Promise<string> {
       const group: any = await groupResponse.json();
       return group.full_path as string;
     }
-    // Not a group either — fall through to the outer error handler below
+    // Surface the group error
+    await handleGitLabError(groupResponse);
   }
+
   await handleGitLabError(projectResponse);
   const project: any = await projectResponse.json();
   return project.path_with_namespace;

--- a/schemas.ts
+++ b/schemas.ts
@@ -3635,16 +3635,18 @@ const workItemTypeEnum = z.string().transform(v => v.toLowerCase()).pipe(
   z.enum(["issue", "task", "incident", "test_case", "epic", "key_result", "objective", "requirement", "ticket"])
 );
 
+const ProjectIdOrPathSchema = z.coerce.string().describe("Project ID, URL-encoded project path, or group path (e.g. 'group/subgroup' for group-level work items)");
+
 // Common params for work item tools
 const WorkItemParamsSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID (IID) of the work item"),
 });
 
 export const GetWorkItemSchema = WorkItemParamsSchema;
 
 export const ListWorkItemsSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   types: z
     .array(workItemTypeEnum)
     .optional()
@@ -3677,7 +3679,7 @@ export const ListWorkItemsSchema = z.object({
 });
 
 export const CreateWorkItemSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   title: z.string().describe("Title of the work item"),
   type: workItemTypeEnum
     .optional()
@@ -3749,14 +3751,14 @@ export const UpdateWorkItemSchema = WorkItemParamsSchema.extend({
 });
 
 export const ConvertWorkItemTypeSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   new_type: workItemTypeEnum.describe("The target work item type to convert to"),
 });
 
 
 export const ListWorkItemStatusesSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   work_item_type: workItemTypeEnum
     .optional()
     .default("issue")
@@ -3764,7 +3766,7 @@ export const ListWorkItemStatusesSchema = z.object({
 });
 
 export const ListWorkItemNotesSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   page_size: z.coerce.number().optional().default(20).describe("Number of discussions to return (default 20)"),
   after: z.string().optional().describe("Cursor for pagination"),
@@ -3772,7 +3774,7 @@ export const ListWorkItemNotesSchema = z.object({
 });
 
 export const CreateWorkItemNoteSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   body: z.string().describe("Note body (Markdown supported)"),
   internal: z.coerce.boolean().optional().default(false).describe("Create as internal/confidential note (only visible to project members)"),
@@ -3780,13 +3782,13 @@ export const CreateWorkItemNoteSchema = z.object({
 });
 
 export const MoveWorkItemSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path of the source project"),
+  project_id: z.coerce.string().describe("Project ID, URL-encoded project path, or group path of the source namespace"),
   iid: z.coerce.number().describe("The internal ID of the work item to move"),
   target_project_id: z.coerce.string().describe("Project ID or URL-encoded path of the target project"),
 });
 
 export const ListCustomFieldDefinitionsSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   work_item_type: workItemTypeEnum
     .optional()
     .default("issue")
@@ -3897,12 +3899,12 @@ export const ListIssueNoteEmojiReactionsSchema = ProjectParamsSchema.extend({
 });
 
 export const ListWorkItemEmojiReactionsSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
 });
 
 export const ListWorkItemNoteEmojiReactionsSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   note_id: z.string().describe("The GraphQL GID of the note (e.g. 'gid://gitlab/Note/123' from list_work_item_notes)"),
 });

--- a/schemas.ts
+++ b/schemas.ts
@@ -3784,7 +3784,7 @@ export const CreateWorkItemNoteSchema = z.object({
 export const MoveWorkItemSchema = z.object({
   project_id: z.coerce.string().describe("Project ID, URL-encoded project path, or group path of the source namespace"),
   iid: z.coerce.number().describe("The internal ID of the work item to move"),
-  target_project_id: z.coerce.string().describe("Project ID or URL-encoded path of the target project"),
+  target_project_id: z.coerce.string().describe("Project ID, URL-encoded project path, or group path of the target namespace"),
 });
 
 export const ListCustomFieldDefinitionsSchema = z.object({
@@ -3853,26 +3853,26 @@ export const DeleteIssueNoteEmojiReactionSchema = ProjectParamsSchema.extend({
 // --- Emoji Reaction schemas (GraphQL: Work Items) ---
 
 export const CreateWorkItemEmojiReactionSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   name: emojiNameField,
 });
 
 export const DeleteWorkItemEmojiReactionSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   name: emojiNameField,
 });
 
 export const CreateWorkItemNoteEmojiReactionSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   note_id: z.string().describe("The GraphQL GID of the note (e.g. 'gid://gitlab/Note/123' from list_work_item_notes)"),
   name: emojiNameField,
 });
 
 export const DeleteWorkItemNoteEmojiReactionSchema = z.object({
-  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  project_id: ProjectIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   note_id: z.string().describe("The GraphQL GID of the note (e.g. 'gid://gitlab/Note/123' from list_work_item_notes)"),
   name: emojiNameField,


### PR DESCRIPTION
## Problem

Work items scoped to a GitLab **group** (URLs of the form `/groups/<path>/-/work_items/<iid>`) could not be fetched or manipulated via any work item tool. The `project_id` parameter was resolved through the REST `/projects/:id` endpoint, which returns 404 for group paths — causing the request to fail before even reaching the GraphQL layer.

## Root Cause

`resolveProjectPath()` called `GET /projects/:id` to obtain `path_with_namespace`, then passed the result to GraphQL's `namespace(fullPath: ...)`. That REST endpoint only resolves projects, not groups. No fallback existed for the 404 case.

Additionally, two functions — `resolveWorkItemGID` and `listIssueStatuses` — had their own **inline** `GET /projects/:id` fetches that completely bypassed `resolveProjectPath`, so they failed for group paths even after the fallback was added.

GitLab's GraphQL `namespace(fullPath: ...)` field natively accepts both project paths and group paths, so the REST lookup was an unnecessary blocker for group-level namespaces.

## Fix

### `index.ts` — `resolveProjectPath`

Added a two-step lookup: when `GET /projects/:id` returns 404, the function now falls back to `GET /groups/:id`. If that succeeds, it returns `group.full_path` for downstream GraphQL use. If the group lookup also returns a non-ok response (404, 429, 5xx, etc.), that error is surfaced directly via `handleGitLabError` — preserving fail-fast behaviour and preventing real errors (rate limits, server faults) from being masked by the original project 404.

### `index.ts` — `resolveWorkItemGID` and `listIssueStatuses`

Both functions previously had their own inline `GET /projects/:id` REST fetch for path resolution, bypassing `resolveProjectPath` entirely. Replaced both with a direct call to `resolveProjectPath(projectId)`, making all work item GraphQL functions route through the single group-aware resolver.

**All 8 `resolveProjectPath` call sites are now work-item functions only.** No REST-based tool (issues, MRs, branches, etc.) was changed — those correctly remain project-scoped.

### `schemas.ts` — all work item schemas

Added a shared `ProjectIdOrPathSchema` constant and applied it to the `project_id` field across all 16 work item tool schemas (`WorkItemParamsSchema`, `ListWorkItemsSchema`, `CreateWorkItemSchema`, `ConvertWorkItemTypeSchema`, `ListWorkItemStatusesSchema`, `ListWorkItemNotesSchema`, `CreateWorkItemNoteSchema`, `MoveWorkItemSchema`, `ListCustomFieldDefinitionsSchema`, and all 7 emoji reaction / timeline event schemas). The description now explicitly states that a group path (e.g. `group/subgroup`) is a valid value, so AI clients pass it rather than failing to find a project ID.

## Behaviour

| Input | Before | After |
|---|---|---|
| Numeric project ID | ✅ Works | ✅ Works |
| Project path (`group/project`) | ✅ Works | ✅ Works |
| Group path (`group/subgroup`) | ❌ 404 thrown | ✅ Resolved via `GET /groups/:id`, passed to GraphQL |
| Typo / deleted / permission 404 | ❌ 404 thrown | ❌ 404 thrown (fail-fast preserved) |
| Rate limit (429) on group lookup | ❌ Masked as project 404 | ❌ 429 surfaced directly |
| Server error (5xx) on group lookup | ❌ Masked as project 404 | ❌ 5xx surfaced directly |

## Notes

- Existing project-level work item flows are unaffected — REST still resolves `path_with_namespace` on the first call, with no overhead.
- The group fallback only incurs an extra REST round-trip on a project 404, so there is no performance impact for the common case.
- No new tools or parameters added; the fix works with the existing `project_id` field.
- REST-based tools (issues, MRs, branches, labels, wikis, etc.) are intentionally unchanged — the GitLab REST API's `/projects/:id` endpoint only resolves projects, so advertising group path support there would be incorrect.