### PR TITLE
fix: guard dependency proxy tools in project-scoped deployments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10992,6 +10992,7 @@ async function handleToolCall(params: any) {
       }
 
       case "get_dependency_proxy_settings": {
+        rejectIfProjectScopedDeployment("get_dependency_proxy_settings");
         const args = GetDependencyProxySettingsSchema.parse(params.arguments);
         const settings = await getDependencyProxySettings(args.group_id);
         return {
@@ -11000,6 +11001,7 @@ async function handleToolCall(params: any) {
       }
 
       case "update_dependency_proxy_settings": {
+        rejectIfProjectScopedDeployment("update_dependency_proxy_settings");
         const args = UpdateDependencyProxySettingsSchema.parse(params.arguments);
         const { group_id, ...options } = args;
         const settings = await updateDependencyProxySettings(group_id, options);
@@ -11009,6 +11011,7 @@ async function handleToolCall(params: any) {
       }
 
       case "list_dependency_proxy_blobs": {
+        rejectIfProjectScopedDeployment("list_dependency_proxy_blobs");
         const args = ListDependencyProxyBlobsSchema.parse(params.arguments);
         const { group_id, ...options } = args;
         const result = await listDependencyProxyBlobs(group_id, options);
@@ -11018,6 +11021,7 @@ async function handleToolCall(params: any) {
       }
 
       case "purge_dependency_proxy_cache": {
+        rejectIfProjectScopedDeployment("purge_dependency_proxy_cache");
         const args = PurgeDependencyProxyCacheSchema.parse(params.arguments);
         await purgeDependencyProxyCache(args.group_id);
         return {

--- a/test/test-geteffectiveprojectid.ts
+++ b/test/test-geteffectiveprojectid.ts
@@ -565,4 +565,73 @@ describe('GITLAB_READ_ONLY_MODE enforces read-only for all write tools', () => {
   });
 });
 
+describe('GITLAB_PROJECT_ID guards dependency proxy tools', () => {
+  let mcpUrl: string;
+  let mockGitLab: MockGitLabServer;
+  let servers: ServerInstance[] = [];
+  let client: CustomHeaderClient;
+
+  before(async () => {
+    const mockPort = await findMockServerPort(9500);
+    mockGitLab = new MockGitLabServer({
+      port: mockPort,
+      validTokens: [MOCK_TOKEN],
+    });
+    await mockGitLab.start();
+    const mockGitLabUrl = mockGitLab.getUrl();
+
+    const mcpPort = await findAvailablePort(3500);
+    const server = await launchServer({
+      mode: TransportMode.STREAMABLE_HTTP,
+      port: mcpPort,
+      timeout: 5000,
+      env: {
+        REMOTE_AUTHORIZATION: 'true',
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PROJECT_ID: DEFAULT_PROJECT_ID,
+        GITLAB_TOOLSETS: 'dependency_proxy',
+      },
+    });
+    servers.push(server);
+    mcpUrl = `http://${HOST}:${mcpPort}/mcp`;
+
+    client = new CustomHeaderClient({
+      authorization: `Bearer ${MOCK_TOKEN}`,
+    });
+    await client.connect(mcpUrl);
+  });
+
+  after(async () => {
+    if (client) await client.disconnect();
+    cleanupServers(servers);
+    if (mockGitLab) await mockGitLab.stop();
+  });
+
+  test('should reject get_dependency_proxy_settings when GITLAB_PROJECT_ID is set', async () => {
+    try {
+      await client.callTool('get_dependency_proxy_settings', { group_id: 'my-group' });
+      assert.fail('Should have rejected get_dependency_proxy_settings');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(
+        error.message.includes('get_dependency_proxy_settings is not allowed'),
+        'Should mention get_dependency_proxy_settings'
+      );
+    }
+  });
+
+  test('should reject purge_dependency_proxy_cache when GITLAB_PROJECT_ID is set', async () => {
+    try {
+      await client.callTool('purge_dependency_proxy_cache', { group_id: 'my-group' });
+      assert.fail('Should have rejected purge_dependency_proxy_cache');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(
+        error.message.includes('purge_dependency_proxy_cache is not allowed'),
+        'Should mention purge_dependency_proxy_cache'
+      );
+    }
+  });
+});
+
 }); // end wrapper describe


### PR DESCRIPTION
## Summary
- Add `rejectIfProjectScopedDeployment()` to all four dependency proxy tool handlers (`get`/`update` settings, `list` blobs, `purge` cache) so project-locked servers cannot reach group-scoped proxy APIs.
- Add regression tests in `test/test-geteffectiveprojectid.ts` for `GITLAB_PROJECT_ID` + `dependency_proxy` toolset (read and destructive tools).

Follow-up to #474 merge; addresses the project-scope guard gap noted in Codex review and post-merge local fix.

## Test plan
- [x] `npm run build`
- [x] `node --import tsx/esm --test test/test-dependency-proxy.ts` (7/7)
- [x] `node --import tsx/esm --test test/test-geteffectiveprojectid.ts` (24/24)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guardrails and tests on MCP tool routing; no changes to GitLab API credentials or proxy behavior itself.
> 
> **Overview**
> **Blocks group-scoped dependency proxy MCP tools when the server is locked to a single project** (`GITLAB_PROJECT_ID`), matching guards already used for other group-level operations.
> 
> Each of the four dependency proxy handlers—`get_dependency_proxy_settings`, `update_dependency_proxy_settings`, `list_dependency_proxy_blobs`, and `purge_dependency_proxy_cache`—now calls `rejectIfProjectScopedDeployment()` before running, so project-scoped deployments cannot invoke group-level proxy APIs.
> 
> New integration tests in `test/test-geteffectiveprojectid.ts` assert rejection for read and purge tools when `GITLAB_PROJECT_ID` and the `dependency_proxy` toolset are configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16b7d09e703abe66eed90b0a0d785e6f1b004c89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->