### PR TITLE
fix: guard against null project in resolveNamesToIds

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2229,26 +2229,40 @@ async function resolveNamesToIds(
   if (!labelNames?.length && !usernames?.length) {
     return { labelIds: [], userIds: [] };
   }
-  const data = await executeGraphQL<{
-    project: { labels: { nodes: Array<{ id: string; title: string }> } };
+
+  labelNames ??= [];
+  usernames ??= [];
+
+  const labelVars = Object.fromEntries(labelNames.map((name, i) => [`l${i}`, name]));
+  // One alias per label — exact title match via the `title` argument, includes ancestor
+  // group labels, single round trip with no pagination needed.
+  const varDefs = labelNames.map((_, i) => `$l${i}: String!`).join(", ");
+  const aliases = labelNames.map((_, i) =>
+    `l${i}: labels(title: $l${i}, includeAncestorGroups: true, first: 1) { nodes { id } }`
+  ).join(" ");
+
+  const { project, users } = await executeGraphQL<{
+    project: { [alias: string]: { nodes: Array<{ id: string }> } } | null;
     users: { nodes: Array<{ id: string; username: string }> };
   }>(
-    `query($path: ID!, $usernames: [String!]!) {
-      project(fullPath: $path) { labels(includeAncestorGroups: true, first: 250) { nodes { id title } } }
+    `query($path: ID!, $usernames: [String!]!${varDefs ? `, ${varDefs}` : ""}) {
+      project(fullPath: $path) { ${aliases || "__typename"} }
       users(usernames: $usernames) { nodes { id username } }
     }`,
-    { path: projectPath, usernames: usernames || [] }
+    { path: projectPath, usernames, ...labelVars }
   );
-  if (!data.project) {
+
+  if (!project) {
     throw new Error(`Project '${projectPath}' not found or inaccessible`);
   }
-  const labelIds = (labelNames || []).map(name => {
-    const label = data.project.labels.nodes.find(l => l.title === name);
-    if (!label) throw new Error(`Label '${name}' not found in project`);
-    return label.id;
+
+  const labelIds = labelNames.map((name, i) => {
+    const nodes = project[`l${i}`]?.nodes;
+    if (!nodes?.length) throw new Error(`Label '${name}' not found in project`);
+    return nodes[0].id;
   });
-  const userIds = (usernames || []).map(name => {
-    const user = data.users.nodes.find(u => u.username === name);
+  const userIds = usernames.map(name => {
+    const user = users.nodes.find(u => u.username === name);
     if (!user) throw new Error(`User '${name}' not found`);
     return user.id;
   });

--- a/index.ts
+++ b/index.ts
@@ -2239,6 +2239,9 @@ async function resolveNamesToIds(
     }`,
     { path: projectPath, usernames: usernames || [] }
   );
+  if (!data.project) {
+    throw new Error(`Project '${projectPath}' not found or inaccessible`);
+  }
   const labelIds = (labelNames || []).map(name => {
     const label = data.project.labels.nodes.find(l => l.title === name);
     if (!label) throw new Error(`Label '${name}' not found in project`);


### PR DESCRIPTION
## Problem

`resolveNamesToIds` had two issues:

1. When GraphQL returns a 200 with `{"data": {"project": null}}` for an invalid/inaccessible project path, accessing `.labels` on it crashed with an unhandled `TypeError` instead of a meaningful error.
2. Label lookup fetched all project labels (up to 250) client-side and filtered by exact title match. This failed for labels defined at an ancestor group level because `includeAncestorGroups: true` doesn't guarantee all ancestor labels are returned within a single page.

## Solution

1. Added a null guard that throws a clear message before the label lookup.
2. Replaced the bulk-fetch approach with one GraphQL alias per label using the documented title argument on `Project.labels` with `includeAncestorGroups: true`. This resolves each label by exact title server-side in a single round trip — no pagination needed, and ancestor group labels are resolved correctly.