### PR TITLE
Fix/rate limit ip port

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11844,6 +11844,11 @@ function registerDownloadProxy(
  */
 async function startSSEServer(): Promise<void> {
   const app = express();
+
+  if (MCP_TRUST_PROXY) {
+    app.set("trust proxy", 1);
+  }
+
   const transports: { [sessionId: string]: SSEServerTransport } = {};
   let shuttingDown = false;
 

--- a/index.ts
+++ b/index.ts
@@ -12389,7 +12389,7 @@ async function startStreamableHTTPServer(): Promise<void> {
     // express-rate-limit throw ERR_ERL_INVALID_IP_ADDRESS. Strip the port first, then
     // delegate to ipKeyGenerator for correct IPv6 subnet handling.
     const rateLimitKeyGenerator = (req: Request) =>
-      ipKeyGenerator((req.ip ?? "").replace(/:\d+$/, ""));
+      ipKeyGenerator((req.ip ?? "").replace(/^(\d+\.\d+\.\d+\.\d+):\d+$/, "$1"));
     const rateLimitOptions = { keyGenerator: rateLimitKeyGenerator };
     app.use(
       mcpAuthRouter({

--- a/index.ts
+++ b/index.ts
@@ -244,6 +244,7 @@ import { z } from "zod";
 import { initializeOAuthClient, GitLabOAuth } from "./oauth.js";
 import { createGitLabOAuthProvider } from "./oauth-proxy.js";
 import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { ipKeyGenerator } from "express-rate-limit";
 import { normalizeGitLabApiUrl } from "./utils/url.js";
 import { estimateMergeCommitCount, filterDiffsByPatterns, summarizeWebhookEvents } from "./utils/helpers.js";
 import { graphqlQueryContainsWriteOperation } from "./utils/graphql-query.js";
@@ -12384,6 +12385,12 @@ async function startStreamableHTTPServer(): Promise<void> {
 
     // Mounts /.well-known/oauth-authorization-server (shadowed above when basePath set),
     //        /.well-known/oauth-protected-resource, /authorize, /token, /register, /revoke
+    // Some proxies include the port in X-Forwarded-For (e.g. "1.2.3.4:5678"), which makes
+    // express-rate-limit throw ERR_ERL_INVALID_IP_ADDRESS. Strip the port first, then
+    // delegate to ipKeyGenerator for correct IPv6 subnet handling.
+    const rateLimitKeyGenerator = (req: Request) =>
+      ipKeyGenerator((req.ip ?? "").replace(/:\d+$/, ""));
+    const rateLimitOptions = { keyGenerator: rateLimitKeyGenerator };
     app.use(
       mcpAuthRouter({
         provider: oauthProvider,
@@ -12391,6 +12398,10 @@ async function startStreamableHTTPServer(): Promise<void> {
         baseUrl: issuerUrl,
         scopesSupported,
         resourceName: "GitLab MCP Server",
+        authorizationOptions: { rateLimit: rateLimitOptions },
+        tokenOptions: { rateLimit: rateLimitOptions },
+        revocationOptions: { rateLimit: rateLimitOptions },
+        clientRegistrationOptions: { rateLimit: rateLimitOptions },
       })
     );
 

--- a/index.ts
+++ b/index.ts
@@ -12393,7 +12393,7 @@ async function startStreamableHTTPServer(): Promise<void> {
       ipKeyGenerator(
         (req.ip ?? "")
           .replace(/^(\d+\.\d+\.\d+\.\d+):\d+$/, "$1")
-          .replace(/^\[([^\]]+)\]:\d+$/, "$1"),
+          .replace(/^\[([^\]]+)\](?::\d+)?$/, "$1"),
       );
     const rateLimitOptions = { keyGenerator: rateLimitKeyGenerator };
     app.use(

--- a/index.ts
+++ b/index.ts
@@ -12385,11 +12385,16 @@ async function startStreamableHTTPServer(): Promise<void> {
 
     // Mounts /.well-known/oauth-authorization-server (shadowed above when basePath set),
     //        /.well-known/oauth-protected-resource, /authorize, /token, /register, /revoke
-    // Some proxies include the port in X-Forwarded-For (e.g. "1.2.3.4:5678"), which makes
-    // express-rate-limit throw ERR_ERL_INVALID_IP_ADDRESS. Strip the port first, then
-    // delegate to ipKeyGenerator for correct IPv6 subnet handling.
+    // Some proxies include the port in X-Forwarded-For (e.g. "1.2.3.4:5678" or
+    // "[2001:db8::1]:5678"), which makes express-rate-limit throw
+    // ERR_ERL_INVALID_IP_ADDRESS. Strip the port first, then delegate to
+    // ipKeyGenerator for correct IPv6 subnet handling.
     const rateLimitKeyGenerator = (req: Request) =>
-      ipKeyGenerator((req.ip ?? "").replace(/^(\d+\.\d+\.\d+\.\d+):\d+$/, "$1"));
+      ipKeyGenerator(
+        (req.ip ?? "")
+          .replace(/^(\d+\.\d+\.\d+\.\d+):\d+$/, "$1")
+          .replace(/^\[([^\]]+)\]:\d+$/, "$1"),
+      );
     const rateLimitOptions = { keyGenerator: rateLimitKeyGenerator };
     app.use(
       mcpAuthRouter({


### PR DESCRIPTION
## Problem

PR #508 introduced two regressions for OAuth deployments behind a reverse proxy:

1. **Breaking change**: `app.set("trust proxy", 1)` was previously unconditional in OAuth mode. #508 made it opt-in via `MCP_TRUST_PROXY=true` with no migration note. Any existing OAuth+proxy deployment now gets `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` from express-rate-limit on every request, causing auth handshake failures and connection drops.

2. **ip:port in X-Forwarded-For**: Some proxies (e.g. AWS NLB on EKS) include the source port in `X-Forwarded-For` (e.g. `160.79.106.36:38914`). With trust proxy enabled, Express sets `request.ip` to this value, causing express-rate-limit to throw `ERR_ERL_INVALID_IP_ADDRESS` on every OAuth endpoint request (`/authorize`, `/token`, `/register`, `/revoke`).

3. **Missed transport**: `startSSEServer` was not updated to respect `MCP_TRUST_PROXY` — only `startStreamableHTTPServer` got the fix from #508.

## Fix

- Pass a custom `keyGenerator` to all OAuth rate limiters that strips the port before delegating to `ipKeyGenerator` for correct IPv6 subnet handling
- Apply `MCP_TRUST_PROXY` in `startSSEServer` to keep both transport modes consistent

## Testing

Verified with a focused test simulating `trust proxy=1` + `X-Forwarded-For: ip:port`:

- **Without fix**: `ERR_ERL_INVALID_IP_ADDRESS` thrown per-request
- **With fix**: no validation errors across IPv4+port, plain IPv4, and IPv6

> [!WARNING]
> If you were running OAuth mode behind a reverse proxy before #508 and haven't set `MCP_TRUST_PROXY=true` yet, add it to your deployment — the old implicit trust proxy behaviour is gone.