### PR TITLE
fix: stateful session slot leak

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11847,6 +11847,14 @@ async function startStreamableHTTPServer(): Promise<void> {
         delete authBySession[sessionId];
         delete authTimeouts[sessionId];
         metrics.expiredSessions++;
+        // Close the transport to free the slot; without this, stale sessions accumulate and exhaust MAX_SESSIONS.
+        const transport = streamableTransports[sessionId];
+
+        if (transport) {
+          transport.close().catch(err => {
+            logger.error(`Error closing transport for expired session ${sessionId}:`, err);
+          });
+        }
       }
     }, SESSION_TIMEOUT_SECONDS * 1000);
   };


### PR DESCRIPTION
## Problem

In stateful mode with `GITLAB_MCP_OAUTH` or `REMOTE_AUTHORIZATION`, `activeSessions` accumulates to `MAX_SESSIONS` over time even when users are inactive, causing new connections to be rejected with 503.

**Root cause:** `SESSION_TIMEOUT_SECONDS` only removes the auth token from `authBySession` but leaves the transport alive in `streamableTransports`. The code even documents this explicitly:

> *"After SESSION_TIMEOUT_SECONDS of inactivity, the auth token is removed **but the transport session remains active**"*

The only place `streamableTransports[sid]` is deleted is inside `transport.onclose`, which fires only when the client disconnects. There is no server-side transport timeout - so idle clients that never disconnect hold their slots indefinitely.

**Observable signal:** `activeSessions - authenticatedSessions` grows over time. In a degraded deployment this looks like:

```json
{
  "activeSessions": 1000,
  "authenticatedSessions": 1,
  "rejectedByCapacity": 90,
  "status": "degraded"
}
```

999 stale sessions occupying slots, 90 real users already being turned away.

## Fix

Close the transport when the auth timeout fires. This triggers the existing `onclose` handler, which consistently handles slot cleanup and metrics - no duplicate logic needed.

```ts
// index.ts - inside setAuthTimeout's setTimeout callback
metrics.expiredSessions++;
// Close the transport to free the slot; without this, stale sessions accumulate and exhaust MAX_SESSIONS.
const transport = streamableTransports[sessionId];
if (transport) {
  transport.close();
}
```

## Impact

- **Active users:** none - the timeout resets on every request, so sessions in use are never closed.
- **Idle users (> SESSION_TIMEOUT_SECONDS):** transport closes cleanly → MCP client re-initializes on next use. This is the MCP Streamable HTTP spec's designed recovery path (404 → re-initialize). The previous behavior was a silent auth failure (GitLab API 401) on the next request anyway, since `authBySession` was already cleared.
