### PR TITLE
feat(namespaces): add parent_id to verify_namespace

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -53,7 +53,7 @@ Project/namespace listing, member queries, group iterations, and server health. 
 | [`list_project_members`](projects.md#list_project_members) | List members of a GitLab project | 📖 |
 | [`list_namespaces`](projects.md#list_namespaces) | List all namespaces (users and groups) available to the current user. Filter by kind='group' for groups only. | 📖 |
 | [`get_namespace`](projects.md#get_namespace) | Get details of a namespace (user or group) by ID or path. Groups are namespaces with kind='group'. | 📖 |
-| [`verify_namespace`](projects.md#verify_namespace) | Verify if a namespace path exists | 📖 |
+| [`verify_namespace`](projects.md#verify_namespace) | Verify if a namespace path exists. Use parent_id to scope the check to a specific parent namespace — required for nested namespaces where the same path may exist under different parents. | 📖 |
 | [`list_group_projects`](projects.md#list_group_projects) | List projects in a group | 📖 |
 | [`list_group_iterations`](projects.md#list_group_iterations) | List group iterations with filtering options | 📖 |
 | [`health_check`](projects.md#health_check) | Verify server status and authentication | 📖 |

--- a/docs/tools/issues.md
+++ b/docs/tools/issues.md
@@ -92,7 +92,7 @@ List issues assigned to the authenticated user
 
 | Parameter | Type | Required | Description |
 |---|---|:-:|---|
-| `project_id` | string |  | Project ID or URL-encoded path (optional when GITLAB_PROJECT_ID is set) |
+| `project_id` | string |  | Project ID or URL-encoded path (optional to search across all accessible projects) |
 | `state` | enum (`opened` \| `closed` \| `all`) |  | Return issues with a specific state (default: opened) |
 | `labels` | array<string> |  | Array of label names to filter by |
 | `milestone` | string |  | Milestone title to filter by |

--- a/docs/tools/projects.md
+++ b/docs/tools/projects.md
@@ -103,13 +103,14 @@ Get details of a namespace (user or group) by ID or path. Groups are namespaces 
 
 *📖 Read-only*
 
-Verify if a namespace path exists
+Verify if a namespace path exists. Use parent_id to scope the check to a specific parent namespace — required for nested namespaces where the same path may exist under different parents.
 
 **Parameters**
 
 | Parameter | Type | Required | Description |
 |---|---|:-:|---|
 | `path` | string | ✓ | Namespace path to verify |
+| `parent_id` | integer |  | Parent namespace ID; required to correctly resolve paths in nested namespaces where the same path may exist under different parents |
 
 ### `list_group_projects`
 

--- a/index.ts
+++ b/index.ts
@@ -9749,6 +9749,7 @@ async function handleToolCall(params: any) {
       case "verify_namespace": {
         const args = VerifyNamespaceSchema.parse(params.arguments);
         const url = new URL(`${GITLAB_API_URL}/namespaces/${encodeURIComponent(args.path)}/exists`);
+        if (args.parent_id !== undefined) url.searchParams.set("parent_id", String(args.parent_id));
 
         const response = await fetch(url.toString(), {
           ...getFetchConfig(),

--- a/index.ts
+++ b/index.ts
@@ -8009,8 +8009,12 @@ async function myIssues(options: MyIssuesOptions = {}): Promise<GitLabIssue[]> {
   // Get current user to find their username
   const currentUser = await getCurrentUser();
 
-  // Use getEffectiveProjectId to handle project ID resolution
-  const effectiveProjectId = getEffectiveProjectId(options.project_id || "");
+  let effectiveProjectId: string;
+  try {
+    effectiveProjectId = getEffectiveProjectId(options.project_id || "");
+  } catch {
+    effectiveProjectId = "";
+  }
 
   // Use listIssues with assignee_username filter
   let listIssuesOptions: Omit<z.infer<typeof ListIssuesSchema>, "project_id"> = {

--- a/index.ts
+++ b/index.ts
@@ -8012,8 +8012,12 @@ async function myIssues(options: MyIssuesOptions = {}): Promise<GitLabIssue[]> {
   let effectiveProjectId: string;
   try {
     effectiveProjectId = getEffectiveProjectId(options.project_id || "");
-  } catch {
-    effectiveProjectId = "";
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("No project ID provided and GITLAB_PROJECT_ID is not set")) {
+      effectiveProjectId = "";
+    } else {
+      throw err;
+    }
   }
 
   // Use listIssues with assignee_username filter

--- a/schemas.ts
+++ b/schemas.ts
@@ -2301,6 +2301,7 @@ export const GetNamespaceSchema = z.object({
 
 export const VerifyNamespaceSchema = z.object({
   path: z.string().describe("Namespace path to verify"),
+  parent_id: z.coerce.number().int().optional().describe("Parent namespace ID; required to correctly resolve paths in nested namespaces where the same path may exist under different parents"),
 });
 
 // Project API operation schemas

--- a/schemas.ts
+++ b/schemas.ts
@@ -2973,7 +2973,7 @@ export const MyIssuesSchema = z.object({
   project_id: z
     .string()
     .optional()
-    .describe("Project ID or URL-encoded path (optional when GITLAB_PROJECT_ID is set)"),
+    .describe("Project ID or URL-encoded path (optional to search across all accessible projects)"),
   state: z
     .enum(["opened", "closed", "all"])
     .optional()

--- a/schemas.ts
+++ b/schemas.ts
@@ -2301,7 +2301,7 @@ export const GetNamespaceSchema = z.object({
 
 export const VerifyNamespaceSchema = z.object({
   path: z.string().describe("Namespace path to verify"),
-  parent_id: z.coerce.number().int().optional().describe("Parent namespace ID; required to correctly resolve paths in nested namespaces where the same path may exist under different parents"),
+  parent_id: z.preprocess(val => (val === "" ? undefined : val), z.number().int().optional()).describe("Parent namespace ID; required to correctly resolve paths in nested namespaces where the same path may exist under different parents"),
 });
 
 // Project API operation schemas

--- a/tools/registry.ts
+++ b/tools/registry.ts
@@ -639,7 +639,7 @@ export const allTools = [
   },
   {
     name: "verify_namespace",
-    description: "Verify if a namespace path exists",
+    description: "Verify if a namespace path exists. Use parent_id to scope the check to a specific parent namespace — required for nested namespaces where the same path may exist under different parents.",
     inputSchema: toJSONSchema(VerifyNamespaceSchema),
   },
   {


### PR DESCRIPTION
## Summary

- **`verify_namespace`**: exposes the `parent_id` query parameter supported by the GitLab
  `/namespaces/:path/exists` API. Without it, the existence check is ambiguous for nested
  namespaces — the same path segment (e.g. `frontend`) can exist under multiple parent groups
  and GitLab returns whichever it finds first. Passing `parent_id` scopes the check correctly.

- **`my_issues`**: fixes a system bug where calling the tool without a `project_id` always
  threw `"No project ID provided and GITLAB_PROJECT_ID is not set"` — even though the parameter
  is optional per the schema. The LLM was behaving correctly; the code was not. `getEffectiveProjectId`
  is now wrapped in a try/catch: if it resolves (via explicit arg or `GITLAB_PROJECT_ID` env var)
  the query is scoped to that project; if not, it falls back to the global `/issues` endpoint
  filtered to the current user.

## Changes

- `schemas.ts` — adds optional `parent_id: number` to `VerifyNamespaceSchema`; clarifies
  `my_issues` `project_id` description to reflect it is truly optional
- `index.ts` — appends `parent_id` query param in `verify_namespace` handler; wraps
  `getEffectiveProjectId` in `myIssues` with a fallback to empty string (global endpoint)
- `tools/registry.ts` — updates `verify_namespace` tool description to document `parent_id`
