### PR TITLE
fix: rename GITLAB_ALLOWED_GROUPS to GITLAB_OAUTH_ALLOWED_GROUPS

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -187,7 +187,7 @@ MCP 서버가 직접 로컬 브라우저 callback을 받을 때만 `GITLAB_OAUTH
 | `STREAMABLE_HTTP` | 예 | 반드시 `true` |
 | `GITLAB_OAUTH_CALLBACK_PROXY` | 선택 | MCP 서버의 고정 `/callback` URL을 사용하려면 `true` |
 | `GITLAB_OAUTH_SCOPES` | 선택 | 쉼표로 구분된 scope 목록(기본값: `api,read_api,read_user`) |
-| `GITLAB_ALLOWED_GROUPS` | 선택 | 쉼표로 구분된 GitLab 그룹 전체 경로 — 해당 그룹 및 하위 그룹 멤버만 토큰을 발급받을 수 있음 |
+| `GITLAB_OAUTH_ALLOWED_GROUPS` | 선택 | 쉼표로 구분된 GitLab 그룹 전체 경로 — 해당 그룹 및 하위 그룹 멤버만 토큰을 발급받을 수 있음 (기존 `GITLAB_ALLOWED_GROUPS` 대체) |
 
 > **`Unregistered redirect_uri` 문제 해결**
 >

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ exchanging credentials with GitLab on behalf of the client.
 | `STREAMABLE_HTTP`     | ✅       | Must be `true`                                             |
 | `GITLAB_OAUTH_CALLBACK_PROXY` | optional | Set to `true` to use the MCP server's fixed `/callback` URL |
 | `GITLAB_OAUTH_SCOPES` | optional | Comma-separated scopes (default: `api,read_api,read_user`) |
-| `GITLAB_ALLOWED_GROUPS` | optional | Comma-separated group full paths — only members (and subgroup members) may obtain a token |
+| `GITLAB_OAUTH_ALLOWED_GROUPS` | optional | Comma-separated group full paths — only members (and subgroup members) may obtain a token (replaces deprecated `GITLAB_ALLOWED_GROUPS`) |
 
 When `STREAMABLE_HTTP=true`, server-side `GITLAB_PERSONAL_ACCESS_TOKEN` or `GITLAB_JOB_TOKEN` require `REMOTE_AUTHORIZATION=true` or `GITLAB_MCP_OAUTH=true`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -187,7 +187,7 @@ OpenCode、MCPJam、Claude.ai 等远程 MCP 客户端可能会在授权时发送
 | `STREAMABLE_HTTP` | 是 | 必须为 `true` |
 | `GITLAB_OAUTH_CALLBACK_PROXY` | 可选 | 设置为 `true` 时使用 MCP 服务器固定的 `/callback` URL |
 | `GITLAB_OAUTH_SCOPES` | 可选 | 逗号分隔的 scope（默认：`api,read_api,read_user`） |
-| `GITLAB_ALLOWED_GROUPS` | 可选 | 逗号分隔的 GitLab 群组完整路径 — 仅该群组及其子群组的成员可获取令牌 |
+| `GITLAB_OAUTH_ALLOWED_GROUPS` | 可选 | 逗号分隔的 GitLab 群组完整路径 — 仅该群组及其子群组的成员可获取令牌（替代已废弃的 `GITLAB_ALLOWED_GROUPS`）|
 
 > **排查 `Unregistered redirect_uri`**
 >

--- a/config.ts
+++ b/config.ts
@@ -84,8 +84,13 @@ export const GITLAB_OAUTH_SCOPES =
     : undefined;
 export const GITLAB_OAUTH_CALLBACK_PROXY =
   getConfig("oauth-callback-proxy", "GITLAB_OAUTH_CALLBACK_PROXY") === "true";
-export const GITLAB_ALLOWED_GROUPS: string[] | undefined = (() => {
-  const raw = getConfig("allowed-groups", "GITLAB_ALLOWED_GROUPS");
+/** @deprecated Use GITLAB_OAUTH_ALLOWED_GROUPS_RAW instead. Will be removed in the next major version. */
+export const GITLAB_ALLOWED_GROUPS_RAW = getConfig("allowed-groups", "GITLAB_ALLOWED_GROUPS");
+export const GITLAB_OAUTH_ALLOWED_GROUPS_RAW = getConfig("oauth-allowed-groups", "GITLAB_OAUTH_ALLOWED_GROUPS");
+export const GITLAB_OAUTH_ALLOWED_GROUPS = (() => {
+  const newVar = GITLAB_OAUTH_ALLOWED_GROUPS_RAW;
+  const oldVar = GITLAB_ALLOWED_GROUPS_RAW;
+  const raw = newVar ?? oldVar;
   if (!raw) return undefined;
   const groups = raw.split(",").map((g) => g.trim()).filter(Boolean);
   return groups.length > 0 ? groups : undefined;

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -120,7 +120,7 @@ Examples:
 - `api`
 - `api,read_user`
 
-### `GITLAB_ALLOWED_GROUPS`
+### `GITLAB_OAUTH_ALLOWED_GROUPS`
 
 Comma-separated list of GitLab group full paths. When set, only users who
 belong to at least one of these groups (or any of their subgroups) are allowed
@@ -128,6 +128,9 @@ to use the server. Users who authenticate successfully via OAuth but are not
 members of any matching group receive a `401 Access Denied` response.
 
 Requires `GITLAB_MCP_OAUTH=true`.
+
+> **Deprecation notice:** The old name `GITLAB_ALLOWED_GROUPS` is still accepted but will be
+> removed in a future major version. Migrate to `GITLAB_OAUTH_ALLOWED_GROUPS`.
 
 Examples:
 

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,9 @@ import {
   USE_PIPELINE,
   GITLAB_TOOL_POLICY_APPROVE_RAW,
   GITLAB_TOOL_POLICY_HIDDEN_RAW,
-  GITLAB_ALLOWED_GROUPS,
+  GITLAB_OAUTH_ALLOWED_GROUPS_RAW,
+  GITLAB_ALLOWED_GROUPS_RAW,
+  GITLAB_OAUTH_ALLOWED_GROUPS,
 } from "./config.js";
 
 /** True when the server is running in remote/network mode (SSE or StreamableHTTP transport). */
@@ -12244,7 +12246,7 @@ async function startStreamableHTTPServer(): Promise<void> {
       "GitLab MCP Server",
       GITLAB_READ_ONLY_MODE,
       GITLAB_OAUTH_SCOPES,
-      GITLAB_ALLOWED_GROUPS,
+      GITLAB_OAUTH_ALLOWED_GROUPS,
       GITLAB_OAUTH_CALLBACK_PROXY,
       callbackUrl,
       statelessOptions
@@ -12796,6 +12798,18 @@ async function runServer() {
 
     logger.info(`Configured GitLab API URLs: ${GITLAB_API_URLS.join(", ")}`);
     logger.info(`Default GitLab API URL: ${GITLAB_API_URL}`);
+
+    if (GITLAB_ALLOWED_GROUPS_RAW) {
+      if (GITLAB_OAUTH_ALLOWED_GROUPS_RAW) {
+        logger.warn("GITLAB_ALLOWED_GROUPS is set but ignored — GITLAB_OAUTH_ALLOWED_GROUPS takes precedence.");
+      } else {
+        logger.warn("GITLAB_ALLOWED_GROUPS is deprecated. Use GITLAB_OAUTH_ALLOWED_GROUPS instead.");
+      }
+    }
+
+    if (GITLAB_OAUTH_ALLOWED_GROUPS) {
+      logger.info(`Group access control enabled for: ${GITLAB_OAUTH_ALLOWED_GROUPS.join(", ")}`);
+    }
   } catch (error) {
     logger.error("Error initializing server:", error);
     process.exit(1);

--- a/test/config-allowed-groups.test.ts
+++ b/test/config-allowed-groups.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for GITLAB_OAUTH_ALLOWED_GROUPS config resolution.
+ *
+ * Verifies that:
+ *   - The new GITLAB_OAUTH_ALLOWED_GROUPS env var is preferred when set.
+ *   - The deprecated GITLAB_ALLOWED_GROUPS is accepted as a fallback and
+ *     sets the deprecation flag so callers can emit a warning.
+ *   - When both are set, the new var wins and GITLAB_ALLOWED_GROUPS_RAW remains
+ *     set, so callers can emit a "set but ignored" warning.
+ *
+ * config.ts reads process.env at module load, so each scenario runs in a
+ * fresh child process — same pattern as test/stateless/config-ttl.test.ts.
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import * as url from "node:url";
+import { describe, test } from "node:test";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const CONFIG_PATH = path.resolve(__dirname, "../config.ts");
+
+interface ConfigSnapshot {
+  GITLAB_OAUTH_ALLOWED_GROUPS: string[] | null;
+  GITLAB_OAUTH_ALLOWED_GROUPS_RAW: string | null;
+  GITLAB_ALLOWED_GROUPS_RAW: string | null;
+}
+
+function loadConfig(env: Record<string, string | undefined>): ConfigSnapshot {
+  const script = `
+    import(${JSON.stringify(url.pathToFileURL(CONFIG_PATH).href)}).then((m) => {
+      const out = {
+        GITLAB_OAUTH_ALLOWED_GROUPS: m.GITLAB_OAUTH_ALLOWED_GROUPS ?? null,
+        GITLAB_OAUTH_ALLOWED_GROUPS_RAW: m.GITLAB_OAUTH_ALLOWED_GROUPS_RAW ?? null,
+        GITLAB_ALLOWED_GROUPS_RAW: m.GITLAB_ALLOWED_GROUPS_RAW ?? null,
+      };
+      process.stdout.write(JSON.stringify(out));
+    }).catch((err) => {
+      process.stderr.write(String(err && err.stack || err));
+      process.exit(2);
+    });
+  `;
+
+  const childEnv: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+  };
+  delete childEnv.GITLAB_OAUTH_ALLOWED_GROUPS;
+  delete childEnv.GITLAB_ALLOWED_GROUPS;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) {
+      delete childEnv[k];
+    } else {
+      childEnv[k] = v;
+    }
+  }
+
+  const stdout = execFileSync(
+    process.execPath,
+    ["--import", "tsx/esm", "--input-type=module", "--eval", script],
+    { env: childEnv, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+  );
+  return JSON.parse(stdout) as ConfigSnapshot;
+}
+
+describe("config.ts — GITLAB_OAUTH_ALLOWED_GROUPS resolution", () => {
+  test("neither var set — resolved value and raws are null", () => {
+    const cfg = loadConfig({});
+    assert.equal(cfg.GITLAB_OAUTH_ALLOWED_GROUPS, null);
+    assert.equal(cfg.GITLAB_OAUTH_ALLOWED_GROUPS_RAW, null);
+    assert.equal(cfg.GITLAB_ALLOWED_GROUPS_RAW, null);
+  });
+
+  test("only new var set — resolved correctly, deprecated raw is null", () => {
+    const cfg = loadConfig({ GITLAB_OAUTH_ALLOWED_GROUPS: "my-org" });
+    assert.deepEqual(cfg.GITLAB_OAUTH_ALLOWED_GROUPS, ["my-org"]);
+    assert.equal(cfg.GITLAB_OAUTH_ALLOWED_GROUPS_RAW, "my-org");
+    assert.equal(cfg.GITLAB_ALLOWED_GROUPS_RAW, null);
+  });
+
+  test("only deprecated var set — resolved via fallback, deprecated raw is set", () => {
+    const cfg = loadConfig({ GITLAB_ALLOWED_GROUPS: "my-org" });
+    assert.deepEqual(cfg.GITLAB_OAUTH_ALLOWED_GROUPS, ["my-org"]);
+    assert.equal(cfg.GITLAB_ALLOWED_GROUPS_RAW, "my-org");
+    assert.equal(cfg.GITLAB_OAUTH_ALLOWED_GROUPS_RAW, null);
+  });
+
+  test("both vars set — new var wins, both raws are set (triggers 'set but ignored' warning)", () => {
+    const cfg = loadConfig({
+      GITLAB_OAUTH_ALLOWED_GROUPS: "new-org",
+      GITLAB_ALLOWED_GROUPS: "old-org",
+    });
+    assert.deepEqual(cfg.GITLAB_OAUTH_ALLOWED_GROUPS, ["new-org"]);
+    assert.equal(cfg.GITLAB_OAUTH_ALLOWED_GROUPS_RAW, "new-org");
+    assert.equal(cfg.GITLAB_ALLOWED_GROUPS_RAW, "old-org");
+  });
+
+  test("comma-separated values are split and trimmed", () => {
+    const cfg = loadConfig({
+      GITLAB_OAUTH_ALLOWED_GROUPS: "my-org/team-a , my-org/team-b , my-org",
+    });
+    assert.deepEqual(cfg.GITLAB_OAUTH_ALLOWED_GROUPS, [
+      "my-org/team-a",
+      "my-org/team-b",
+      "my-org",
+    ]);
+  });
+
+  test("empty string resolves to null", () => {
+    const cfg = loadConfig({ GITLAB_OAUTH_ALLOWED_GROUPS: "" });
+    assert.equal(cfg.GITLAB_OAUTH_ALLOWED_GROUPS, null);
+  });
+
+  test("whitespace-only entries are filtered out", () => {
+    const cfg = loadConfig({ GITLAB_OAUTH_ALLOWED_GROUPS: " , , " });
+    assert.equal(cfg.GITLAB_OAUTH_ALLOWED_GROUPS, null);
+  });
+});


### PR DESCRIPTION
## Summary

- Renames `GITLAB_ALLOWED_GROUPS` to `GITLAB_OAUTH_ALLOWED_GROUPS` to follow the existing `GITLAB_OAUTH_*` naming convention and make its OAuth-only scope explicit (closes zereight/gitlab-mcp#514)
- The old name is still accepted with a backwards-compatible fallback; a `logger.warn` deprecation notice is printed at startup. Will be removed in the next major version.
- Adds a startup log `"Group access control enabled for: <groups>"` when the config is set, consistent with other startup banners
- Updates docs/environment-variables.md, README.md, README.ko.md, README.zh-CN.md
- Adds unit tests covering the env var resolution logic (new var preferred, deprecated fallback, both set, comma parsing, empty/whitespace edge cases)
