### PR TITLE
fix: expose metrics in Prometheus format

### DIFF
--- a/docs/configuration/dynamic-api-url.md
+++ b/docs/configuration/dynamic-api-url.md
@@ -220,13 +220,19 @@ curl -X POST http://localhost:3002/mcp \
 
 ### Pool Statistics
 
-You can monitor the connection pool via the metrics endpoint:
+Prometheus can scrape the metrics endpoint directly:
 
 ```bash
 curl http://localhost:3002/metrics
 ```
 
-Response:
+JSON metrics remain available for scripts:
+
+```bash
+curl http://localhost:3002/metrics.json
+```
+
+JSON response:
 ```json
 {
   "activeSessions": 5,

--- a/docs/configuration/stateless-mode.md
+++ b/docs/configuration/stateless-mode.md
@@ -226,10 +226,10 @@ termination. In non-OAuth modes the behaviour is unchanged.
 
 ### Metrics
 
-The `/metrics` endpoint reports per-instance counters. In stateless mode,
-`activeSessions` and `authenticatedSessions` become less meaningful (each
-request is its own session from the pod's perspective) — scale your
-dashboards accordingly.
+The `/metrics` endpoint reports Prometheus per-instance counters. JSON metrics
+are available at `/metrics.json`. In stateless mode, `activeSessions` and
+`authenticatedSessions` become less meaningful (each request is its own session
+from the pod's perspective) — scale your dashboards accordingly.
 
 ### Interop with legacy clients
 

--- a/index.ts
+++ b/index.ts
@@ -12736,25 +12736,120 @@ async function startStreamableHTTPServer(): Promise<void> {
     });
   });
 
+  const getMetricsSnapshot = () => ({
+    ...metrics,
+    activeSessions: Object.keys(streamableTransports).length,
+    authenticatedSessions: Object.keys(authBySession).length,
+    gitlabClientPool: clientPool.getStats(),
+    uptime: process.uptime(),
+    memoryUsage: process.memoryUsage(),
+    config: {
+      maxSessions: MAX_SESSIONS,
+      maxRequestsPerMinute: MAX_REQUESTS_PER_MINUTE,
+      sessionTimeoutSeconds: SESSION_TIMEOUT_SECONDS,
+      remoteAuthEnabled: REMOTE_AUTHORIZATION,
+      mcpOAuthEnabled: GITLAB_MCP_OAUTH,
+      statelessModeEnabled: OAUTH_STATELESS_MODE && STATELESS_MATERIAL !== null,
+      statelessRotationKey: OAUTH_STATELESS_MODE && STATELESS_MATERIAL?.previous != null,
+    },
+  });
+
+  const escapePrometheusLabel = (value: unknown) =>
+    String(value).replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+
+  const formatPrometheusMetrics = () => {
+    const snapshot = getMetricsSnapshot();
+    const configLabels = Object.entries({
+      max_sessions: snapshot.config.maxSessions,
+      max_requests_per_minute: snapshot.config.maxRequestsPerMinute,
+      session_timeout_seconds: snapshot.config.sessionTimeoutSeconds,
+      remote_auth_enabled: snapshot.config.remoteAuthEnabled,
+      mcp_oauth_enabled: snapshot.config.mcpOAuthEnabled,
+      stateless_mode_enabled: snapshot.config.statelessModeEnabled,
+      stateless_rotation_key: snapshot.config.statelessRotationKey,
+    })
+      .map(([key, value]) => `${key}="${escapePrometheusLabel(value)}"`)
+      .join(",");
+
+    return [
+      "# HELP gitlab_mcp_requests_processed_total Total MCP requests processed",
+      "# TYPE gitlab_mcp_requests_processed_total counter",
+      `gitlab_mcp_requests_processed_total ${snapshot.requestsProcessed}`,
+      "",
+      "# HELP gitlab_mcp_requests_rejected_total Requests rejected, by reason",
+      "# TYPE gitlab_mcp_requests_rejected_total counter",
+      `gitlab_mcp_requests_rejected_total{reason="rate_limit"} ${snapshot.rejectedByRateLimit}`,
+      `gitlab_mcp_requests_rejected_total{reason="capacity"} ${snapshot.rejectedByCapacity}`,
+      "",
+      "# HELP gitlab_mcp_auth_failures_total Authentication failures",
+      "# TYPE gitlab_mcp_auth_failures_total counter",
+      `gitlab_mcp_auth_failures_total ${snapshot.authFailures}`,
+      "",
+      "# HELP gitlab_mcp_sessions_total Total sessions created",
+      "# TYPE gitlab_mcp_sessions_total counter",
+      `gitlab_mcp_sessions_total ${snapshot.totalSessions}`,
+      "",
+      "# HELP gitlab_mcp_sessions_expired_total Sessions expired due to inactivity",
+      "# TYPE gitlab_mcp_sessions_expired_total counter",
+      `gitlab_mcp_sessions_expired_total ${snapshot.expiredSessions}`,
+      "",
+      "# HELP gitlab_mcp_active_sessions Currently active sessions",
+      "# TYPE gitlab_mcp_active_sessions gauge",
+      `gitlab_mcp_active_sessions ${snapshot.activeSessions}`,
+      "",
+      "# HELP gitlab_mcp_authenticated_sessions Currently authenticated sessions",
+      "# TYPE gitlab_mcp_authenticated_sessions gauge",
+      `gitlab_mcp_authenticated_sessions ${snapshot.authenticatedSessions}`,
+      "",
+      "# HELP gitlab_mcp_client_pool_size Current GitLab client pool size",
+      "# TYPE gitlab_mcp_client_pool_size gauge",
+      `gitlab_mcp_client_pool_size ${snapshot.gitlabClientPool.size}`,
+      "",
+      "# HELP gitlab_mcp_client_pool_max_size Maximum GitLab client pool size",
+      "# TYPE gitlab_mcp_client_pool_max_size gauge",
+      `gitlab_mcp_client_pool_max_size ${snapshot.gitlabClientPool.maxSize}`,
+      "",
+      "# HELP gitlab_mcp_uptime_seconds Process uptime in seconds",
+      "# TYPE gitlab_mcp_uptime_seconds gauge",
+      `gitlab_mcp_uptime_seconds ${snapshot.uptime}`,
+      "",
+      "# HELP gitlab_mcp_memory_usage_bytes Node.js memory usage by type",
+      "# TYPE gitlab_mcp_memory_usage_bytes gauge",
+      ...Object.entries(snapshot.memoryUsage).map(
+        ([key, value]) => `gitlab_mcp_memory_usage_bytes{type="${escapePrometheusLabel(key)}"} ${value}`
+      ),
+      "",
+      "# HELP gitlab_mcp_stateless_requests_total Stateless MCP requests processed",
+      "# TYPE gitlab_mcp_stateless_requests_total counter",
+      `gitlab_mcp_stateless_requests_total ${snapshot.statelessRequests}`,
+      "",
+      "# HELP gitlab_mcp_stateless_auth_total Stateless auth successes, by source",
+      "# TYPE gitlab_mcp_stateless_auth_total counter",
+      `gitlab_mcp_stateless_auth_total{source="header"} ${snapshot.statelessAuthFromHeader}`,
+      `gitlab_mcp_stateless_auth_total{source="sealed_session_id"} ${snapshot.statelessAuthFromSealedSid}`,
+      "",
+      "# HELP gitlab_mcp_stateless_auth_failures_total Stateless auth failures",
+      "# TYPE gitlab_mcp_stateless_auth_failures_total counter",
+      `gitlab_mcp_stateless_auth_failures_total ${snapshot.statelessAuthFailures}`,
+      "",
+      "# HELP gitlab_mcp_stateless_session_id_rotations_total Stateless session id rotations",
+      "# TYPE gitlab_mcp_stateless_session_id_rotations_total counter",
+      `gitlab_mcp_stateless_session_id_rotations_total ${snapshot.statelessSidRotated}`,
+      "",
+      "# HELP gitlab_mcp_config_info Static configuration (value is always 1)",
+      "# TYPE gitlab_mcp_config_info gauge",
+      `gitlab_mcp_config_info{${configLabels}} 1`,
+      "",
+    ].join("\n");
+  };
+
   // Metrics endpoint
   app.get("/metrics", (_req: Request, res: Response) => {
-    res.json({
-      ...metrics,
-      activeSessions: Object.keys(streamableTransports).length,
-      authenticatedSessions: Object.keys(authBySession).length,
-      gitlabClientPool: clientPool.getStats(),
-      uptime: process.uptime(),
-      memoryUsage: process.memoryUsage(),
-      config: {
-        maxSessions: MAX_SESSIONS,
-        maxRequestsPerMinute: MAX_REQUESTS_PER_MINUTE,
-        sessionTimeoutSeconds: SESSION_TIMEOUT_SECONDS,
-        remoteAuthEnabled: REMOTE_AUTHORIZATION,
-        mcpOAuthEnabled: GITLAB_MCP_OAUTH,
-        statelessModeEnabled: OAUTH_STATELESS_MODE && STATELESS_MATERIAL !== null,
-        statelessRotationKey: OAUTH_STATELESS_MODE && STATELESS_MATERIAL?.previous != null,
-      },
-    });
+    res.type("text/plain; version=0.0.4").send(formatPrometheusMetrics());
+  });
+
+  app.get("/metrics.json", (_req: Request, res: Response) => {
+    res.json(getMetricsSnapshot());
   });
 
   // Health check endpoint

--- a/test/dynamic-api-url-test.ts
+++ b/test/dynamic-api-url-test.ts
@@ -282,7 +282,7 @@ describe('Dynamic API URL - Connection Pool', () => {
     });
     servers.push(server);
     mcpUrl = `http://${HOST}:${mcpPort}/mcp`;
-    metricsUrl = `http://${HOST}:${mcpPort}/metrics`;
+    metricsUrl = `http://${HOST}:${mcpPort}/metrics.json`;
 
     console.log(`MCP Server: ${mcpUrl}`);
     console.log(`Metrics URL: ${metricsUrl}`);
@@ -298,7 +298,7 @@ describe('Dynamic API URL - Connection Pool', () => {
     }
   });
 
-  test('should track pool statistics via metrics endpoint', async () => {
+  test('should track pool statistics via metrics JSON endpoint', async () => {
     // Make some connections first
     const client1 = new CustomHeaderClient({
       'authorization': `Bearer ${MOCK_TOKEN_1}`,
@@ -317,7 +317,7 @@ describe('Dynamic API URL - Connection Pool', () => {
 
     // Check metrics
     const response = await fetch(metricsUrl);
-    assert.ok(response.ok, 'Metrics endpoint should be accessible');
+    assert.ok(response.ok, 'Metrics JSON endpoint should be accessible');
     
     const metrics = await response.json();
     assert.ok(metrics.gitlabClientPool, 'Should have pool metrics');

--- a/test/remote-auth-simple-test.ts
+++ b/test/remote-auth-simple-test.ts
@@ -34,9 +34,9 @@ const KEEPALIVE_INTERVAL_MS = 2000; // Must be less than SESSION_TIMEOUT_SECONDS
 const KEEPALIVE_REQUEST_COUNT = 3; // Number of keepalive requests to test
 
 async function getMetrics(mcpUrl: string): Promise<{ activeSessions: number; authenticatedSessions: number }> {
-  const metricsUrl = mcpUrl.replace(/\/mcp$/, '/metrics');
+  const metricsUrl = mcpUrl.replace(/\/mcp$/, '/metrics.json');
   const response = await fetch(metricsUrl);
-  assert.strictEqual(response.status, 200, 'metrics endpoint should be available');
+  assert.strictEqual(response.status, 200, 'metrics JSON endpoint should be available');
   return (await response.json()) as { activeSessions: number; authenticatedSessions: number };
 }
 
@@ -174,6 +174,19 @@ describe('Remote Authorization - Basic Functionality', () => {
     console.log('  ✓ Multiple tool list calls successful with persistent auth');
 
     await client.disconnect();
+  });
+
+  test('should expose Prometheus metrics at /metrics', async () => {
+    const metricsUrl = mcpUrl.replace(/\/mcp$/, '/metrics');
+    const response = await fetch(metricsUrl);
+    assert.strictEqual(response.status, 200, 'metrics endpoint should be available');
+    assert.match(response.headers.get('content-type') || '', /^text\/plain/);
+
+    const body = await response.text();
+    assert.match(body, /# HELP gitlab_mcp_requests_processed_total/);
+    assert.match(body, /# TYPE gitlab_mcp_active_sessions gauge/);
+    assert.match(body, /gitlab_mcp_config_info\{[^}]*remote_auth_enabled="true"/);
+    console.log('  ✓ Prometheus metrics available');
   });
 
   test('should reject connection without auth header', async () => {


### PR DESCRIPTION
## Summary

- Serve Prometheus text exposition from `/metrics`.
- Keep the existing JSON metrics payload at `/metrics.json` for compatibility.
- Update tests/docs that consume the JSON metrics endpoint.

## Test plan

- [x] `npm run build`
- [x] `node --import tsx/esm --test test/remote-auth-simple-test.ts`
- [x] `node --import tsx/esm --test test/dynamic-api-url-test.ts`
- [x] `node --import tsx/esm --test test/streamable-http-static-token-auth.test.ts`
- [ ] CI

Closes #500

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only surface change with backward-compatible JSON at a new path; operators scraping `/metrics` as JSON must switch to `/metrics.json`.
> 
> **Overview**
> **`/metrics` now serves Prometheus text exposition** (`text/plain; version=0.0.4`) instead of JSON. The previous snapshot is unchanged at **`/metrics.json`**, built from a shared `getMetricsSnapshot()` helper.
> 
> Prometheus output adds `gitlab_mcp_*` counters/gauges for request volume, rejections, auth/session stats, client pool size, uptime, memory by type, stateless-mode counters, and a `gitlab_mcp_config_info` gauge with config labels.
> 
> Docs describe Prometheus scraping on `/metrics` and script use of `/metrics.json`. Tests that asserted JSON metrics now hit `/metrics.json`; **`remote-auth-simple-test`** adds coverage for Prometheus content-type and sample metric lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50fa4b7be8ceba176c74fbd83cf3a9265c87e667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->