### PR TITLE
fix: compact tool response JSON

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -830,7 +830,7 @@ function createServer(): McpServer {
           return logCompletion({
             content: [{
               type: "text",
-              text: JSON.stringify({ categories, hint: "Call discover_tools with a category name to activate it" }, null, 2),
+              text: JSON.stringify({ categories, hint: "Call discover_tools with a category name to activate it" }),
             }],
           });
         }
@@ -903,7 +903,7 @@ function createServer(): McpServer {
               activated: category,
               addedTools: addedNames,
               totalTools: filteredTools.length,
-            }, null, 2),
+            }),
           }],
         });
       }
@@ -9029,7 +9029,7 @@ async function handleToolCall(params: any) {
           }
           const json = await response.json();
           return {
-            content: [{ type: "text", text: JSON.stringify(json, null, 2) }],
+            content: [{ type: "text", text: JSON.stringify(json) }],
           };
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -9037,7 +9037,7 @@ async function handleToolCall(params: any) {
             content: [
               {
                 type: "text",
-                text: JSON.stringify({ error: `GraphQL request failed: ${message}` }, null, 2),
+                text: JSON.stringify({ error: `GraphQL request failed: ${message}` }),
               },
             ],
           };
@@ -9051,7 +9051,7 @@ async function handleToolCall(params: any) {
         try {
           const forkedProject = await forkProject(forkArgs.project_id, forkArgs.namespace);
           return {
-            content: [{ type: "text", text: JSON.stringify(forkedProject, null, 2) }],
+            content: [{ type: "text", text: JSON.stringify(forkedProject) }],
           };
         } catch (forkError) {
           logger.error({ err: forkError }, "Error forking repository");
@@ -9063,7 +9063,7 @@ async function handleToolCall(params: any) {
             content: [
               {
                 type: "text",
-                text: JSON.stringify({ error: forkErrorMessage }, null, 2),
+                text: JSON.stringify({ error: forkErrorMessage }),
               },
             ],
           };
@@ -9083,7 +9083,7 @@ async function handleToolCall(params: any) {
         });
 
         return {
-          content: [{ type: "text", text: JSON.stringify(branch, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(branch) }],
         };
       }
 
@@ -9092,7 +9092,7 @@ async function handleToolCall(params: any) {
         const diffResp = await getBranchDiffs(args.project_id, args.from, args.to, args.straight);
         diffResp.diffs = filterDiffsByPatterns(diffResp.diffs, args.excluded_file_patterns);
         return {
-          content: [{ type: "text", text: JSON.stringify(diffResp, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(diffResp) }],
         };
       }
 
@@ -9100,7 +9100,7 @@ async function handleToolCall(params: any) {
         const args = SearchRepositoriesSchema.parse(params.arguments);
         const results = await searchProjects(args.search, args.page, args.per_page);
         return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(results) }],
         };
       }
 
@@ -9115,7 +9115,7 @@ async function handleToolCall(params: any) {
           per_page: args.per_page,
         });
         return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(results) }],
         };
       }
 
@@ -9132,7 +9132,7 @@ async function handleToolCall(params: any) {
           per_page: args.per_page,
         });
         return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(results) }],
         };
       }
 
@@ -9148,7 +9148,7 @@ async function handleToolCall(params: any) {
           per_page: args.per_page,
         });
         return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(results) }],
         };
       }
 
@@ -9157,7 +9157,7 @@ async function handleToolCall(params: any) {
         const args = CreateRepositorySchema.parse(params.arguments);
         const repository = await createRepository(args);
         return {
-          content: [{ type: "text", text: JSON.stringify(repository, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(repository) }],
         };
       }
 
@@ -9186,7 +9186,7 @@ async function handleToolCall(params: any) {
         const group = GitLabGroupSchema.parse(data);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(group, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(group) }],
         };
       }
 
@@ -9194,7 +9194,7 @@ async function handleToolCall(params: any) {
         const args = GetFileContentsSchema.parse(params.arguments);
         const contents = await getFileContents(args.project_id, args.file_path, args.ref);
         return {
-          content: [{ type: "text", text: JSON.stringify(contents, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(contents) }],
         };
       }
 
@@ -9211,7 +9211,7 @@ async function handleToolCall(params: any) {
           args.commit_id
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -9224,7 +9224,7 @@ async function handleToolCall(params: any) {
           args.files.map(f => ({ path: f.file_path, content: f.content }))
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -9233,7 +9233,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const issue = await createIssue(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(issue) }],
         };
       }
 
@@ -9242,7 +9242,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const mergeRequest = await createMergeRequest(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(mergeRequest, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(mergeRequest) }],
         };
       }
 
@@ -9272,7 +9272,7 @@ async function handleToolCall(params: any) {
           args.resolved // Now one of body or resolved must be provided, not both
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(note) }],
         };
       }
 
@@ -9286,7 +9286,7 @@ async function handleToolCall(params: any) {
           args.created_at
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(note) }],
         };
       }
 
@@ -9299,7 +9299,7 @@ async function handleToolCall(params: any) {
         );
 
         return {
-          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(note) }],
         };
       }
 
@@ -9321,7 +9321,7 @@ async function handleToolCall(params: any) {
         );
 
         return {
-          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(note) }],
         };
       }
 
@@ -9337,7 +9337,7 @@ async function handleToolCall(params: any) {
         );
 
         return {
-          content: [{ type: "text", text: JSON.stringify(notes, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(notes) }],
         };
       }
 
@@ -9351,7 +9351,7 @@ async function handleToolCall(params: any) {
         );
 
         return {
-          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(note) }],
         };
       }
 
@@ -9360,21 +9360,21 @@ async function handleToolCall(params: any) {
         const args = ListMergeRequestEmojiReactionsSchema.parse(params.arguments);
         const path = buildAwardEmojiPath("merge_requests", args.project_id, args.merge_request_iid);
         const result = await listRestAwardEmoji(path);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "list_merge_request_note_emoji_reactions": {
         const args = ListMergeRequestNoteEmojiReactionsSchema.parse(params.arguments);
         const path = buildAwardEmojiPath("merge_requests", args.project_id, args.merge_request_iid, { noteId: args.note_id, discussionId: args.discussion_id });
         const result = await listRestAwardEmoji(path);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "create_merge_request_emoji_reaction": {
         const args = CreateMergeRequestEmojiReactionSchema.parse(params.arguments);
         const path = buildAwardEmojiPath("merge_requests", args.project_id, args.merge_request_iid);
         const result = await createRestAwardEmoji(path, args.name);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "delete_merge_request_emoji_reaction": {
@@ -9388,7 +9388,7 @@ async function handleToolCall(params: any) {
         const args = CreateMergeRequestNoteEmojiReactionSchema.parse(params.arguments);
         const path = buildAwardEmojiPath("merge_requests", args.project_id, args.merge_request_iid, { noteId: args.note_id, discussionId: args.discussion_id });
         const result = await createRestAwardEmoji(path, args.name);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "delete_merge_request_note_emoji_reaction": {
@@ -9409,7 +9409,7 @@ async function handleToolCall(params: any) {
           args.resolved
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(note) }],
         };
       }
 
@@ -9423,7 +9423,7 @@ async function handleToolCall(params: any) {
           args.created_at
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(note) }],
         };
       }
 
@@ -9432,21 +9432,21 @@ async function handleToolCall(params: any) {
         const args = ListIssueEmojiReactionsSchema.parse(params.arguments);
         const path = buildAwardEmojiPath("issues", args.project_id, args.issue_iid);
         const result = await listRestAwardEmoji(path);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "list_issue_note_emoji_reactions": {
         const args = ListIssueNoteEmojiReactionsSchema.parse(params.arguments);
         const path = buildAwardEmojiPath("issues", args.project_id, args.issue_iid, { noteId: args.note_id, discussionId: args.discussion_id });
         const result = await listRestAwardEmoji(path);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "create_issue_emoji_reaction": {
         const args = CreateIssueEmojiReactionSchema.parse(params.arguments);
         const path = buildAwardEmojiPath("issues", args.project_id, args.issue_iid);
         const result = await createRestAwardEmoji(path, args.name);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "delete_issue_emoji_reaction": {
@@ -9460,7 +9460,7 @@ async function handleToolCall(params: any) {
         const args = CreateIssueNoteEmojiReactionSchema.parse(params.arguments);
         const path = buildAwardEmojiPath("issues", args.project_id, args.issue_iid, { noteId: args.note_id, discussionId: args.discussion_id });
         const result = await createRestAwardEmoji(path, args.name);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "delete_issue_note_emoji_reaction": {
@@ -9474,7 +9474,7 @@ async function handleToolCall(params: any) {
         const args = ListTodosSchema.parse(params.arguments);
         const todos = await listTodos(args);
         return {
-          content: [{ type: "text", text: JSON.stringify(todos, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(todos) }],
         };
       }
 
@@ -9482,7 +9482,7 @@ async function handleToolCall(params: any) {
         const args = MarkTodoDoneSchema.parse(params.arguments);
         const todo = await markTodoDone(args.id);
         return {
-          content: [{ type: "text", text: JSON.stringify(todo, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(todo) }],
         };
       }
 
@@ -9535,7 +9535,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(mergeRequestWithDeploymentSummary, null, 2),
+              text: JSON.stringify(mergeRequestWithDeploymentSummary),
             },
           ],
         };
@@ -9551,7 +9551,7 @@ async function handleToolCall(params: any) {
         );
         const filteredDiffs = filterDiffsByPatterns(diffs, args.excluded_file_patterns);
         return {
-          content: [{ type: "text", text: JSON.stringify(filteredDiffs, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(filteredDiffs) }],
         };
       }
 
@@ -9564,7 +9564,7 @@ async function handleToolCall(params: any) {
           args.excluded_file_patterns
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(files, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(files) }],
         };
       }
 
@@ -9573,7 +9573,7 @@ async function handleToolCall(params: any) {
         const { project_id, merge_request_iid, ...options } = args;
         const pipelines = await listMergeRequestPipelines(project_id, merge_request_iid, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(pipelines, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(pipelines) }],
         };
       }
 
@@ -9588,7 +9588,7 @@ async function handleToolCall(params: any) {
           args.unidiff
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(changes, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(changes) }],
         };
       }
 
@@ -9602,7 +9602,7 @@ async function handleToolCall(params: any) {
           args.unidiff
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(fileDiff, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(fileDiff) }],
         };
       }
 
@@ -9610,7 +9610,7 @@ async function handleToolCall(params: any) {
         const args = ListMergeRequestVersionsSchema.parse(params.arguments);
         const versions = await listMergeRequestVersions(args.project_id, args.merge_request_iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(versions, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(versions) }],
         };
       }
 
@@ -9623,7 +9623,7 @@ async function handleToolCall(params: any) {
           args.unidiff
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(version, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(version) }],
         };
       }
 
@@ -9637,7 +9637,7 @@ async function handleToolCall(params: any) {
           source_branch
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(mergeRequest, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(mergeRequest) }],
         };
       }
 
@@ -9646,7 +9646,7 @@ async function handleToolCall(params: any) {
         const { project_id, merge_request_iid, ...options } = args;
         const mergeRequest = await mergeMergeRequest(project_id, options, merge_request_iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(mergeRequest, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(mergeRequest) }],
         };
       }
 
@@ -9659,7 +9659,7 @@ async function handleToolCall(params: any) {
           args.approval_password
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(approvalState, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(approvalState) }],
         };
       }
 
@@ -9667,7 +9667,7 @@ async function handleToolCall(params: any) {
         const args = UnapproveMergeRequestSchema.parse(params.arguments);
         const approvalState = await unapproveMergeRequest(args.project_id, args.merge_request_iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(approvalState, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(approvalState) }],
         };
       }
 
@@ -9678,7 +9678,7 @@ async function handleToolCall(params: any) {
           args.merge_request_iid
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(approvalState, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(approvalState) }],
         };
       }
 
@@ -9689,7 +9689,7 @@ async function handleToolCall(params: any) {
           args.merge_request_iid
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(conflicts, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(conflicts) }],
         };
       }
 
@@ -9702,7 +9702,7 @@ async function handleToolCall(params: any) {
           options
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(discussions, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(discussions) }],
         };
       }
 
@@ -9732,7 +9732,7 @@ async function handleToolCall(params: any) {
         const namespaces = z.array(GitLabNamespaceSchema).parse(data);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(namespaces, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(namespaces) }],
         };
       }
 
@@ -9751,7 +9751,7 @@ async function handleToolCall(params: any) {
         const namespace = GitLabNamespaceSchema.parse(data);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(namespace, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(namespace) }],
         };
       }
 
@@ -9769,7 +9769,7 @@ async function handleToolCall(params: any) {
         const namespaceExists = GitLabNamespaceExistsResponseSchema.parse(data);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(namespaceExists, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(namespaceExists) }],
         };
       }
 
@@ -9798,7 +9798,7 @@ async function handleToolCall(params: any) {
         const data = await response.json();
         // Return raw data without parsing through our schema to avoid type mismatches in tests
         return {
-          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(data) }],
         };
       }
 
@@ -9807,7 +9807,7 @@ async function handleToolCall(params: any) {
         const projects = await listProjects(args);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(projects, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(projects) }],
         };
       }
 
@@ -9816,7 +9816,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const members = await listProjectMembers(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(members, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(members) }],
         };
       }
 
@@ -9825,7 +9825,7 @@ async function handleToolCall(params: any) {
         const usersMap = await getUsers(args.usernames);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(usersMap, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(usersMap) }],
         };
       }
 
@@ -9844,7 +9844,7 @@ async function handleToolCall(params: any) {
         const user = GitLabUserFullSchema.parse(data);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(user, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(user) }],
         };
       }
 
@@ -9861,7 +9861,7 @@ async function handleToolCall(params: any) {
         const user = GitLabCurrentUserSchema.parse(data);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(user, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(user) }],
         };
       }
 
@@ -9871,7 +9871,7 @@ async function handleToolCall(params: any) {
 
         const note = await createNote(project_id, noteable_type, noteable_iid, body);
         return {
-          content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(note) }],
         };
       }
 
@@ -9881,7 +9881,7 @@ async function handleToolCall(params: any) {
 
         const draftNote = await getDraftNote(project_id, merge_request_iid, draft_note_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(draftNote, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(draftNote) }],
         };
       }
 
@@ -9891,7 +9891,7 @@ async function handleToolCall(params: any) {
 
         const draftNotes = await listDraftNotes(project_id, merge_request_iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(draftNotes, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(draftNotes) }],
         };
       }
 
@@ -9908,7 +9908,7 @@ async function handleToolCall(params: any) {
           resolve_discussion
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(draftNote, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(draftNote) }],
         };
       }
 
@@ -9926,7 +9926,7 @@ async function handleToolCall(params: any) {
           resolve_discussion
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(draftNote, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(draftNote) }],
         };
       }
 
@@ -9946,7 +9946,7 @@ async function handleToolCall(params: any) {
 
         const publishedNote = await publishDraftNote(project_id, merge_request_iid, draft_note_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(publishedNote, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(publishedNote) }],
         };
       }
 
@@ -9956,7 +9956,7 @@ async function handleToolCall(params: any) {
 
         const publishedNotes = await bulkPublishDraftNotes(project_id, merge_request_iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(publishedNotes, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(publishedNotes) }],
         };
       }
 
@@ -9972,7 +9972,7 @@ async function handleToolCall(params: any) {
           created_at
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(thread, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(thread) }],
         };
       }
 
@@ -9991,7 +9991,7 @@ async function handleToolCall(params: any) {
         const cleanedOptions = cleanMutuallyExclusiveIdUsernameOptions(options);
         const issues = await listIssues(project_id, cleanedOptions);
         return {
-          content: [{ type: "text", text: JSON.stringify(issues, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(issues) }],
         };
       }
 
@@ -9999,7 +9999,7 @@ async function handleToolCall(params: any) {
         const args = MyIssuesSchema.parse(params.arguments);
         const issues = await myIssues(args);
         return {
-          content: [{ type: "text", text: JSON.stringify(issues, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(issues) }],
         };
       }
 
@@ -10007,7 +10007,7 @@ async function handleToolCall(params: any) {
         const args = GetIssueSchema.parse(params.arguments);
         const issue = await getIssue(args.project_id, args.issue_iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(issue) }],
         };
       }
 
@@ -10016,7 +10016,7 @@ async function handleToolCall(params: any) {
         const { project_id, issue_iid, ...options } = args;
         const issue = await updateIssue(project_id, issue_iid, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(issue) }],
         };
       }
 
@@ -10138,7 +10138,7 @@ async function handleToolCall(params: any) {
         const args = ListIssueLinksSchema.parse(params.arguments);
         const links = await listIssueLinks(args.project_id, args.issue_iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(links, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(links) }],
         };
       }
 
@@ -10148,7 +10148,7 @@ async function handleToolCall(params: any) {
 
         const discussions = await listIssueDiscussions(project_id, issue_iid, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(discussions, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(discussions) }],
         };
       }
 
@@ -10156,7 +10156,7 @@ async function handleToolCall(params: any) {
         const args = GetIssueLinkSchema.parse(params.arguments);
         const link = await getIssueLink(args.project_id, args.issue_iid, args.issue_link_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(link, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(link) }],
         };
       }
 
@@ -10170,7 +10170,7 @@ async function handleToolCall(params: any) {
           args.link_type
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(link, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(link) }],
         };
       }
 
@@ -10198,7 +10198,7 @@ async function handleToolCall(params: any) {
         const args = GetWorkItemSchema.parse(params.arguments);
         const result = await getWorkItem(args.project_id, args.iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10207,7 +10207,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const result = await listWorkItems(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10216,7 +10216,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const result = await createWorkItem(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10225,7 +10225,7 @@ async function handleToolCall(params: any) {
         const { project_id, iid, ...options } = args;
         const result = await updateWorkItem(project_id, iid, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10237,7 +10237,7 @@ async function handleToolCall(params: any) {
           args.new_type
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10245,7 +10245,7 @@ async function handleToolCall(params: any) {
         const args = ListWorkItemStatusesSchema.parse(params.arguments);
         const result = await listIssueStatuses(args.project_id, args.work_item_type);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10253,7 +10253,7 @@ async function handleToolCall(params: any) {
         const args = ListCustomFieldDefinitionsSchema.parse(params.arguments);
         const result = await listCustomFieldDefinitions(args.project_id, args.work_item_type);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10261,7 +10261,7 @@ async function handleToolCall(params: any) {
         const args = MoveWorkItemSchema.parse(params.arguments);
         const result = await moveWorkItem(args.project_id, args.iid, args.target_project_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10269,7 +10269,7 @@ async function handleToolCall(params: any) {
         const args = ListWorkItemNotesSchema.parse(params.arguments);
         const result = await listWorkItemNotes(args.project_id, args.iid, args);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10277,7 +10277,7 @@ async function handleToolCall(params: any) {
         const args = CreateWorkItemNoteSchema.parse(params.arguments);
         const result = await createWorkItemNote(args.project_id, args.iid, args.body, args);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10286,46 +10286,46 @@ async function handleToolCall(params: any) {
         const args = ListWorkItemEmojiReactionsSchema.parse(params.arguments);
         const { workItemGID } = await resolveWorkItemGID(args.project_id, args.iid);
         const result = await listGraphQLAwardEmoji(workItemGID);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "list_work_item_note_emoji_reactions": {
         const args = ListWorkItemNoteEmojiReactionsSchema.parse(params.arguments);
         const result = await listGraphQLAwardEmoji(args.note_id);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "create_work_item_emoji_reaction": {
         const args = CreateWorkItemEmojiReactionSchema.parse(params.arguments);
         const { workItemGID } = await resolveWorkItemGID(args.project_id, args.iid);
         const result = await addGraphQLAwardEmoji(workItemGID, args.name);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "delete_work_item_emoji_reaction": {
         const args = DeleteWorkItemEmojiReactionSchema.parse(params.arguments);
         const { workItemGID } = await resolveWorkItemGID(args.project_id, args.iid);
         const result = await removeGraphQLAwardEmoji(workItemGID, args.name);
-        return { content: [{ type: "text", text: JSON.stringify(result ?? { status: "success", message: "Work item emoji reaction removed" }, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result ?? { status: "success", message: "Work item emoji reaction removed" }) }] };
       }
 
       case "create_work_item_note_emoji_reaction": {
         const args = CreateWorkItemNoteEmojiReactionSchema.parse(params.arguments);
         const result = await addGraphQLAwardEmoji(args.note_id, args.name);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "delete_work_item_note_emoji_reaction": {
         const args = DeleteWorkItemNoteEmojiReactionSchema.parse(params.arguments);
         const result = await removeGraphQLAwardEmoji(args.note_id, args.name);
-        return { content: [{ type: "text", text: JSON.stringify(result ?? { status: "success", message: "Work item note emoji reaction removed" }, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(result ?? { status: "success", message: "Work item note emoji reaction removed" }) }] };
       }
 
       case "get_timeline_events": {
         const args = GetTimelineEventsSchema.parse(params.arguments);
         const result = await getTimelineEvents(args.project_id, args.incident_iid);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10339,7 +10339,7 @@ async function handleToolCall(params: any) {
           args.tag_names
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10347,7 +10347,7 @@ async function handleToolCall(params: any) {
         const args = ListLabelsSchema.parse(params.arguments);
         const labels = await listLabels(args.project_id, args);
         return {
-          content: [{ type: "text", text: JSON.stringify(labels, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(labels) }],
         };
       }
 
@@ -10355,7 +10355,7 @@ async function handleToolCall(params: any) {
         const args = GetLabelSchema.parse(params.arguments);
         const label = await getLabel(args.project_id, args.label_id, args.include_ancestor_groups);
         return {
-          content: [{ type: "text", text: JSON.stringify(label, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(label) }],
         };
       }
 
@@ -10363,7 +10363,7 @@ async function handleToolCall(params: any) {
         const args = CreateLabelSchema.parse(params.arguments);
         const label = await createLabel(args.project_id, args);
         return {
-          content: [{ type: "text", text: JSON.stringify(label, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(label) }],
         };
       }
 
@@ -10372,7 +10372,7 @@ async function handleToolCall(params: any) {
         const { project_id, label_id, ...options } = args;
         const label = await updateLabel(project_id, label_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(label, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(label) }],
         };
       }
 
@@ -10397,7 +10397,7 @@ async function handleToolCall(params: any) {
         const args = ListGroupProjectsSchema.parse(params.arguments);
         const projects = await listGroupProjects(args);
         return {
-          content: [{ type: "text", text: JSON.stringify(projects, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(projects) }],
         };
       }
 
@@ -10411,7 +10411,7 @@ async function handleToolCall(params: any) {
           with_content,
         });
         return {
-          content: [{ type: "text", text: JSON.stringify(wikiPages, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(wikiPages) }],
         };
       }
 
@@ -10419,7 +10419,7 @@ async function handleToolCall(params: any) {
         const { project_id, slug } = GetWikiPageSchema.parse(params.arguments);
         const wikiPage = await getWikiPage(project_id, slug);
         return {
-          content: [{ type: "text", text: JSON.stringify(wikiPage, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(wikiPage) }],
         };
       }
 
@@ -10427,7 +10427,7 @@ async function handleToolCall(params: any) {
         const { project_id, title, content, format } = CreateWikiPageSchema.parse(params.arguments);
         const wikiPage = await createWikiPage(project_id, title, content, format);
         return {
-          content: [{ type: "text", text: JSON.stringify(wikiPage, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(wikiPage) }],
         };
       }
 
@@ -10437,7 +10437,7 @@ async function handleToolCall(params: any) {
         );
         const wikiPage = await updateWikiPage(project_id, slug, title, content, format);
         return {
-          content: [{ type: "text", text: JSON.stringify(wikiPage, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(wikiPage) }],
         };
       }
 
@@ -10471,7 +10471,7 @@ async function handleToolCall(params: any) {
           with_content,
         });
         return {
-          content: [{ type: "text", text: JSON.stringify(wikiPages, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(wikiPages) }],
         };
       }
 
@@ -10479,7 +10479,7 @@ async function handleToolCall(params: any) {
         const { group_id, slug } = GetGroupWikiPageSchema.parse(params.arguments);
         const wikiPage = await getGroupWikiPage(group_id, slug);
         return {
-          content: [{ type: "text", text: JSON.stringify(wikiPage, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(wikiPage) }],
         };
       }
 
@@ -10489,7 +10489,7 @@ async function handleToolCall(params: any) {
         );
         const wikiPage = await createGroupWikiPage(group_id, title, content, format);
         return {
-          content: [{ type: "text", text: JSON.stringify(wikiPage, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(wikiPage) }],
         };
       }
 
@@ -10499,7 +10499,7 @@ async function handleToolCall(params: any) {
         );
         const wikiPage = await updateGroupWikiPage(group_id, slug, title, content, format);
         return {
-          content: [{ type: "text", text: JSON.stringify(wikiPage, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(wikiPage) }],
         };
       }
 
@@ -10537,7 +10537,7 @@ async function handleToolCall(params: any) {
               }
             : items;
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10546,7 +10546,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const pipelines = await listPipelines(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(pipelines, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(pipelines) }],
         };
       }
 
@@ -10557,7 +10557,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(pipeline, null, 2),
+              text: JSON.stringify(pipeline),
             },
           ],
         };
@@ -10568,7 +10568,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const deployments = await listDeployments(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(deployments, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(deployments) }],
         };
       }
 
@@ -10576,7 +10576,7 @@ async function handleToolCall(params: any) {
         const { project_id, deployment_id } = GetDeploymentSchema.parse(params.arguments);
         const deployment = await getDeployment(project_id, deployment_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(deployment, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(deployment) }],
         };
       }
 
@@ -10585,7 +10585,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const environments = await listEnvironments(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(environments, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(environments) }],
         };
       }
 
@@ -10593,7 +10593,7 @@ async function handleToolCall(params: any) {
         const { project_id, environment_id } = GetEnvironmentSchema.parse(params.arguments);
         const environment = await getEnvironment(project_id, environment_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(environment, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(environment) }],
         };
       }
 
@@ -10606,7 +10606,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(jobs, null, 2),
+              text: JSON.stringify(jobs),
             },
           ],
         };
@@ -10621,7 +10621,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(triggerJobs, null, 2),
+              text: JSON.stringify(triggerJobs),
             },
           ],
         };
@@ -10634,7 +10634,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(jobDetails, null, 2),
+              text: JSON.stringify(jobDetails),
             },
           ],
         };
@@ -10660,7 +10660,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const result = await validateCiLint(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10669,7 +10669,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const result = await validateProjectCiLint(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -10762,7 +10762,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(artifacts, null, 2),
+              text: JSON.stringify(artifacts),
             },
           ],
         };
@@ -10778,7 +10778,7 @@ async function handleToolCall(params: any) {
           }
           const downloadUrl = buildDownloadUrl("job-artifacts", { project_id, job_id });
           return {
-            content: [{ type: "text", text: JSON.stringify({ download_url: downloadUrl, filename: `artifacts_job_${job_id}.zip` }, null, 2) }],
+            content: [{ type: "text", text: JSON.stringify({ download_url: downloadUrl, filename: `artifacts_job_${job_id}.zip` }) }],
           };
         }
         const filePath = await downloadJobArtifacts(project_id, job_id, local_path);
@@ -10786,7 +10786,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify({ success: true, file_path: filePath }, null, 2),
+              text: JSON.stringify({ success: true, file_path: filePath }),
             },
           ],
         };
@@ -10816,7 +10816,7 @@ async function handleToolCall(params: any) {
 
         const mergeRequests = await listMergeRequests(project_id, cleanedOptions);
         return {
-          content: [{ type: "text", text: JSON.stringify(mergeRequests, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(mergeRequests) }],
         };
       }
 
@@ -10827,7 +10827,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(milestones, null, 2),
+              text: JSON.stringify(milestones),
             },
           ],
         };
@@ -10840,7 +10840,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(milestone, null, 2),
+              text: JSON.stringify(milestone),
             },
           ],
         };
@@ -10853,7 +10853,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(milestone, null, 2),
+              text: JSON.stringify(milestone),
             },
           ],
         };
@@ -10868,7 +10868,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(milestone, null, 2),
+              text: JSON.stringify(milestone),
             },
           ],
         };
@@ -10901,7 +10901,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(issues, null, 2),
+              text: JSON.stringify(issues),
             },
           ],
         };
@@ -10916,7 +10916,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(mergeRequests, null, 2),
+              text: JSON.stringify(mergeRequests),
             },
           ],
         };
@@ -10929,7 +10929,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(milestone, null, 2),
+              text: JSON.stringify(milestone),
             },
           ],
         };
@@ -10944,7 +10944,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify(events, null, 2),
+              text: JSON.stringify(events),
             },
           ],
         };
@@ -10954,7 +10954,7 @@ async function handleToolCall(params: any) {
         const args = ListCommitsSchema.parse(params.arguments);
         const commits = await listCommits(args.project_id, args);
         return {
-          content: [{ type: "text", text: JSON.stringify(commits, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(commits) }],
         };
       }
 
@@ -10962,7 +10962,7 @@ async function handleToolCall(params: any) {
         const args = GetCommitSchema.parse(params.arguments);
         const commit = await getCommit(args.project_id, args.sha, args.stats);
         return {
-          content: [{ type: "text", text: JSON.stringify(commit, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(commit) }],
         };
       }
 
@@ -10970,7 +10970,7 @@ async function handleToolCall(params: any) {
         const args = GetCommitDiffSchema.parse(params.arguments);
         const diff = await getCommitDiff(args.project_id, args.sha, args.full_diff);
         return {
-          content: [{ type: "text", text: JSON.stringify(diff, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(diff) }],
         };
       }
 
@@ -10979,7 +10979,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const blame = await getFileBlame(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(blame, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(blame) }],
         };
       }
 
@@ -10988,7 +10988,7 @@ async function handleToolCall(params: any) {
         const { project_id, sha, ...options } = args;
         const statuses = await listCommitStatuses(project_id, sha, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(statuses, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(statuses) }],
         };
       }
 
@@ -10997,7 +10997,7 @@ async function handleToolCall(params: any) {
         const { project_id, sha, ...options } = args;
         const status = await createCommitStatus(project_id, sha, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(status, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(status) }],
         };
       }
 
@@ -11005,7 +11005,7 @@ async function handleToolCall(params: any) {
         const args = ListGroupIterationsSchema.parse(params.arguments);
         const iterations = await listGroupIterations(args.group_id, args);
         return {
-          content: [{ type: "text", text: JSON.stringify(iterations, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(iterations) }],
         };
       }
 
@@ -11015,27 +11015,27 @@ async function handleToolCall(params: any) {
         const args = ListProjectVariablesSchema.parse(params.arguments);
         const { project_id, ...options } = args;
         const variables = await listProjectVariables(project_id, options);
-        return { content: [{ type: "text", text: JSON.stringify(variables, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(variables) }] };
       }
 
       case "get_project_variable": {
         const args = GetProjectVariableSchema.parse(params.arguments);
         const variable = await getProjectVariable(args.project_id, args.key, args.filter);
-        return { content: [{ type: "text", text: JSON.stringify(variable, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(variable) }] };
       }
 
       case "create_project_variable": {
         const args = CreateProjectVariableSchema.parse(params.arguments);
         const { project_id, ...options } = args;
         const variable = await createProjectVariable(project_id, options);
-        return { content: [{ type: "text", text: JSON.stringify(variable, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(variable) }] };
       }
 
       case "update_project_variable": {
         const args = UpdateProjectVariableSchema.parse(params.arguments);
         const { project_id, key, ...options } = args;
         const variable = await updateProjectVariable(project_id, key, options);
-        return { content: [{ type: "text", text: JSON.stringify(variable, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(variable) }] };
       }
 
       case "delete_project_variable": {
@@ -11060,14 +11060,14 @@ async function handleToolCall(params: any) {
         const args = ListGroupVariablesSchema.parse(params.arguments);
         const { group_id, ...options } = args;
         const variables = await listGroupVariables(group_id, options);
-        return { content: [{ type: "text", text: JSON.stringify(variables, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(variables) }] };
       }
 
       case "get_group_variable": {
         rejectIfProjectScopedDeployment("get_group_variable");
         const args = GetGroupVariableSchema.parse(params.arguments);
         const variable = await getGroupVariable(args.group_id, args.key, args.filter);
-        return { content: [{ type: "text", text: JSON.stringify(variable, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(variable) }] };
       }
 
       case "create_group_variable": {
@@ -11075,7 +11075,7 @@ async function handleToolCall(params: any) {
         const args = CreateGroupVariableSchema.parse(params.arguments);
         const { group_id, ...options } = args;
         const variable = await createGroupVariable(group_id, options);
-        return { content: [{ type: "text", text: JSON.stringify(variable, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(variable) }] };
       }
 
       case "update_group_variable": {
@@ -11083,7 +11083,7 @@ async function handleToolCall(params: any) {
         const args = UpdateGroupVariableSchema.parse(params.arguments);
         const { group_id, key, ...options } = args;
         const variable = await updateGroupVariable(group_id, key, options);
-        return { content: [{ type: "text", text: JSON.stringify(variable, null, 2) }] };
+        return { content: [{ type: "text", text: JSON.stringify(variable) }] };
       }
 
       case "delete_group_variable": {
@@ -11109,7 +11109,7 @@ async function handleToolCall(params: any) {
         const args = GetDependencyProxySettingsSchema.parse(params.arguments);
         const settings = await getDependencyProxySettings(args.group_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(settings, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(settings) }],
         };
       }
 
@@ -11119,7 +11119,7 @@ async function handleToolCall(params: any) {
         const { group_id, ...options } = args;
         const settings = await updateDependencyProxySettings(group_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(settings, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(settings) }],
         };
       }
 
@@ -11129,7 +11129,7 @@ async function handleToolCall(params: any) {
         const { group_id, ...options } = args;
         const result = await listDependencyProxyBlobs(group_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       }
 
@@ -11156,13 +11156,13 @@ async function handleToolCall(params: any) {
           const args = MarkdownUploadRemoteSchema.parse(params.arguments);
           const upload = await markdownUpload(args.project_id, undefined, args.content, args.filename);
           return {
-            content: [{ type: "text", text: JSON.stringify(upload, null, 2) }],
+            content: [{ type: "text", text: JSON.stringify(upload) }],
           };
         }
         const args = MarkdownUploadSchema.parse(params.arguments);
         const upload = await markdownUpload(args.project_id, args.file_path);
         return {
-          content: [{ type: "text", text: JSON.stringify(upload, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(upload) }],
         };
       }
 
@@ -11180,7 +11180,7 @@ async function handleToolCall(params: any) {
             project_id: args.project_id, secret: args.secret, filename: args.filename,
           });
           return {
-            content: [{ type: "text", text: JSON.stringify({ download_url: downloadUrl, filename: args.filename }, null, 2) }],
+            content: [{ type: "text", text: JSON.stringify({ download_url: downloadUrl, filename: args.filename }) }],
           };
         }
 
@@ -11199,7 +11199,7 @@ async function handleToolCall(params: any) {
               { type: "image", data: base64, mimeType: result.mimeType },
               {
                 type: "text",
-                text: JSON.stringify({ filename: result.filename, mimeType: result.mimeType }, null, 2),
+                text: JSON.stringify({ filename: result.filename, mimeType: result.mimeType }),
               },
             ],
           };
@@ -11209,7 +11209,7 @@ async function handleToolCall(params: any) {
           content: [
             {
               type: "text",
-              text: JSON.stringify({ success: true, file_path: result.savedPath }, null, 2),
+              text: JSON.stringify({ success: true, file_path: result.savedPath }),
             },
           ],
         };
@@ -11219,7 +11219,7 @@ async function handleToolCall(params: any) {
         const args = ListEventsSchema.parse(params.arguments);
         const events = await listEvents(args);
         return {
-          content: [{ type: "text", text: JSON.stringify(events, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(events) }],
         };
       }
 
@@ -11228,7 +11228,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const events = await getProjectEvents(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(events, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(events) }],
         };
       }
 
@@ -11237,7 +11237,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const releases = await listReleases(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(releases, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(releases) }],
         };
       }
 
@@ -11249,7 +11249,7 @@ async function handleToolCall(params: any) {
           args.include_html_description
         );
         return {
-          content: [{ type: "text", text: JSON.stringify(release, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(release) }],
         };
       }
 
@@ -11258,7 +11258,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const release = await createRelease(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(release, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(release) }],
         };
       }
 
@@ -11267,7 +11267,7 @@ async function handleToolCall(params: any) {
         const { project_id, tag_name, ...options } = args;
         const release = await updateRelease(project_id, tag_name, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(release, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(release) }],
         };
       }
 
@@ -11312,7 +11312,7 @@ async function handleToolCall(params: any) {
             project_id: args.project_id, tag_name: args.tag_name, direct_asset_path: args.direct_asset_path,
           });
           return {
-            content: [{ type: "text", text: JSON.stringify({ download_url: downloadUrl, filename: args.direct_asset_path.split("/").pop() || args.direct_asset_path }, null, 2) }],
+            content: [{ type: "text", text: JSON.stringify({ download_url: downloadUrl, filename: args.direct_asset_path.split("/").pop() || args.direct_asset_path }) }],
           };
         }
         const assetContent = await downloadReleaseAsset(
@@ -11330,7 +11330,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const tags = await listTags(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(tags, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(tags) }],
         };
       }
 
@@ -11338,7 +11338,7 @@ async function handleToolCall(params: any) {
         const args = GetTagSchema.parse(params.arguments);
         const tag = await getTag(args.project_id, args.tag_name);
         return {
-          content: [{ type: "text", text: JSON.stringify(tag, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(tag) }],
         };
       }
 
@@ -11347,7 +11347,7 @@ async function handleToolCall(params: any) {
         const { project_id, ...options } = args;
         const tag = await createTag(project_id, options);
         return {
-          content: [{ type: "text", text: JSON.stringify(tag, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(tag) }],
         };
       }
 
@@ -11372,7 +11372,7 @@ async function handleToolCall(params: any) {
         const args = GetTagSignatureSchema.parse(params.arguments);
         const signature = await getTagSignature(args.project_id, args.tag_name);
         return {
-          content: [{ type: "text", text: JSON.stringify(signature, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(signature) }],
         };
       }
 
@@ -11380,7 +11380,7 @@ async function handleToolCall(params: any) {
         const args = ListWebhooksSchema.parse(params.arguments);
         const webhooks = await listWebhooks(args);
         return {
-          content: [{ type: "text", text: JSON.stringify(webhooks, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(webhooks) }],
         };
       }
 
@@ -11388,7 +11388,7 @@ async function handleToolCall(params: any) {
         const args = ListWebhookEventsSchema.parse(params.arguments);
         const events = await listWebhookEvents(args);
         return {
-          content: [{ type: "text", text: JSON.stringify(events, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(events) }],
         };
       }
 
@@ -11413,7 +11413,7 @@ async function handleToolCall(params: any) {
           };
         }
         return {
-          content: [{ type: "text", text: JSON.stringify(event, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(event) }],
         };
       }
 
@@ -11448,7 +11448,7 @@ async function handleToolCall(params: any) {
         const branch = GitLabBranchSchema.parse(data);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(branch, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(branch) }],
         };
       }
 
@@ -11478,7 +11478,7 @@ async function handleToolCall(params: any) {
         const branches = z.array(GitLabBranchSchema).parse(data);
 
         return {
-          content: [{ type: "text", text: JSON.stringify(branches, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(branches) }],
         };
       }
 
@@ -11497,7 +11497,7 @@ async function handleToolCall(params: any) {
         await handleGitLabError(response);
 
         return {
-          content: [{ type: "text", text: JSON.stringify({ status: "deleted", branch: args.branch_name }, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify({ status: "deleted", branch: args.branch_name }) }],
         };
       }
 
@@ -11519,7 +11519,7 @@ async function handleToolCall(params: any) {
         await handleGitLabError(response);
         const data = z.array(GitLabProtectedBranchSchema).parse(await response.json());
         return {
-          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(data) }],
         };
       }
 
@@ -11538,7 +11538,7 @@ async function handleToolCall(params: any) {
         await handleGitLabError(response);
         const data = GitLabProtectedBranchSchema.parse(await response.json());
         return {
-          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(data) }],
         };
       }
 
@@ -11566,7 +11566,7 @@ async function handleToolCall(params: any) {
         await handleGitLabError(response);
         const data = GitLabProtectedBranchSchema.parse(await response.json());
         return {
-          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(data) }],
         };
       }
 
@@ -11585,7 +11585,7 @@ async function handleToolCall(params: any) {
 
         await handleGitLabError(response);
         return {
-          content: [{ type: "text", text: JSON.stringify({ status: "unprotected", branch: args.branch_name }, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify({ status: "unprotected", branch: args.branch_name }) }],
         };
       }
 
@@ -11606,7 +11606,7 @@ async function handleToolCall(params: any) {
         await handleGitLabError(response);
         const data = await response.json();
         return {
-          content: [{ type: "text", text: JSON.stringify({ status: "updated", default_branch: args.default_branch, project: data }, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify({ status: "updated", default_branch: args.default_branch, project: data }) }],
         };
       }
 

--- a/test/test-list-issues.ts
+++ b/test/test-list-issues.ts
@@ -6,8 +6,8 @@ import { MockGitLabServer, findMockServerPort } from "./utils/mock-gitlab-server
 const MOCK_TOKEN = "glpat-mock-token-12345";
 const TEST_PROJECT_ID = "123";
 
-async function callListIssues(args: Record<string, unknown> = {}, env: NodeJS.ProcessEnv) {
-  return new Promise<unknown[]>((resolve, reject) => {
+async function callListIssuesResult(args: Record<string, unknown> = {}, env: NodeJS.ProcessEnv) {
+  return new Promise<{ data: unknown[]; text?: string }>((resolve, reject) => {
     const proc = spawn("node", ["build/index.js"], {
       stdio: ["pipe", "pipe", "pipe"],
       env: {
@@ -40,12 +40,12 @@ async function callListIssues(args: Record<string, unknown> = {}, env: NodeJS.Pr
           const content = response.result?.content?.[0]?.text;
           if (content) {
             try {
-              resolve(JSON.parse(content));
+              resolve({ data: JSON.parse(content), text: content });
             } catch {
               reject(new Error(`Failed to parse tool output JSON: ${content}`));
             }
           } else {
-            resolve(response.result);
+            resolve({ data: response.result });
           }
         }
       } catch (e) {
@@ -62,6 +62,10 @@ async function callListIssues(args: Record<string, unknown> = {}, env: NodeJS.Pr
       }) + "\n"
     );
   });
+}
+
+async function callListIssues(args: Record<string, unknown> = {}, env: NodeJS.ProcessEnv) {
+  return (await callListIssuesResult(args, env)).data;
 }
 
 describe("list_issues", () => {
@@ -97,6 +101,20 @@ describe("list_issues", () => {
     assert.ok(firstIssue && typeof firstIssue === "object" && "title" in firstIssue);
     const title = Reflect.get(firstIssue, "title");
     assert.strictEqual(title, "Test Issue 1");
+  });
+
+  test("returns compact JSON text", async () => {
+    const result = await callListIssuesResult(
+      { project_id: TEST_PROJECT_ID },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+      }
+    );
+
+    assert.ok(result.text, "Tool response should include text content");
+    assert.doesNotMatch(result.text!, /\n\s+\"/, "Tool response JSON should not be pretty-printed");
+    assert.ok(Array.isArray(result.data), "Response should remain valid JSON");
   });
 
   test("prefers author_username over author_id when both are provided", async () => {

--- a/test/test-list-issues.ts
+++ b/test/test-list-issues.ts
@@ -113,7 +113,7 @@ describe("list_issues", () => {
     );
 
     assert.ok(result.text, "Tool response should include text content");
-    assert.doesNotMatch(result.text!, /\n\s+\"/, "Tool response JSON should not be pretty-printed");
+    assert.doesNotMatch(result.text!, /\n\s+"/, "Tool response JSON should not be pretty-printed");
     assert.ok(Array.isArray(result.data), "Response should remain valid JSON");
   });
 


### PR DESCRIPTION
## Summary

- Compact tool response JSON by removing pretty-print whitespace.
- Keep the response payloads as JSON instead of switching to YAML, so existing clients can continue parsing `content[0].text` with `JSON.parse`.
- Add coverage that `list_issues` still returns valid JSON and is no longer pretty-printed.

This addresses the token/size goal from #284 without a new YAML dependency or a response-format break.

## Test plan

- [x] `npm run build`
- [x] `tsx test/test-list-issues.ts`
- [x] `tsx test/test-list-merge-requests.ts`
- [x] `node --import tsx/esm --test test/test-issue-description-patch.ts`
- [x] `node --import tsx/esm --test test/test-token-optimizations.ts`
- [ ] CI

Closes #284

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only serialization change with the same JSON structure; low risk aside from clients that depended on pretty-printed whitespace.
> 
> **Overview**
> Shrinks MCP tool output by serializing JSON **without** pretty-printing (`JSON.stringify` no longer passes `null, 2`) across `index.ts` handlers, including `discover_tools` and the GitLab API tool switch cases. Payload shape is unchanged—still JSON in `content[0].text`—so clients can keep using `JSON.parse`.
> 
> Adds a `list_issues` integration test that asserts the raw text is compact (no indented newlines) while remaining valid JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee297029a20426ee59e473d630a29dbe0b078c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->