### PR TITLE
feat(oauth): support external token script

### DIFF
--- a/docs/auth/oauth-setup.md
+++ b/docs/auth/oauth-setup.md
@@ -157,6 +157,20 @@ The MCP server automatically handles token refresh:
 - Automatically refreshes the token if it's expired (or will expire within 5 minutes)
 - If refresh fails, it will restart the OAuth flow
 
+## External Token Script
+
+If another tool already manages OAuth credentials, let gitlab-mcp ask that tool
+for a token:
+
+```bash
+GITLAB_USE_OAUTH=true \
+GITLAB_OAUTH_TOKEN_SCRIPT="coder external-auth access-token gitlab"
+```
+
+The script must print an access token to stdout. JSON output with an
+`access_token` or `token` field is also accepted. When this is set, gitlab-mcp
+skips the browser flow and token file refresh.
+
 ## Using a Different Port
 
 If port 8888 is already in use, you can use a different port:

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -57,6 +57,25 @@ Default:
 
 Optional custom path for the stored OAuth token file.
 
+### `GITLAB_OAUTH_TOKEN_SCRIPT`
+
+Optional command that prints an OAuth access token to stdout. When set with
+`GITLAB_USE_OAUTH=true`, the server uses this command instead of the local
+browser OAuth flow and token file refresh.
+
+Example:
+
+```bash
+GITLAB_USE_OAUTH=true \
+GITLAB_OAUTH_TOKEN_SCRIPT="coder external-auth access-token gitlab"
+```
+
+The command may also print JSON with an `access_token` or `token` field.
+
+### `GITLAB_OAUTH_TOKEN_SCRIPT_TIMEOUT_SECONDS`
+
+Timeout for `GITLAB_OAUTH_TOKEN_SCRIPT`. Default: `30`.
+
 ## Remote / Multi-User Authentication
 
 ### `REMOTE_AUTHORIZATION`

--- a/oauth.ts
+++ b/oauth.ts
@@ -5,6 +5,8 @@ import * as path from "path";
 import * as http from "http";
 import * as net from "net";
 import * as url from "url";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import open from "open";
 import pkceChallenge from "pkce-challenge";
 import { pino } from "pino";
@@ -13,6 +15,8 @@ const logger = pino({
   name: "gitlab-mcp-oauth",
   level: process.env.LOG_LEVEL || "info",
 }, pino.destination(2));
+
+const execFileAsync = promisify(execFile);
 
 function escapeHtml(str: string): string {
   const map: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
@@ -44,6 +48,7 @@ interface OAuthConfig {
   gitlabUrl: string;
   scopes: string[];
   tokenStoragePath?: string;
+  tokenScript?: string;
 }
 
 /**
@@ -561,9 +566,64 @@ export class GitLabOAuth {
   }
 
   /**
+   * Get an access token from an external command.
+   */
+  private async getScriptToken(): Promise<TokenData> {
+    if (!this.config.tokenScript) {
+      throw new Error("OAuth token script is not configured");
+    }
+
+    const shell = process.platform === "win32" ? process.env.ComSpec || "cmd.exe" : "/bin/sh";
+    const args = process.platform === "win32"
+      ? ["/d", "/s", "/c", this.config.tokenScript]
+      : ["-c", this.config.tokenScript];
+    const timeoutSeconds = Number.parseInt(process.env.GITLAB_OAUTH_TOKEN_SCRIPT_TIMEOUT_SECONDS || "30", 10);
+    const timeoutMs = (Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : 30) * 1000;
+    const { stdout } = await execFileAsync(shell, args, {
+      timeout: timeoutMs,
+      maxBuffer: 1024 * 1024,
+    });
+    const output = stdout.trim();
+
+    if (!output) {
+      throw new Error("OAuth token script produced no output");
+    }
+
+    let accessToken = output;
+    try {
+      const parsed = JSON.parse(output) as unknown;
+      if (typeof parsed === "string") {
+        accessToken = parsed;
+      } else if (parsed && typeof parsed === "object") {
+        const value = (parsed as { access_token?: unknown; token?: unknown }).access_token ??
+          (parsed as { token?: unknown }).token;
+        if (typeof value === "string") {
+          accessToken = value;
+        }
+      }
+    } catch {
+      // Plain-token stdout is the common case.
+    }
+
+    if (!accessToken.trim()) {
+      throw new Error("OAuth token script returned an empty token");
+    }
+
+    return {
+      access_token: accessToken.trim(),
+      created_at: Date.now(),
+      token_type: "Bearer",
+    };
+  }
+
+  /**
    * Get a valid access token, refreshing if necessary
    */
   async getAccessToken(force = false): Promise<string> {
+    if (this.config.tokenScript) {
+      return (await this.getScriptToken()).access_token;
+    }
+
     let tokenData = this.loadToken();
 
     // If no token or expired (or forced), start OAuth flow or refresh
@@ -607,6 +667,10 @@ export class GitLabOAuth {
    * Check if a valid token exists
    */
   hasValidToken(): boolean {
+    if (this.config.tokenScript) {
+      return true;
+    }
+
     const tokenData = this.loadToken();
     if (!tokenData) {
       return false;
@@ -625,20 +689,22 @@ export async function initializeOAuthClient(gitlabUrl: string = "https://gitlab.
   const clientSecret = process.env.GITLAB_OAUTH_CLIENT_SECRET;
   const redirectUri = process.env.GITLAB_OAUTH_REDIRECT_URI || "http://127.0.0.1:8888/callback";
   const tokenStoragePath = process.env.GITLAB_OAUTH_TOKEN_PATH;
+  const tokenScript = process.env.GITLAB_OAUTH_TOKEN_SCRIPT;
 
-  if (!clientId) {
+  if (!clientId && !tokenScript) {
     throw new Error(
-      "GITLAB_OAUTH_CLIENT_ID environment variable is required for OAuth authentication"
+      "GITLAB_OAUTH_CLIENT_ID or GITLAB_OAUTH_TOKEN_SCRIPT environment variable is required for OAuth authentication"
     );
   }
 
   const oauth = new GitLabOAuth({
-    clientId,
+    clientId: clientId || "external-token-script",
     clientSecret,
     redirectUri,
     gitlabUrl,
     scopes: [process.env.GITLAB_READ_ONLY_MODE === "true" ? "read_api" : "api"],
     tokenStoragePath,
+    tokenScript,
   });
 
   // Single call: triggers browser flow if needed, or reads cached token

--- a/oauth.ts
+++ b/oauth.ts
@@ -597,11 +597,15 @@ export class GitLabOAuth {
       } else if (parsed && typeof parsed === "object") {
         const value = (parsed as { access_token?: unknown; token?: unknown }).access_token ??
           (parsed as { token?: unknown }).token;
-        if (typeof value === "string") {
-          accessToken = value;
+        if (typeof value !== "string") {
+          throw new Error("OAuth token script JSON must include a string access_token or token field");
         }
+        accessToken = value;
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith("OAuth token script JSON")) {
+        throw error;
+      }
       // Plain-token stdout is the common case.
     }
 

--- a/test/oauth-tests.ts
+++ b/test/oauth-tests.ts
@@ -273,21 +273,41 @@ async function testPortAvailability(): Promise<void> {
 // Test: External OAuth token script
 async function testOAuthTokenScript(): Promise<void> {
   const scriptPath = path.join(process.cwd(), '.test-oauth-token-script.sh');
-  fs.writeFileSync(scriptPath, '#!/bin/sh\nprintf "%s\\n" "script-token-123"\n', { mode: 0o700 });
+
+  const writeScript = (output: string) => {
+    fs.writeFileSync(scriptPath, `#!/bin/sh\nprintf '%s\\n' '${output}'\n`, { mode: 0o700 });
+  };
+
+  const oauth = () => new GitLabOAuth({
+    clientId: TEST_CLIENT_ID,
+    redirectUri: TEST_REDIRECT_URI,
+    gitlabUrl: TEST_GITLAB_URL,
+    scopes: ['api'],
+    tokenStoragePath: TEST_TOKEN_PATH,
+    tokenScript: scriptPath,
+  });
 
   try {
-    const oauth = new GitLabOAuth({
-      clientId: TEST_CLIENT_ID,
-      redirectUri: TEST_REDIRECT_URI,
-      gitlabUrl: TEST_GITLAB_URL,
-      scopes: ['api'],
-      tokenStoragePath: TEST_TOKEN_PATH,
-      tokenScript: scriptPath,
-    });
+    writeScript('script-token-123');
+    const plainToken = await oauth().getAccessToken();
+    assert(plainToken === 'script-token-123', 'Should return plain token from external script');
+    assert(oauth().hasValidToken(), 'Token script should count as a valid token source');
 
-    const token = await oauth.getAccessToken();
-    assert(token === 'script-token-123', 'Should return token from external script');
-    assert(oauth.hasValidToken(), 'Token script should count as a valid token source');
+    writeScript(JSON.stringify({ access_token: 'json-token-123' }));
+    const jsonToken = await oauth().getAccessToken();
+    assert(jsonToken === 'json-token-123', 'Should extract access_token from JSON output');
+
+    writeScript(JSON.stringify({ expires_in: 3600 }));
+    try {
+      await oauth().getAccessToken();
+      assert(false, 'Should reject JSON output without a token field');
+    } catch (error) {
+      assert(
+        error instanceof Error &&
+          error.message.includes('OAuth token script JSON must include a string access_token or token field'),
+        'Should explain missing token field in JSON output'
+      );
+    }
   } finally {
     if (fs.existsSync(scriptPath)) {
       fs.unlinkSync(scriptPath);

--- a/test/oauth-tests.ts
+++ b/test/oauth-tests.ts
@@ -270,6 +270,31 @@ async function testPortAvailability(): Promise<void> {
   assert(typeof available === 'boolean', 'Port availability check should return boolean');
 }
 
+// Test: External OAuth token script
+async function testOAuthTokenScript(): Promise<void> {
+  const scriptPath = path.join(process.cwd(), '.test-oauth-token-script.sh');
+  fs.writeFileSync(scriptPath, '#!/bin/sh\nprintf "%s\\n" "script-token-123"\n', { mode: 0o700 });
+
+  try {
+    const oauth = new GitLabOAuth({
+      clientId: TEST_CLIENT_ID,
+      redirectUri: TEST_REDIRECT_URI,
+      gitlabUrl: TEST_GITLAB_URL,
+      scopes: ['api'],
+      tokenStoragePath: TEST_TOKEN_PATH,
+      tokenScript: scriptPath,
+    });
+
+    const token = await oauth.getAccessToken();
+    assert(token === 'script-token-123', 'Should return token from external script');
+    assert(oauth.hasValidToken(), 'Token script should count as a valid token source');
+  } finally {
+    if (fs.existsSync(scriptPath)) {
+      fs.unlinkSync(scriptPath);
+    }
+  }
+}
+
 // Test 11: OAuth redirect URI parsing
 async function testRedirectUriParsing(): Promise<void> {
   const redirectUri = 'http://127.0.0.1:8888/callback';
@@ -420,6 +445,7 @@ async function runOAuthTests(): Promise<boolean> {
     testTokenFilePermissions,
     process.platform === 'win32'
   );
+  await runTest('External OAuth token script', testOAuthTokenScript, process.platform === 'win32');
 
   // Network and configuration tests
   await runTest('Port availability check', testPortAvailability);


### PR DESCRIPTION
## Summary

- Add `GITLAB_OAUTH_TOKEN_SCRIPT` for local OAuth users who already have an external credential manager.
- Accept either a plain token on stdout or JSON with `access_token` / `token`.
- Add `GITLAB_OAUTH_TOKEN_SCRIPT_TIMEOUT_SECONDS` with a 30s default.
- Document the Coder-style setup from #312.

When the script is configured, gitlab-mcp skips the browser OAuth flow and token-file refresh.

## Test plan

- [x] `npm run build`
- [x] `tsx test/oauth-tests.ts`
- [x] `node --import tsx/esm --test test/test-auth-retry.ts`
- [ ] CI

Closes #312

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OAuth tokens are obtained on every API call when the script is enabled; misconfigured or slow scripts can break auth, though the browser flow is unchanged without the env var.
> 
> **Overview**
> Adds **external OAuth token sourcing** so gitlab-mcp can use credentials from another tool (e.g. Coder) instead of the local browser flow and token file.
> 
> When `GITLAB_OAUTH_TOKEN_SCRIPT` is set with `GITLAB_USE_OAUTH=true`, `getAccessToken()` runs that command via the shell on each request, parses plain stdout or JSON with `access_token` / `token`, and honors `GITLAB_OAUTH_TOKEN_SCRIPT_TIMEOUT_SECONDS` (default 30s). Browser OAuth, refresh, and on-disk token caching are bypassed; `hasValidToken()` treats the script path as always valid. OAuth init now accepts **either** `GITLAB_OAUTH_CLIENT_ID` or the token script.
> 
> Docs cover setup and env vars; oauth tests exercise plain/JSON output and invalid JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554fe2449278f7c3212b1313037a4941bb6f4ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->