### PR TITLE
ci: request Cursor review on pull requests

### DIFF
--- a/.github/workflows/mention-cursor.yml
+++ b/.github/workflows/mention-cursor.yml
@@ -1,6 +1,8 @@
 name: Mention Cursor on PR
 
 on:
+  # Required so the workflow can comment on fork PRs. Keep this workflow free of
+  # checkout steps and any execution of pull request code.
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
 
@@ -35,7 +37,7 @@ jobs:
             const alreadyRequested = comments.some(
               (comment) =>
                 comment.user?.login === 'github-actions[bot]' &&
-                comment.body?.startsWith(marker),
+                comment.body?.startsWith(body),
             );
 
             if (alreadyRequested) {

--- a/.github/workflows/mention-cursor.yml
+++ b/.github/workflows/mention-cursor.yml
@@ -2,7 +2,7 @@ name: Mention Cursor on PR
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 permissions:
   issues: write
@@ -18,8 +18,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const marker = '<!-- cursor-review-request -->';
-            const body = `${marker}\n@cursor please review this pull request.`;
+            const headSha = context.payload.pull_request.head.sha;
+            const marker = `<!-- cursor-review-request:${headSha} -->`;
+            const body = `${marker}\n@cursor please review the latest changes in this pull request.`;
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
 
@@ -35,7 +36,7 @@ jobs:
             );
 
             if (alreadyRequested) {
-              core.notice('Cursor review has already been requested for this PR.');
+              core.notice(`Cursor review has already been requested for ${headSha}.`);
               return;
             }
 

--- a/.github/workflows/mention-cursor.yml
+++ b/.github/workflows/mention-cursor.yml
@@ -4,18 +4,19 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
 
-permissions:
-  issues: write
-  pull-requests: read
-
 jobs:
   mention-cursor:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    concurrency:
+      group: mention-cursor-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      issues: write
 
     steps:
       - name: Request Cursor review
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const headSha = context.payload.pull_request.head.sha;
@@ -31,8 +32,10 @@ jobs:
               per_page: 100,
             });
 
-            const alreadyRequested = comments.some((comment) =>
-              comment.body?.includes(marker),
+            const alreadyRequested = comments.some(
+              (comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                comment.body?.startsWith(marker),
             );
 
             if (alreadyRequested) {

--- a/.github/workflows/mention-cursor.yml
+++ b/.github/workflows/mention-cursor.yml
@@ -1,0 +1,47 @@
+name: Mention Cursor on PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  mention-cursor:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Request Cursor review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- cursor-review-request -->';
+            const body = `${marker}\n@cursor please review this pull request.`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const alreadyRequested = comments.some((comment) =>
+              comment.body?.includes(marker),
+            );
+
+            if (alreadyRequested) {
+              core.notice('Cursor review has already been requested for this PR.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });

--- a/.github/workflows/mention-cursor.yml
+++ b/.github/workflows/mention-cursor.yml
@@ -13,6 +13,7 @@ jobs:
     concurrency:
       group: mention-cursor-${{ github.event.pull_request.number }}
       cancel-in-progress: true
+    # issues: write is required to create the Cursor review request comment.
     permissions:
       issues: write
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that comments @cursor when PRs are opened, reopened, marked ready for review, or updated with new commits
- skip draft PRs and dedupe by pull request head SHA so each pushed revision gets at most one Cursor request
- use pull_request_target only for issue comments, with no checkout or PR-code execution, so fork PRs can be handled safely
- serialize runs per PR, pin actions/github-script to an immutable commit, and only trust github-actions[bot] comments for dedupe

## Validation
- npx prettier --check .github/workflows/mention-cursor.yml
- actionlint not installed; skipped


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> pull_request_target runs in the base repo context; the workflow avoids checkout/PR code but still posts bot comments and needs correct minimal permissions.
> 
> **Overview**
> Adds **`.github/workflows/mention-cursor.yml`**, a CI job that posts a single **`@cursor`** review request comment when a non-draft PR is opened, reopened, marked ready, or synchronized.
> 
> It uses **`pull_request_target`** with **`issues: write`** only—no checkout or PR code execution—so fork PRs can get comments safely. **Concurrency** is scoped per PR number; **`actions/github-script`** is pinned to a commit SHA. Deduping lists issue comments and skips posting if **`github-actions[bot]`** already left a comment whose body starts with the same head-SHA marker and review text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500d64a97ea29c8b9b3e7a164ebc78f3c60af32e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->