### PR TITLE
chore(docker): add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@
 !.npmrc
 # Ignore test files
 test*.ts
+test
+mcp-server/test

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Ignore all files by default
+*
+# Include specific files and directories
+!*.ts
+!mcp-server
+!package-lock.json
+!package.json
+!stateless
+!tools
+!tsconfig.json
+!utils
+!.npmrc
+# Ignore test files
+test*.ts


### PR DESCRIPTION
I added a [`.dockerignore` file](https://docs.docker.com/build/concepts/context/#dockerignore-files) to

1. reduce the size of the build context,
2. keep files like `test-note.js` out of the final container image