### PR TITLE
feat: binary (base64) commits and per-file actions in push_files

### DIFF
--- a/activate-fork.sh
+++ b/activate-fork.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Point Claude Code's `gitlab` MCP server at the hodyhq fork (binary + update support).
+# RUN THIS WITH CLAUDE CODE FULLY QUIT, then relaunch — the running app owns
+# ~/.claude.json and will clobber the edit otherwise.
+#
+#   bash ~/.dev/Projects/gitlab-mcp/activate-fork.sh          # activate fork
+#   bash ~/.dev/Projects/gitlab-mcp/activate-fork.sh --revert # back to upstream npx
+set -euo pipefail
+
+CFG="$HOME/.claude.json"
+BUILD="/home/hody/.dev/Projects/gitlab-mcp/build/index.js"
+MODE="${1:-activate}"
+
+[ -f "$CFG" ] || { echo "no $CFG"; exit 1; }
+[ "$MODE" = "activate" ] && [ ! -f "$BUILD" ] && { echo "build missing: $BUILD (run: cd ~/.dev/Projects/gitlab-mcp && npm install && npm run build)"; exit 1; }
+
+cp "$CFG" "$CFG.bak.$(date +%s)"
+
+python3 - "$CFG" "$BUILD" "$MODE" <<'PY'
+import json, sys
+cfg, build, mode = sys.argv[1], sys.argv[2], sys.argv[3]
+d = json.load(open(cfg)); n = 0
+def walk(o):
+    global n
+    if isinstance(o, dict):
+        ms = o.get("mcpServers")
+        if isinstance(ms, dict) and "gitlab" in ms:
+            g = ms["gitlab"]
+            if mode == "revert":
+                g["command"] = "npx"; g["args"] = ["-y", "@zereight/mcp-gitlab"]
+            else:
+                g["command"] = "node"; g["args"] = [build]
+            n += 1
+        for v in o.values(): walk(v)
+walk(d)
+json.dump(d, open(cfg, "w"), indent=2); open(cfg, "a").write("\n")
+print(f"{'reverted' if mode=='revert' else 'activated fork on'} {n} gitlab server(s). Backup saved. Now relaunch Claude Code.")
+PY

--- a/index.ts
+++ b/index.ts
@@ -4464,7 +4464,8 @@ async function createOrUpdateFile(
   branch: string,
   previousPath?: string,
   last_commit_id?: string,
-  commit_id?: string
+  commit_id?: string,
+  encoding?: "text" | "base64"
 ): Promise<GitLabCreateUpdateFileResponse> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const encodedPath = encodeURIComponent(filePath);
@@ -4474,9 +4475,11 @@ async function createOrUpdateFile(
 
   const body: Record<string, any> = {
     branch,
-    content: encodeRepoFilePayloadContent(content),
+    // base64 content is passed through untouched (binary-safe); otherwise fall
+    // back to the global text/base64 convenience toggle.
+    content: encoding === "base64" ? content : encodeRepoFilePayloadContent(content),
     commit_message: commitMessage,
-    encoding: GITLAB_REPO_FILE_ENCODING,
+    encoding: encoding === "base64" ? "base64" : GITLAB_REPO_FILE_ENCODING,
     ...(previousPath ? { previous_path: previousPath } : {}),
   };
 
@@ -4558,12 +4561,26 @@ async function createCommit(
     body: JSON.stringify({
       branch,
       commit_message: message,
-      actions: actions.map(action => ({
-        action: "create",
-        file_path: action.path,
-        content: encodeRepoFilePayloadContent(action.content),
-        encoding: GITLAB_REPO_FILE_ENCODING,
-      })),
+      actions: actions.map(action => {
+        // Honour per-file action (create/update/delete/move) instead of
+        // hardcoding "create", and pass base64 content through untouched so
+        // binary files commit correctly.
+        const act = action.action ?? "create";
+        const entry: Record<string, any> = { action: act, file_path: action.path };
+        if (act === "move" && action.previous_path) {
+          entry.previous_path = action.previous_path;
+        }
+        if (act !== "delete") {
+          if (action.encoding === "base64") {
+            entry.content = action.content ?? ""; // already base64 (binary-safe)
+            entry.encoding = "base64";
+          } else {
+            entry.content = encodeRepoFilePayloadContent(action.content ?? "");
+            entry.encoding = GITLAB_REPO_FILE_ENCODING;
+          }
+        }
+        return entry;
+      }),
     }),
   });
 
@@ -9120,7 +9137,8 @@ async function handleToolCall(params: any) {
           args.branch,
           args.previous_path,
           args.last_commit_id,
-          args.commit_id
+          args.commit_id,
+          args.encoding
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -9133,7 +9151,13 @@ async function handleToolCall(params: any) {
           args.project_id,
           args.commit_message,
           args.branch,
-          args.files.map(f => ({ path: f.file_path, content: f.content }))
+          args.files.map(f => ({
+            path: f.file_path,
+            content: f.content,
+            action: f.action,
+            encoding: f.encoding,
+            previous_path: f.previous_path,
+          }))
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/index.ts
+++ b/index.ts
@@ -4475,11 +4475,11 @@ async function createOrUpdateFile(
 
   const body: Record<string, any> = {
     branch,
-    // base64 content is passed through untouched (binary-safe); otherwise fall
-    // back to the global text/base64 convenience toggle.
-    content: encoding === "base64" ? content : encodeRepoFilePayloadContent(content),
+    // An explicit per-call encoding wins (text or base64, content sent as-is);
+    // when omitted, fall back to the global text/base64 convenience toggle.
+    content: encoding !== undefined ? content : encodeRepoFilePayloadContent(content),
     commit_message: commitMessage,
-    encoding: encoding === "base64" ? "base64" : GITLAB_REPO_FILE_ENCODING,
+    encoding: encoding ?? GITLAB_REPO_FILE_ENCODING,
     ...(previousPath ? { previous_path: previousPath } : {}),
   };
 
@@ -4571,12 +4571,19 @@ async function createCommit(
           entry.previous_path = action.previous_path;
         }
         if (act !== "delete") {
-          if (action.encoding === "base64") {
-            entry.content = action.content ?? ""; // already base64 (binary-safe)
-            entry.encoding = "base64";
-          } else {
-            entry.content = encodeRepoFilePayloadContent(action.content ?? "");
-            entry.encoding = GITLAB_REPO_FILE_ENCODING;
+          const hasContent = action.content !== undefined;
+          // A `move` with no content must keep the original file's content — omit the
+          // content field entirely rather than blanking it with "".
+          if (!(act === "move" && !hasContent)) {
+            if (action.encoding !== undefined) {
+              // explicit text or base64 — send content as-is
+              entry.content = action.content ?? "";
+              entry.encoding = action.encoding;
+            } else {
+              // fall back to the global text/base64 convenience toggle
+              entry.content = encodeRepoFilePayloadContent(action.content ?? "");
+              entry.encoding = GITLAB_REPO_FILE_ENCODING;
+            }
           }
         }
         return entry;

--- a/schemas.ts
+++ b/schemas.ts
@@ -822,7 +822,12 @@ export const GitLabContentSchema = z.union([
 // Operation schemas
 export const FileOperationSchema = z.object({
   path: z.string(),
-  content: z.string(),
+  content: z.string().optional(),
+  // Per-file action + encoding so push_files can update/delete/move and carry
+  // binary files (base64). Defaults preserve existing behaviour.
+  action: z.enum(["create", "update", "delete", "move"]).optional(),
+  encoding: z.enum(["text", "base64"]).optional(),
+  previous_path: z.string().optional(),
 });
 
 // Tree and commit schemas
@@ -1473,6 +1478,10 @@ export const CreateOrUpdateFileSchema = ProjectParamsSchema.extend({
   previous_path: z.string().optional().describe("Path of the file to move/rename"),
   last_commit_id: z.string().optional().describe("Last known file commit ID"),
   commit_id: z.string().optional().describe("Current file commit ID (for update operations)"),
+  encoding: z
+    .enum(["text", "base64"])
+    .optional()
+    .describe("Content encoding. Use 'base64' for binary files (content must already be base64-encoded); defaults to text."),
 });
 
 export const SearchRepositoriesSchema = z
@@ -1544,11 +1553,20 @@ export const PushFilesSchema = ProjectParamsSchema.extend({
   files: z
     .array(
       z.object({
-        file_path: z.string().describe("Path where to create the file"),
-        content: z.string().describe("Content of the file"),
+        file_path: z.string().describe("Path of the file in the repo"),
+        content: z.string().optional().describe("File content (base64-encoded when encoding='base64'; omit for action='delete')"),
+        action: z
+          .enum(["create", "update", "delete", "move"])
+          .optional()
+          .describe("Commit action for this file. Defaults to 'create'."),
+        encoding: z
+          .enum(["text", "base64"])
+          .optional()
+          .describe("Use 'base64' for binary files (content must already be base64-encoded); defaults to text."),
+        previous_path: z.string().optional().describe("Source path when action='move'"),
       })
     )
-    .describe("Array of files to push"),
+    .describe("Array of files to commit in a single commit (create/update/delete/move, text or binary)"),
   commit_message: z.string().describe("Commit message"),
 });
 

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -2,6 +2,8 @@
 
 import {
   GetFileContentsSchema,
+  PushFilesSchema,
+  CreateOrUpdateFileSchema,
   GitLabFileContentSchema,
   GitLabRepositorySchema,
   CreatePipelineSchema,
@@ -134,6 +136,97 @@ function runGetFileContentsSchemaTests(): { passed: number; failed: number } {
       const expected = testCase.expected || {};
       const matches = project_id === expected.project_id && file_path === expected.file_path && ref === expected.ref;
       if (matches) {
+        result.status = 'passed';
+      } else {
+        result.error = `Unexpected parsed result: ${JSON.stringify(parsed.data)}`;
+      }
+    } else {
+      result.error = parsed.error?.message || 'Schema validation failed';
+    }
+
+    if (result.status === 'passed') {
+      passed++;
+      console.log(`✅ ${result.name}`);
+    } else {
+      failed++;
+      console.log(`❌ ${result.name}: ${result.error}`);
+    }
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed`);
+
+  return { passed, failed };
+}
+
+function runPushFilesSchemaTests(): { passed: number; failed: number } {
+  console.log('🧪 Testing PushFilesSchema / CreateOrUpdateFileSchema (per-file action + encoding)...');
+
+  interface Case {
+    name: string;
+    input: Record<string, any>;
+    shouldFail?: boolean;
+    check?: (data: any) => boolean;
+  }
+
+  const base = { project_id: '1', branch: 'main', commit_message: 'm' };
+  const cases: Case[] = [
+    {
+      name: 'schema:push_files:plain-text-default',
+      input: { ...base, files: [{ file_path: 'a.txt', content: 'hi' }] },
+      check: d => d.files[0].action === undefined && d.files[0].encoding === undefined,
+    },
+    {
+      name: 'schema:push_files:binary-base64',
+      input: { ...base, files: [{ file_path: 'logo.png', content: 'aGk=', encoding: 'base64' }] },
+      check: d => d.files[0].encoding === 'base64',
+    },
+    {
+      name: 'schema:push_files:action-update',
+      input: { ...base, files: [{ file_path: 'a.txt', content: 'new', action: 'update' }] },
+      check: d => d.files[0].action === 'update',
+    },
+    {
+      name: 'schema:push_files:action-delete-content-optional',
+      input: { ...base, files: [{ file_path: 'a.txt', action: 'delete' }] },
+      check: d => d.files[0].action === 'delete' && d.files[0].content === undefined,
+    },
+    {
+      name: 'schema:push_files:action-move-previous-path',
+      input: { ...base, files: [{ file_path: 'b.txt', action: 'move', previous_path: 'a.txt' }] },
+      check: d => d.files[0].action === 'move' && d.files[0].previous_path === 'a.txt',
+    },
+    {
+      name: 'schema:push_files:reject-bad-action',
+      input: { ...base, files: [{ file_path: 'a.txt', content: 'x', action: 'frobnicate' }] },
+      shouldFail: true,
+    },
+    {
+      name: 'schema:push_files:reject-bad-encoding',
+      input: { ...base, files: [{ file_path: 'a.txt', content: 'x', encoding: 'rot13' }] },
+      shouldFail: true,
+    },
+    {
+      name: 'schema:create_or_update_file:encoding-base64',
+      input: { project_id: '1', file_path: 'logo.png', content: 'aGk=', commit_message: 'm', branch: 'main', encoding: 'base64' },
+      check: d => d.encoding === 'base64',
+    },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  cases.forEach(testCase => {
+    const result: TestResult = { name: testCase.name, status: 'failed' };
+    const schema = testCase.name.startsWith('schema:create_or_update_file')
+      ? CreateOrUpdateFileSchema
+      : PushFilesSchema;
+    const parsed = schema.safeParse(testCase.input);
+
+    if (testCase.shouldFail) {
+      result.status = parsed.success ? 'failed' : 'passed';
+      if (parsed.success) result.error = 'Expected schema validation to fail';
+    } else if (parsed.success) {
+      if (!testCase.check || testCase.check(parsed.data)) {
         result.status = 'passed';
       } else {
         result.error = `Unexpected parsed result: ${JSON.stringify(parsed.data)}`;
@@ -1658,6 +1751,7 @@ function runGitLabDependencyProxyBlobSchemaTests(): { passed: number; failed: nu
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const getFileContentsResult = runGetFileContentsSchemaTests();
+  const pushFilesResult = runPushFilesSchemaTests();
   const fileContentResult = runGitLabFileContentSchemaTests();
   const createPipelineResult = runCreatePipelineSchemaTests();
   const commitStatusResult = runCommitStatusSchemaTests();
@@ -1677,8 +1771,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const dependencyProxyResult = runGitLabDependencyProxySchemaTests();
   const dependencyProxyBlobResult = runGitLabDependencyProxyBlobSchemaTests();
 
-  const totalPassed = getFileContentsResult.passed + fileContentResult.passed + createPipelineResult.passed + commitStatusResult.passed + createIssueNoteResult.passed + getMergeRequestResult.passed + listMergeRequestPipelinesResult.passed + gitLabMergeRequestResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + approvedByUsernamesResult.passed + listLabelsResult.passed + treeItemResult.passed + repositoryTreeResult.passed + gitLabUserFullResult.passed + gitLabMarkdownUploadResult.passed + dependencyProxyResult.passed + dependencyProxyBlobResult.passed;
-  const totalFailed = getFileContentsResult.failed + fileContentResult.failed + createPipelineResult.failed + commitStatusResult.failed + createIssueNoteResult.failed + getMergeRequestResult.failed + listMergeRequestPipelinesResult.failed + gitLabMergeRequestResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + approvedByUsernamesResult.failed + listLabelsResult.failed + treeItemResult.failed + repositoryTreeResult.failed + gitLabUserFullResult.failed + gitLabMarkdownUploadResult.failed + dependencyProxyResult.failed + dependencyProxyBlobResult.failed;
+  const totalPassed = getFileContentsResult.passed + pushFilesResult.passed + fileContentResult.passed + createPipelineResult.passed + commitStatusResult.passed + createIssueNoteResult.passed + getMergeRequestResult.passed + listMergeRequestPipelinesResult.passed + gitLabMergeRequestResult.passed + emojiReactionResult.passed + repositorySchemaResult.passed + labelsCoercionResult.passed + approvedByUsernamesResult.passed + listLabelsResult.passed + treeItemResult.passed + repositoryTreeResult.passed + gitLabUserFullResult.passed + gitLabMarkdownUploadResult.passed + dependencyProxyResult.passed + dependencyProxyBlobResult.passed;
+  const totalFailed = getFileContentsResult.failed + pushFilesResult.failed + fileContentResult.failed + createPipelineResult.failed + commitStatusResult.failed + createIssueNoteResult.failed + getMergeRequestResult.failed + listMergeRequestPipelinesResult.failed + gitLabMergeRequestResult.failed + emojiReactionResult.failed + repositorySchemaResult.failed + labelsCoercionResult.failed + approvedByUsernamesResult.failed + listLabelsResult.failed + treeItemResult.failed + repositoryTreeResult.failed + gitLabUserFullResult.failed + gitLabMarkdownUploadResult.failed + dependencyProxyResult.failed + dependencyProxyBlobResult.failed;
 
   console.log(`\nTotal Results: ${totalPassed} passed, ${totalFailed} failed`);
 

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -196,6 +196,18 @@ function runPushFilesSchemaTests(): { passed: number; failed: number } {
       check: d => d.files[0].action === 'move' && d.files[0].previous_path === 'a.txt',
     },
     {
+      // schema permits move without previous_path (GitLab's API validates it);
+      // this documents that contract.
+      name: 'schema:push_files:move-without-previous-path-parses',
+      input: { ...base, files: [{ file_path: 'b.txt', action: 'move' }] },
+      check: d => d.files[0].action === 'move' && d.files[0].previous_path === undefined,
+    },
+    {
+      name: 'schema:push_files:explicit-text-encoding',
+      input: { ...base, files: [{ file_path: 'a.txt', content: 'hi', encoding: 'text' }] },
+      check: d => d.files[0].encoding === 'text',
+    },
+    {
       name: 'schema:push_files:reject-bad-action',
       input: { ...base, files: [{ file_path: 'a.txt', content: 'x', action: 'frobnicate' }] },
       shouldFail: true,


### PR DESCRIPTION
## What & why

`push_files` currently hardcodes `action: "create"` for every file, so it:

- errors with *"A file with this name already exists"* on any existing file (can't update),
- can't delete or move files, and
- treats all content as text, so committing **binary** files (images, etc.) is impossible.

I hit all three building a small project with this MCP (committing PNG logos and updating files in one commit).

## Changes

- **`push_files`** — each file entry gains optional fields:
  - `action`: `create` | `update` | `delete` | `move` (default `create`)
  - `encoding`: `text` | `base64` — base64 content is passed through untouched (binary-safe)
  - `previous_path` (for `move`); `content` is now optional (omit for `delete`)
- **`create_or_update_file`** — gains optional `encoding: "base64"` for binary files.

Defaults preserve existing behaviour — the global `GITLAB_REPO_FILE_ENCODING` toggle still works, and text commits are unchanged. The base64 path sends content straight to GitLab's commits/files API with `encoding: "base64"` instead of double-encoding it.

## Tests

Added `PushFilesSchema` / `CreateOrUpdateFileSchema` cases to `test/schema-tests.ts` (action / encoding / optional-content / move, plus rejection of invalid `action`/`encoding`). `npm run build` is clean and the schema suite reports **109 passed, 0 failed**.

Also verified end-to-end against a live GitLab: a PNG committed via `push_files` (`encoding: "base64"`) round-trips byte-for-byte (sha256 match), and `update` / `delete` actions work as expected.
