### PR TITLE
refactor: extract metrics formatter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -150,6 +150,7 @@ import { registerDownloadProxy } from "./downloads/proxy.js";
 import type { DownloadProxyDependencies } from "./downloads/proxy.js";
 import { createDownloadToken } from "./utils/download-token.js";
 import { determineTransportMode, TransportMode } from "./server/transport-mode.js";
+import { formatPrometheusMetrics } from "./server/metrics.js";
 import { normalizeGitLabApiUrl } from "./utils/url.js";
 import {
   estimateMergeCommitCount,
@@ -13376,98 +13377,9 @@ async function startStreamableHTTPServer(): Promise<void> {
     },
   });
 
-  const escapePrometheusLabel = (value: unknown) =>
-    String(value).replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
-
-  const formatPrometheusMetrics = () => {
-    const snapshot = getMetricsSnapshot();
-    const configLabels = Object.entries({
-      max_sessions: snapshot.config.maxSessions,
-      max_requests_per_minute: snapshot.config.maxRequestsPerMinute,
-      session_timeout_seconds: snapshot.config.sessionTimeoutSeconds,
-      remote_auth_enabled: snapshot.config.remoteAuthEnabled,
-      mcp_oauth_enabled: snapshot.config.mcpOAuthEnabled,
-      stateless_mode_enabled: snapshot.config.statelessModeEnabled,
-      stateless_rotation_key: snapshot.config.statelessRotationKey,
-    })
-      .map(([key, value]) => `${key}="${escapePrometheusLabel(value)}"`)
-      .join(",");
-
-    return [
-      "# HELP gitlab_mcp_requests_processed_total Total MCP requests processed",
-      "# TYPE gitlab_mcp_requests_processed_total counter",
-      `gitlab_mcp_requests_processed_total ${snapshot.requestsProcessed}`,
-      "",
-      "# HELP gitlab_mcp_requests_rejected_total Requests rejected, by reason",
-      "# TYPE gitlab_mcp_requests_rejected_total counter",
-      `gitlab_mcp_requests_rejected_total{reason="rate_limit"} ${snapshot.rejectedByRateLimit}`,
-      `gitlab_mcp_requests_rejected_total{reason="capacity"} ${snapshot.rejectedByCapacity}`,
-      "",
-      "# HELP gitlab_mcp_auth_failures_total Authentication failures",
-      "# TYPE gitlab_mcp_auth_failures_total counter",
-      `gitlab_mcp_auth_failures_total ${snapshot.authFailures}`,
-      "",
-      "# HELP gitlab_mcp_sessions_total Total sessions created",
-      "# TYPE gitlab_mcp_sessions_total counter",
-      `gitlab_mcp_sessions_total ${snapshot.totalSessions}`,
-      "",
-      "# HELP gitlab_mcp_sessions_expired_total Sessions expired due to inactivity",
-      "# TYPE gitlab_mcp_sessions_expired_total counter",
-      `gitlab_mcp_sessions_expired_total ${snapshot.expiredSessions}`,
-      "",
-      "# HELP gitlab_mcp_active_sessions Currently active sessions",
-      "# TYPE gitlab_mcp_active_sessions gauge",
-      `gitlab_mcp_active_sessions ${snapshot.activeSessions}`,
-      "",
-      "# HELP gitlab_mcp_authenticated_sessions Currently authenticated sessions",
-      "# TYPE gitlab_mcp_authenticated_sessions gauge",
-      `gitlab_mcp_authenticated_sessions ${snapshot.authenticatedSessions}`,
-      "",
-      "# HELP gitlab_mcp_client_pool_size Current GitLab client pool size",
-      "# TYPE gitlab_mcp_client_pool_size gauge",
-      `gitlab_mcp_client_pool_size ${snapshot.gitlabClientPool.size}`,
-      "",
-      "# HELP gitlab_mcp_client_pool_max_size Maximum GitLab client pool size",
-      "# TYPE gitlab_mcp_client_pool_max_size gauge",
-      `gitlab_mcp_client_pool_max_size ${snapshot.gitlabClientPool.maxSize}`,
-      "",
-      "# HELP gitlab_mcp_uptime_seconds Process uptime in seconds",
-      "# TYPE gitlab_mcp_uptime_seconds gauge",
-      `gitlab_mcp_uptime_seconds ${snapshot.uptime}`,
-      "",
-      "# HELP gitlab_mcp_memory_usage_bytes Node.js memory usage by type",
-      "# TYPE gitlab_mcp_memory_usage_bytes gauge",
-      ...Object.entries(snapshot.memoryUsage).map(
-        ([key, value]) => `gitlab_mcp_memory_usage_bytes{type="${escapePrometheusLabel(key)}"} ${value}`
-      ),
-      "",
-      "# HELP gitlab_mcp_stateless_requests_total Stateless MCP requests processed",
-      "# TYPE gitlab_mcp_stateless_requests_total counter",
-      `gitlab_mcp_stateless_requests_total ${snapshot.statelessRequests}`,
-      "",
-      "# HELP gitlab_mcp_stateless_auth_total Stateless auth successes, by source",
-      "# TYPE gitlab_mcp_stateless_auth_total counter",
-      `gitlab_mcp_stateless_auth_total{source="header"} ${snapshot.statelessAuthFromHeader}`,
-      `gitlab_mcp_stateless_auth_total{source="sealed_session_id"} ${snapshot.statelessAuthFromSealedSid}`,
-      "",
-      "# HELP gitlab_mcp_stateless_auth_failures_total Stateless auth failures",
-      "# TYPE gitlab_mcp_stateless_auth_failures_total counter",
-      `gitlab_mcp_stateless_auth_failures_total ${snapshot.statelessAuthFailures}`,
-      "",
-      "# HELP gitlab_mcp_stateless_session_id_rotations_total Stateless session id rotations",
-      "# TYPE gitlab_mcp_stateless_session_id_rotations_total counter",
-      `gitlab_mcp_stateless_session_id_rotations_total ${snapshot.statelessSidRotated}`,
-      "",
-      "# HELP gitlab_mcp_config_info Static configuration (value is always 1)",
-      "# TYPE gitlab_mcp_config_info gauge",
-      `gitlab_mcp_config_info{${configLabels}} 1`,
-      "",
-    ].join("\n");
-  };
-
   // Metrics endpoint
   app.get("/metrics", (_req: Request, res: Response) => {
-    res.type("text/plain; version=0.0.4").send(formatPrometheusMetrics());
+    res.type("text/plain; version=0.0.4").send(formatPrometheusMetrics(getMetricsSnapshot()));
   });
 
   app.get("/metrics.json", (_req: Request, res: Response) => {

--- a/server/metrics.ts
+++ b/server/metrics.ts
@@ -1,0 +1,116 @@
+export interface MetricsSnapshot {
+  requestsProcessed: number;
+  rejectedByRateLimit: number;
+  rejectedByCapacity: number;
+  authFailures: number;
+  totalSessions: number;
+  expiredSessions: number;
+  activeSessions: number;
+  authenticatedSessions: number;
+  gitlabClientPool: { size: number; maxSize: number };
+  uptime: number;
+  memoryUsage: NodeJS.MemoryUsage;
+  statelessRequests: number;
+  statelessAuthFromHeader: number;
+  statelessAuthFromSealedSid: number;
+  statelessAuthFailures: number;
+  statelessSidRotated: number;
+  config: {
+    maxSessions: number;
+    maxRequestsPerMinute: number;
+    sessionTimeoutSeconds: number;
+    remoteAuthEnabled: boolean;
+    mcpOAuthEnabled: boolean;
+    statelessModeEnabled: boolean;
+    statelessRotationKey: boolean;
+  };
+}
+
+export function escapePrometheusLabel(value: unknown): string {
+  return String(value).replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+}
+
+export function formatPrometheusMetrics(snapshot: MetricsSnapshot): string {
+  const configLabels = Object.entries({
+    max_sessions: snapshot.config.maxSessions,
+    max_requests_per_minute: snapshot.config.maxRequestsPerMinute,
+    session_timeout_seconds: snapshot.config.sessionTimeoutSeconds,
+    remote_auth_enabled: snapshot.config.remoteAuthEnabled,
+    mcp_oauth_enabled: snapshot.config.mcpOAuthEnabled,
+    stateless_mode_enabled: snapshot.config.statelessModeEnabled,
+    stateless_rotation_key: snapshot.config.statelessRotationKey,
+  })
+    .map(([key, value]) => `${key}="${escapePrometheusLabel(value)}"`)
+    .join(",");
+
+  return [
+    "# HELP gitlab_mcp_requests_processed_total Total MCP requests processed",
+    "# TYPE gitlab_mcp_requests_processed_total counter",
+    `gitlab_mcp_requests_processed_total ${snapshot.requestsProcessed}`,
+    "",
+    "# HELP gitlab_mcp_requests_rejected_total Requests rejected, by reason",
+    "# TYPE gitlab_mcp_requests_rejected_total counter",
+    `gitlab_mcp_requests_rejected_total{reason="rate_limit"} ${snapshot.rejectedByRateLimit}`,
+    `gitlab_mcp_requests_rejected_total{reason="capacity"} ${snapshot.rejectedByCapacity}`,
+    "",
+    "# HELP gitlab_mcp_auth_failures_total Authentication failures",
+    "# TYPE gitlab_mcp_auth_failures_total counter",
+    `gitlab_mcp_auth_failures_total ${snapshot.authFailures}`,
+    "",
+    "# HELP gitlab_mcp_sessions_total Total sessions created",
+    "# TYPE gitlab_mcp_sessions_total counter",
+    `gitlab_mcp_sessions_total ${snapshot.totalSessions}`,
+    "",
+    "# HELP gitlab_mcp_sessions_expired_total Sessions expired due to inactivity",
+    "# TYPE gitlab_mcp_sessions_expired_total counter",
+    `gitlab_mcp_sessions_expired_total ${snapshot.expiredSessions}`,
+    "",
+    "# HELP gitlab_mcp_active_sessions Currently active sessions",
+    "# TYPE gitlab_mcp_active_sessions gauge",
+    `gitlab_mcp_active_sessions ${snapshot.activeSessions}`,
+    "",
+    "# HELP gitlab_mcp_authenticated_sessions Currently authenticated sessions",
+    "# TYPE gitlab_mcp_authenticated_sessions gauge",
+    `gitlab_mcp_authenticated_sessions ${snapshot.authenticatedSessions}`,
+    "",
+    "# HELP gitlab_mcp_client_pool_size Current GitLab client pool size",
+    "# TYPE gitlab_mcp_client_pool_size gauge",
+    `gitlab_mcp_client_pool_size ${snapshot.gitlabClientPool.size}`,
+    "",
+    "# HELP gitlab_mcp_client_pool_max_size Maximum GitLab client pool size",
+    "# TYPE gitlab_mcp_client_pool_max_size gauge",
+    `gitlab_mcp_client_pool_max_size ${snapshot.gitlabClientPool.maxSize}`,
+    "",
+    "# HELP gitlab_mcp_uptime_seconds Process uptime in seconds",
+    "# TYPE gitlab_mcp_uptime_seconds gauge",
+    `gitlab_mcp_uptime_seconds ${snapshot.uptime}`,
+    "",
+    "# HELP gitlab_mcp_memory_usage_bytes Node.js memory usage by type",
+    "# TYPE gitlab_mcp_memory_usage_bytes gauge",
+    ...Object.entries(snapshot.memoryUsage).map(
+      ([key, value]) => `gitlab_mcp_memory_usage_bytes{type="${escapePrometheusLabel(key)}"} ${value}`
+    ),
+    "",
+    "# HELP gitlab_mcp_stateless_requests_total Stateless MCP requests processed",
+    "# TYPE gitlab_mcp_stateless_requests_total counter",
+    `gitlab_mcp_stateless_requests_total ${snapshot.statelessRequests}`,
+    "",
+    "# HELP gitlab_mcp_stateless_auth_total Stateless auth successes, by source",
+    "# TYPE gitlab_mcp_stateless_auth_total counter",
+    `gitlab_mcp_stateless_auth_total{source="header"} ${snapshot.statelessAuthFromHeader}`,
+    `gitlab_mcp_stateless_auth_total{source="sealed_session_id"} ${snapshot.statelessAuthFromSealedSid}`,
+    "",
+    "# HELP gitlab_mcp_stateless_auth_failures_total Stateless auth failures",
+    "# TYPE gitlab_mcp_stateless_auth_failures_total counter",
+    `gitlab_mcp_stateless_auth_failures_total ${snapshot.statelessAuthFailures}`,
+    "",
+    "# HELP gitlab_mcp_stateless_session_id_rotations_total Stateless session id rotations",
+    "# TYPE gitlab_mcp_stateless_session_id_rotations_total counter",
+    `gitlab_mcp_stateless_session_id_rotations_total ${snapshot.statelessSidRotated}`,
+    "",
+    "# HELP gitlab_mcp_config_info Static configuration (value is always 1)",
+    "# TYPE gitlab_mcp_config_info gauge",
+    `gitlab_mcp_config_info{${configLabels}} 1`,
+    "",
+  ].join("\n");
+}

--- a/test/server/metrics.test.ts
+++ b/test/server/metrics.test.ts
@@ -1,0 +1,50 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { escapePrometheusLabel, formatPrometheusMetrics } from "../../server/metrics.js";
+
+describe("Prometheus metrics formatting", () => {
+  test("escapes label values", () => {
+    assert.strictEqual(escapePrometheusLabel('a"b\\c\nd'), 'a\\"b\\\\c\\nd');
+  });
+
+  test("formats current MCP metrics", () => {
+    const body = formatPrometheusMetrics({
+      requestsProcessed: 2,
+      rejectedByRateLimit: 1,
+      rejectedByCapacity: 0,
+      authFailures: 3,
+      totalSessions: 4,
+      expiredSessions: 5,
+      activeSessions: 6,
+      authenticatedSessions: 7,
+      gitlabClientPool: { size: 8, maxSize: 100 },
+      uptime: 9,
+      memoryUsage: {
+        rss: 10,
+        heapTotal: 11,
+        heapUsed: 12,
+        external: 13,
+        arrayBuffers: 14,
+      },
+      statelessRequests: 15,
+      statelessAuthFromHeader: 16,
+      statelessAuthFromSealedSid: 17,
+      statelessAuthFailures: 18,
+      statelessSidRotated: 19,
+      config: {
+        maxSessions: 1000,
+        maxRequestsPerMinute: 60,
+        sessionTimeoutSeconds: 3600,
+        remoteAuthEnabled: true,
+        mcpOAuthEnabled: false,
+        statelessModeEnabled: false,
+        statelessRotationKey: false,
+      },
+    });
+
+    assert.match(body, /# HELP gitlab_mcp_requests_processed_total/);
+    assert.match(body, /gitlab_mcp_requests_processed_total 2/);
+    assert.match(body, /gitlab_mcp_requests_rejected_total\{reason="rate_limit"\} 1/);
+    assert.match(body, /gitlab_mcp_config_info\{[^}]*remote_auth_enabled="true"/);
+  });
+});


### PR DESCRIPTION
## Summary

Part of #516.

This keeps the metrics refactor slice behavior-preserving:

- moves Prometheus metrics escaping/formatting into `server/metrics.ts`
- adds direct unit coverage for label escaping and metric output shape
- keeps metrics counters, snapshots, and Express routes in `index.ts`

## Verification

- `rtk npm run build`
- `node --import tsx/esm --test test/server/metrics.test.ts`
- `rtk npm run test:remote-auth`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of observability output with no auth or request-path changes.
> 
> **Overview**
> Moves Prometheus label escaping and `/metrics` text formatting out of `index.ts` into **`server/metrics.ts`**, with a **`MetricsSnapshot`** type and **`formatPrometheusMetrics(snapshot)`** so formatting is pure and testable.
> 
> The **`/metrics`** handler now passes **`getMetricsSnapshot()`** into that helper; counters, snapshot assembly, and **`/metrics.json`** stay in **`index.ts`**.
> 
> Adds **`test/server/metrics.test.ts`** (label escaping and output shape) and includes it in **`test:mock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a13bbdeac8cf397403b0209c6c6e6b3cf25a99ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->