### PR TITLE
chore: update MCP SDK

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "omg-mcp-server",
       "version": "1.0.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1"
+        "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -11,7 +11,7 @@
     "test": "node --test test/run-tests.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1"
+    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.25",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/node-fetch": "^2.6.12",
         "diff": "^9.0.0",
         "express": "^5.1.0",
@@ -811,9 +811,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\""
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.24.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node-fetch": "^2.6.12",
     "diff": "^9.0.0",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- Update `@modelcontextprotocol/sdk` to `^1.29.0` in the root package and lockfile.
- Align the nested `mcp-server` package with the same SDK range.

## Sources inspected
- `package.json`
- `package-lock.json`
- `mcp-server/package.json`
- npm metadata for `@modelcontextprotocol/sdk@1.29.0`

## Validation
- `npm run build`
- `npm run test:schema` — 105 passed, 0 failed; JSON schema helper tests passed
- `node --import tsx/esm --test test/remote-auth-simple-test.ts test/mcp-oauth-tests.ts test/streamable-http-static-token-auth.test.ts test/streamable-http-concurrent-session.test.ts test/streamable-http-unauthenticated-discovery.test.ts test/nullish-tool-arguments-schema.test.ts` — 52 passed, 0 failed
- `cd mcp-server && npm install --ignore-scripts --package-lock=false && npm run build`

## Notes
- Left `zod` and `zod-to-json-schema` pinned to avoid reintroducing the previous schema conversion breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no application code changes; prior zod pins are explicitly left unchanged to avoid schema regressions.
> 
> **Overview**
> Bumps **`@modelcontextprotocol/sdk`** to **`^1.29.0`** in the root **`package.json`** and **`mcp-server/package.json`**, with matching **`package-lock.json`** updates so both packages resolve the same SDK release (root lockfile moves from 1.26.0 to 1.29.0).
> 
> No TypeScript or runtime code changes in this diff—only dependency alignment between the main GitLab MCP server and the nested OMG MCP server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2f40cab0e24da6ee77f8d64ca298c6c351fae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->