### PR TITLE
fix: add hidden CI variable field and group read guard tests

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -4016,6 +4016,7 @@ export const GitLabCiVariableSchema = z.object({
   value: z.string(),
   protected: z.boolean().optional(),
   masked: z.boolean().optional(),
+  hidden: z.boolean().optional(),
   raw: z.boolean().optional(),
   environment_scope: z.string().optional(),
   description: z.string().nullable().optional(),

--- a/schemas.ts
+++ b/schemas.ts
@@ -4013,7 +4013,7 @@ export const HealthCheckSchema = z.object({});
 export const GitLabCiVariableSchema = z.object({
   variable_type: z.enum(["env_var", "file"]).optional(),
   key: z.string(),
-  value: z.string(),
+  value: z.string().nullable(),
   protected: z.boolean().optional(),
   masked: z.boolean().optional(),
   hidden: z.boolean().optional(),

--- a/test/test-ci-variables.ts
+++ b/test/test-ci-variables.ts
@@ -8,6 +8,7 @@ const TEST_PROJECT_ID = "123";
 const TEST_GROUP_ID = "my-group";
 const TEST_VAR_KEY = "DB_URL";
 const TEST_GROUP_VAR_KEY = "SHARED_SECRET";
+const TEST_HIDDEN_VAR_KEY = "HIDDEN_VAR";
 const TEST_SCOPE = "production";
 
 const MOCK_PROJECT_VARIABLE = {
@@ -100,6 +101,24 @@ describe("CI/CD variable tools", () => {
         const scope = (req.query as Record<string, string>)["filter[environment_scope]"];
         lastReceivedFilterScope = scope;
         res.json({ ...MOCK_PROJECT_VARIABLE, environment_scope: scope ?? "*" });
+      }
+    );
+
+    mockServer.addMockHandler(
+      "get",
+      `/projects/${TEST_PROJECT_ID}/variables/${TEST_HIDDEN_VAR_KEY}`,
+      (_req, res) => {
+        res.json({
+          variable_type: "env_var",
+          key: TEST_HIDDEN_VAR_KEY,
+          value: null,
+          protected: false,
+          masked: true,
+          hidden: true,
+          raw: false,
+          environment_scope: "*",
+          description: null,
+        });
       }
     );
 
@@ -196,6 +215,17 @@ describe("CI/CD variable tools", () => {
     assert.strictEqual(result.key, TEST_VAR_KEY);
     assert.strictEqual(result.environment_scope, "*");
     assert.strictEqual(result.variable_type, "env_var");
+  });
+
+  test("get_project_variable returns hidden variable with null value", async () => {
+    const result = await callTool(
+      "get_project_variable",
+      { project_id: TEST_PROJECT_ID, key: TEST_HIDDEN_VAR_KEY },
+      baseEnv
+    );
+    assert.strictEqual(result.key, TEST_HIDDEN_VAR_KEY);
+    assert.strictEqual(result.value, null);
+    assert.strictEqual(result.hidden, true);
   });
 
   test("create_project_variable returns created variable", async () => {

--- a/test/test-ci-variables.ts
+++ b/test/test-ci-variables.ts
@@ -33,6 +33,14 @@ const MOCK_GROUP_VARIABLE = {
   description: null,
 };
 
+const MOCK_HIDDEN_PROJECT_VARIABLE = {
+  ...MOCK_PROJECT_VARIABLE,
+  key: TEST_HIDDEN_VAR_KEY,
+  value: null,
+  hidden: true,
+  description: null,
+};
+
 async function callTool(
   toolName: string,
   args: Record<string, unknown>,
@@ -108,17 +116,7 @@ describe("CI/CD variable tools", () => {
       "get",
       `/projects/${TEST_PROJECT_ID}/variables/${TEST_HIDDEN_VAR_KEY}`,
       (_req, res) => {
-        res.json({
-          variable_type: "env_var",
-          key: TEST_HIDDEN_VAR_KEY,
-          value: null,
-          protected: false,
-          masked: true,
-          hidden: true,
-          raw: false,
-          environment_scope: "*",
-          description: null,
-        });
+        res.json(MOCK_HIDDEN_PROJECT_VARIABLE);
       }
     );
 

--- a/test/test-geteffectiveprojectid.ts
+++ b/test/test-geteffectiveprojectid.ts
@@ -28,6 +28,24 @@ if (!process.env.TEST_PROJECT_ID) {
   process.env.TEST_PROJECT_ID = DEFAULT_PROJECT_ID;
 }
 
+const GROUP_VARIABLE_READ_TOOL_CASES = [
+  { toolName: 'list_group_variables', args: { group_id: 'my-group' } },
+  { toolName: 'get_group_variable', args: { group_id: 'my-group', key: 'SHARED_SECRET' } },
+] as const;
+
+async function assertToolNotAllowedAsync(
+  callToolAsync: () => Promise<unknown>,
+  toolName: string,
+): Promise<void> {
+  try {
+    await callToolAsync();
+    assert.fail(`Should have rejected ${toolName}`);
+  } catch (error) {
+    assert.ok(error instanceof Error);
+    assert.ok(error.message.includes(`${toolName} is not allowed`), `Should mention ${toolName}`);
+  }
+}
+
 console.log('🔍 Testing getEffectiveProjectId functionality');
 console.log('');
 
@@ -366,23 +384,9 @@ describe('GITLAB_PROJECT_ID guards repository and group mutators', () => {
     }
   });
 
-  test('should reject list_group_variables when GITLAB_PROJECT_ID is set', async () => {
-    try {
-      await client.callTool('list_group_variables', { group_id: 'my-group' });
-      assert.fail('Should have rejected list_group_variables');
-    } catch (error) {
-      assert.ok(error instanceof Error);
-      assert.ok(error.message.includes('list_group_variables is not allowed'), 'Should mention list_group_variables');
-    }
-  });
-
-  test('should reject get_group_variable when GITLAB_PROJECT_ID is set', async () => {
-    try {
-      await client.callTool('get_group_variable', { group_id: 'my-group', key: 'SHARED_SECRET' });
-      assert.fail('Should have rejected get_group_variable');
-    } catch (error) {
-      assert.ok(error instanceof Error);
-      assert.ok(error.message.includes('get_group_variable is not allowed'), 'Should mention get_group_variable');
+  test('should reject group variable read tools when GITLAB_PROJECT_ID is set', async () => {
+    for (const { toolName, args } of GROUP_VARIABLE_READ_TOOL_CASES) {
+      await assertToolNotAllowedAsync(() => client.callTool(toolName, args), toolName);
     }
   });
 
@@ -468,23 +472,9 @@ describe('GITLAB_ALLOWED_PROJECT_IDS guards repository and group mutators (allow
     }
   });
 
-  test('should reject list_group_variables with GITLAB_ALLOWED_PROJECT_IDS', async () => {
-    try {
-      await client.callTool('list_group_variables', { group_id: 'my-group' });
-      assert.fail('Should have rejected list_group_variables');
-    } catch (error) {
-      assert.ok(error instanceof Error);
-      assert.ok(error.message.includes('list_group_variables is not allowed'), 'Should mention list_group_variables');
-    }
-  });
-
-  test('should reject get_group_variable with GITLAB_ALLOWED_PROJECT_IDS', async () => {
-    try {
-      await client.callTool('get_group_variable', { group_id: 'my-group', key: 'SHARED_SECRET' });
-      assert.fail('Should have rejected get_group_variable');
-    } catch (error) {
-      assert.ok(error instanceof Error);
-      assert.ok(error.message.includes('get_group_variable is not allowed'), 'Should mention get_group_variable');
+  test('should reject group variable read tools with GITLAB_ALLOWED_PROJECT_IDS', async () => {
+    for (const { toolName, args } of GROUP_VARIABLE_READ_TOOL_CASES) {
+      await assertToolNotAllowedAsync(() => client.callTool(toolName, args), toolName);
     }
   });
 

--- a/test/test-geteffectiveprojectid.ts
+++ b/test/test-geteffectiveprojectid.ts
@@ -28,24 +28,6 @@ if (!process.env.TEST_PROJECT_ID) {
   process.env.TEST_PROJECT_ID = DEFAULT_PROJECT_ID;
 }
 
-const GROUP_VARIABLE_READ_TOOL_CASES = [
-  { toolName: 'list_group_variables', args: { group_id: 'my-group' } },
-  { toolName: 'get_group_variable', args: { group_id: 'my-group', key: 'SHARED_SECRET' } },
-] as const;
-
-async function assertToolNotAllowedAsync(
-  callToolAsync: () => Promise<unknown>,
-  toolName: string,
-): Promise<void> {
-  try {
-    await callToolAsync();
-    assert.fail(`Should have rejected ${toolName}`);
-  } catch (error) {
-    assert.ok(error instanceof Error);
-    assert.ok(error.message.includes(`${toolName} is not allowed`), `Should mention ${toolName}`);
-  }
-}
-
 console.log('🔍 Testing getEffectiveProjectId functionality');
 console.log('');
 
@@ -384,9 +366,23 @@ describe('GITLAB_PROJECT_ID guards repository and group mutators', () => {
     }
   });
 
-  test('should reject group variable read tools when GITLAB_PROJECT_ID is set', async () => {
-    for (const { toolName, args } of GROUP_VARIABLE_READ_TOOL_CASES) {
-      await assertToolNotAllowedAsync(() => client.callTool(toolName, args), toolName);
+  test('should reject list_group_variables when GITLAB_PROJECT_ID is set', async () => {
+    try {
+      await client.callTool('list_group_variables', { group_id: 'my-group' });
+      assert.fail('Should have rejected list_group_variables');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('list_group_variables is not allowed'), 'Should mention list_group_variables');
+    }
+  });
+
+  test('should reject get_group_variable when GITLAB_PROJECT_ID is set', async () => {
+    try {
+      await client.callTool('get_group_variable', { group_id: 'my-group', key: 'SHARED_SECRET' });
+      assert.fail('Should have rejected get_group_variable');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('get_group_variable is not allowed'), 'Should mention get_group_variable');
     }
   });
 
@@ -472,9 +468,23 @@ describe('GITLAB_ALLOWED_PROJECT_IDS guards repository and group mutators (allow
     }
   });
 
-  test('should reject group variable read tools with GITLAB_ALLOWED_PROJECT_IDS', async () => {
-    for (const { toolName, args } of GROUP_VARIABLE_READ_TOOL_CASES) {
-      await assertToolNotAllowedAsync(() => client.callTool(toolName, args), toolName);
+  test('should reject list_group_variables with GITLAB_ALLOWED_PROJECT_IDS', async () => {
+    try {
+      await client.callTool('list_group_variables', { group_id: 'my-group' });
+      assert.fail('Should have rejected list_group_variables');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('list_group_variables is not allowed'), 'Should mention list_group_variables');
+    }
+  });
+
+  test('should reject get_group_variable with GITLAB_ALLOWED_PROJECT_IDS', async () => {
+    try {
+      await client.callTool('get_group_variable', { group_id: 'my-group', key: 'SHARED_SECRET' });
+      assert.fail('Should have rejected get_group_variable');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('get_group_variable is not allowed'), 'Should mention get_group_variable');
     }
   });
 

--- a/test/test-geteffectiveprojectid.ts
+++ b/test/test-geteffectiveprojectid.ts
@@ -318,6 +318,7 @@ describe('GITLAB_PROJECT_ID guards repository and group mutators', () => {
         REMOTE_AUTHORIZATION: 'true',
         GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
         GITLAB_PROJECT_ID: DEFAULT_PROJECT_ID,
+        GITLAB_TOOLSETS: 'variables',
       }
     });
     servers.push(server);
@@ -365,6 +366,26 @@ describe('GITLAB_PROJECT_ID guards repository and group mutators', () => {
     }
   });
 
+  test('should reject list_group_variables when GITLAB_PROJECT_ID is set', async () => {
+    try {
+      await client.callTool('list_group_variables', { group_id: 'my-group' });
+      assert.fail('Should have rejected list_group_variables');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('list_group_variables is not allowed'), 'Should mention list_group_variables');
+    }
+  });
+
+  test('should reject get_group_variable when GITLAB_PROJECT_ID is set', async () => {
+    try {
+      await client.callTool('get_group_variable', { group_id: 'my-group', key: 'SHARED_SECRET' });
+      assert.fail('Should have rejected get_group_variable');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('get_group_variable is not allowed'), 'Should mention get_group_variable');
+    }
+  });
+
   test('should allow get_project (non-mutator) when GITLAB_PROJECT_ID is set', async () => {
     const result = await client.callTool('get_project', { project_id: '' });
     assert.ok(result.content, 'Should have content');
@@ -399,6 +420,7 @@ describe('GITLAB_ALLOWED_PROJECT_IDS guards repository and group mutators (allow
         REMOTE_AUTHORIZATION: 'true',
         GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
         GITLAB_ALLOWED_PROJECT_IDS: DEFAULT_PROJECT_ID,
+        GITLAB_TOOLSETS: 'variables',
       }
     });
     servers.push(server);
@@ -443,6 +465,26 @@ describe('GITLAB_ALLOWED_PROJECT_IDS guards repository and group mutators (allow
     } catch (error) {
       assert.ok(error instanceof Error);
       assert.ok(error.message.includes('create_group is not allowed'), 'Should mention create_group');
+    }
+  });
+
+  test('should reject list_group_variables with GITLAB_ALLOWED_PROJECT_IDS', async () => {
+    try {
+      await client.callTool('list_group_variables', { group_id: 'my-group' });
+      assert.fail('Should have rejected list_group_variables');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('list_group_variables is not allowed'), 'Should mention list_group_variables');
+    }
+  });
+
+  test('should reject get_group_variable with GITLAB_ALLOWED_PROJECT_IDS', async () => {
+    try {
+      await client.callTool('get_group_variable', { group_id: 'my-group', key: 'SHARED_SECRET' });
+      assert.fail('Should have rejected get_group_variable');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('get_group_variable is not allowed'), 'Should mention get_group_variable');
     }
   });
 


### PR DESCRIPTION
## Summary
- Add optional `hidden` to `GitLabCiVariableSchema` so GitLab 17.4+ variable responses preserve masked/hidden metadata
- Add regression tests ensuring `list_group_variables` and `get_group_variable` are rejected under project-scoped deployments (`GITLAB_PROJECT_ID` and `GITLAB_ALLOWED_PROJECT_IDS`)

Follow-up to #479. P1 list-filter contract cleanup intentionally deferred for observation.

## Test plan
- [x] `npm run build`
- [x] `node --import tsx/esm --test test/test-geteffectiveprojectid.ts` (22/22 pass)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only optional field plus test coverage for existing project-scoping guards; no new runtime behavior in application code shown in the diff.
> 
> **Overview**
> Adds optional **`hidden`** to `GitLabCiVariableSchema` so GitLab 17.4+ CI variable responses keep masked/hidden metadata when parsed.
> 
> Integration tests now enable the **`variables`** toolset and assert **`list_group_variables`** and **`get_group_variable`** are blocked when the server is scoped with **`GITLAB_PROJECT_ID`** or **`GITLAB_ALLOWED_PROJECT_IDS`**, matching other group-level guards (e.g. `create_group`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62161c9ca9c4cc3c6836623d13400e9d26980bab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->