### PR TITLE
fix: add express-rate-limit v8 as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node-fetch": "^2.6.12",
         "diff": "^9.0.0",
         "express": "^5.1.0",
-        "express-rate-limit": "^8.0.0",
+        "express-rate-limit": "^8.5.2",
         "fetch-cookie": "^3.1.0",
         "form-data": "^4.0.0",
         "http-proxy-agent": "^7.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/node-fetch": "^2.6.12",
         "diff": "^9.0.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.0",
         "fetch-cookie": "^3.1.0",
         "form-data": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
@@ -2330,9 +2331,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
-      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/node-fetch": "^2.6.12",
     "diff": "^9.0.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.0",
     "fetch-cookie": "^3.1.0",
     "form-data": "^4.0.0",
     "http-proxy-agent": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/node-fetch": "^2.6.12",
     "diff": "^9.0.0",
     "express": "^5.1.0",
-    "express-rate-limit": "^8.0.0",
+    "express-rate-limit": "^8.5.2",
     "fetch-cookie": "^3.1.0",
     "form-data": "^4.0.0",
     "http-proxy-agent": "^7.0.2",


### PR DESCRIPTION
## Summary
- Add `express-rate-limit@^8.0.0` as a direct dependency so `ipKeyGenerator` (introduced in PR #519) resolves at install time.
- Prevents startup `SyntaxError` when npm hoists transitive `express-rate-limit@7.x` from `@modelcontextprotocol/sdk`.

Fixes #525

## Test plan
- [x] `npm run build`
- [x] `node --import tsx/esm --test test/utils/proxy-client-ip.test.ts`
- [x] `npm ls express-rate-limit` shows direct v8 dependency
- [ ] `npx -y @zereight/mcp-gitlab@<this-branch>` starts without `ipKeyGenerator` import error (after publish)


Made with [Cursor](https://cursor.com)