### PR TITLE
fix(schemas): expose merge_user and merged_by on merge request responses

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -1180,6 +1180,8 @@ export const GitLabMergeRequestSchema = z.object({
   merged_at: z.string().nullable(),
   closed_at: z.string().nullable(),
   merge_commit_sha: z.string().nullable(),
+  merge_user: GitLabUserSchema.nullable().optional().describe("User who performed the merge (GitLab API v4 field)"),
+  merged_by: GitLabUserSchema.nullable().optional().describe("Deprecated alias for merge_user, kept for backwards compatibility"),
   detailed_merge_status: z.string().optional(),
   merge_status: z.string().optional(),
   merge_error: z.string().nullable().optional(),

--- a/test/schema-tests.ts
+++ b/test/schema-tests.ts
@@ -898,6 +898,61 @@ function runGitLabMergeRequestSchemaTests(): { passed: number; failed: number } 
       },
       validate: (data: Record<string, any>) => data.labels === undefined,
     },
+    {
+      name: 'schema:gitlab_merge_request:preserves-merge-user',
+      input: {
+        ...baseMergeRequest,
+        state: 'merged',
+        merged_at: '2026-05-08T00:00:00.000Z',
+        merge_commit_sha: 'abc123',
+        merge_user: {
+          id: '7',
+          username: 'merger',
+          name: 'Merge Bot',
+          avatar_url: null,
+          web_url: 'https://gitlab.example.com/merger',
+        },
+      },
+      validate: (data: Record<string, any>) =>
+        data.merge_user?.id === '7' &&
+        data.merge_user?.username === 'merger' &&
+        data.merge_user?.name === 'Merge Bot',
+    },
+    {
+      name: 'schema:gitlab_merge_request:preserves-merged-by',
+      input: {
+        ...baseMergeRequest,
+        state: 'merged',
+        merged_by: {
+          id: '8',
+          username: 'legacy-merger',
+          name: 'Legacy Merger',
+          avatar_url: null,
+          web_url: 'https://gitlab.example.com/legacy-merger',
+        },
+      },
+      validate: (data: Record<string, any>) =>
+        data.merged_by?.id === '8' &&
+        data.merged_by?.username === 'legacy-merger',
+    },
+    {
+      name: 'schema:gitlab_merge_request:allows-null-merge-user',
+      input: {
+        ...baseMergeRequest,
+        merge_user: null,
+        merged_by: null,
+      },
+      validate: (data: Record<string, any>) =>
+        data.merge_user === null && data.merged_by === null,
+    },
+    {
+      name: 'schema:gitlab_merge_request:allows-omitted-merge-user',
+      input: {
+        ...baseMergeRequest,
+      },
+      validate: (data: Record<string, any>) =>
+        data.merge_user === undefined && data.merged_by === undefined,
+    },
   ];
 
   let passed = 0;


### PR DESCRIPTION
## Problem

Fixes #476.

`GitLabMergeRequestSchema` parses strictly (no `.passthrough()`), so the `merge_user` / `merged_by` user objects returned by the GitLab API were silently stripped at `.parse()` time. There was no way to determine **who** merged an MR — `merged_at` and `merge_commit_sha` were present, but the merging user was lost.

## Fix

Add `merge_user` and `merged_by` to `GitLabMergeRequestSchema`, reusing the existing `GitLabUserSchema` (consistent with how `author` / `assignees` / `reviewers` are defined) as `nullable().optional()`:

- `merge_user` — current GitLab API v4 field for the user who performed the merge
- `merged_by` — deprecated alias GitLab still returns for backwards compatibility

The schema is shared by `get_merge_request` **and** `list_merge_requests`, so both tools now surface these fields.

I chose the targeted field addition over `.passthrough()` (the issue's alternative suggestion) to avoid changing strict-parsing behavior across the whole schema.

## Verification

- Field names and structure verified against the [official GitLab merge requests API docs](https://docs.gitlab.com/api/merge_requests/): `merge_user` is an object (`id`, `name`, `username`, `state`, `avatar_url`, `web_url`); `merged_by` is the deprecated alias (GitLab 14.7, removal scheduled for API v5).
- `npm run build` passes (clean `tsc`).
- Added 4 unit tests to `test/schema-tests.ts` (preserves `merge_user`, preserves `merged_by`, allows null, allows omitted) — all pass.

## Note

`GitLabUserSchema` does not declare the `state` sub-field, so `merge_user.state` is not surfaced — but this is consistent with the existing `author` / `assignees` / `reviewers` handling, and not a regression. Happy to add `state` to `GitLabUserSchema` (affects all user objects) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)