### PR TITLE
docs: document GitHub Actions Pages source for MkDocs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,10 @@ jobs:
         run: pip install -r requirements-docs.txt
 
       - name: Build site
-        run: mkdocs build --strict
+        run: |
+          mkdocs build --strict
+          # Prevent Jekyll processing if legacy Pages ever reads the artifact
+          touch site/.nojekyll
 
       - name: Upload Pages artifact
         # actions/upload-pages-artifact@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,12 @@ make tools-docs
 and commit the regenerated files alongside your code change. The docs CI
 workflow ([`.github/workflows/docs.yml`](.github/workflows/docs.yml))
 rebuilds and deploys the site on every push to `main` that touches `docs/`,
-`mkdocs.yml`, or `requirements-docs.txt`.
+`mkdocs.yml`, `requirements-docs.txt`, `tools/registry.ts`, `schemas.ts`,
+or `scripts/generate-tool-docs.ts`.
+
+**Hosted site (maintainers, one-time):** GitHub Pages must use
+**Build and deployment → Source: GitHub Actions**, not deploy from `main`.
+See [`docs/reference/github-pages-setup.md`](docs/reference/github-pages-setup.md).
 
 **When changing prose docs:**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [English](./README.md) | [한국어](./README.ko.md) | [简体中文](./README.zh-CN.md)
 
-📖 **[Read the full documentation →](https://zereight.github.io/gitlab-mcp/)**
+📖 **[Read the full documentation →](https://zereight.github.io/gitlab-mcp/)** — MkDocs Material site deployed by [`.github/workflows/docs.yml`](.github/workflows/docs.yml).
+
+**Maintainers / forks:** set **Settings → Pages → Source: GitHub Actions** (not deploy from `main`), then run **Deploy Documentation** or push a docs change. Legacy branch deploy serves Jekyll (no tabs/search). Details: [GitHub Pages Setup](docs/reference/github-pages-setup.md).
 
 > **New Feature**: Dynamic GitLab API URL support with connection pooling! See [Dynamic API URL Documentation](docs/configuration/dynamic-api-url.md) for details.
 
@@ -36,6 +38,7 @@ Quick start: choose either Personal Access Token or OAuth2 setup below and use `
 - [Environment Variables Reference](./docs/configuration/environment-variables.md)
 - [Stateless Mode — Multi-Pod HPA](./docs/configuration/stateless-mode.md)
 - [Custom Agents and Multiple PAT Setup](./docs/auth/custom-agent-multiple-pat.md)
+- [GitHub Pages Setup (MkDocs deploy)](./docs/reference/github-pages-setup.md)
 
 ## Usage
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -182,7 +182,13 @@ make tools-docs
 
 and commit the regenerated files alongside your code change. The docs CI
 workflow rebuilds and deploys the site on every push to `main` that touches
-`docs/`, `mkdocs.yml`, or `requirements-docs.txt`.
+`docs/`, `mkdocs.yml`, `requirements-docs.txt`, `tools/registry.ts`,
+`schemas.ts`, or `scripts/generate-tool-docs.ts`.
+
+**Hosted site (maintainers, one-time):** GitHub Pages must use
+**Build and deployment → Source: GitHub Actions**, not deploy from `main`.
+See [GitHub Pages Setup](reference/github-pages-setup.md) for details and
+verification steps.
 
 **When changing prose docs:**
 

--- a/docs/reference/github-pages-setup.md
+++ b/docs/reference/github-pages-setup.md
@@ -1,0 +1,55 @@
+# GitHub Pages Setup (MkDocs)
+
+The documentation site at [zereight.github.io/gitlab-mcp](https://zereight.github.io/gitlab-mcp/)
+is built with **MkDocs Material** and deployed by the
+[`Deploy Documentation`](https://github.com/zereight/gitlab-mcp/actions/workflows/docs.yml)
+GitHub Actions workflow (`.github/workflows/docs.yml`).
+
+## One-time repository setup
+
+After merging the MkDocs site workflow, enable **GitHub Actions** as the Pages
+source (this is **not** stored in git):
+
+1. Open **Settings → Pages** for the repository.
+2. Under **Build and deployment**, set **Source** to **GitHub Actions**.
+3. Do **not** use **Deploy from a branch** (`main` / `/`). That legacy mode runs
+   Jekyll over `README.md` and `docs/*.md`, which replaces the MkDocs output
+   (no navigation tabs, no search, flat `docs/...html` URLs).
+
+4. Trigger a deploy:
+   - **Actions → Deploy Documentation → Run workflow**, or
+   - Push a commit that touches `docs/`, `mkdocs.yml`, `requirements-docs.txt`,
+     `tools/registry.ts`, `schemas.ts`, or `scripts/generate-tool-docs.ts`.
+
+## How deployment works
+
+| Step | What happens |
+|------|----------------|
+| Trigger | Push to `main` (paths above) or `workflow_dispatch` |
+| Build | `mkdocs build --strict` → `site/` |
+| Publish | `actions/deploy-pages` uploads the artifact to GitHub Pages |
+
+Local preview (same theme as the hosted site):
+
+```bash
+make serve    # http://127.0.0.1:8000/gitlab-mcp/
+make build    # strict build, same as CI
+```
+
+## Verify the live site
+
+A successful MkDocs deploy should show:
+
+- **Material theme** navigation tabs (Home, Getting Started, Tools, …)
+- Site search in the header
+- URLs like `/gitlab-mcp/getting-started/` (not only `/gitlab-mcp/docs/getting-started/index.html`)
+- Page source **without** `generator: Jekyll`
+
+If you still see Jekyll or a README-style homepage, Pages is likely still on
+**Deploy from a branch**. Switch to **GitHub Actions** and re-run the workflow.
+
+## Forks
+
+Forks need the same **Settings → Pages → GitHub Actions** step. The workflow
+file ships with the repo, but GitHub does not enable Actions-based Pages
+automatically for every fork.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
   - Reference:
       - GitHub Secrets Setup: reference/setup-github-secrets.md
       - Dependency Proxy Design: reference/dependency-proxy-design.md
+      - GitHub Pages Setup: reference/github-pages-setup.md
   - Contributing: contributing.md
 
 extra:


### PR DESCRIPTION
## Summary
- Add `docs/reference/github-pages-setup.md` with one-time **Settings → Pages → GitHub Actions** instructions and live-site verification steps
- Document the requirement in `CONTRIBUTING.md` and `docs/contributing.md`
- Harden `docs.yml` by writing `site/.nojekyll` after `mkdocs build --strict`

## Context
#499 merged the MkDocs workflow, but the hosted site stayed on legacy Jekyll until Pages source was switched to GitHub Actions. This PR captures that setup in-repo so maintainers and forks do not repeat the misconfiguration.

## Test plan
- [x] `mkdocs build --strict` passes locally
- [ ] After merge: confirm `Deploy Documentation` workflow runs and https://zereight.github.io/gitlab-mcp/ shows Material tabs/search (not Jekyll)


Made with [Cursor](https://cursor.com)