### PR TITLE
refactor: extract transport mode selection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !mcp-server
 !package-lock.json
 !package.json
+!server
 !stateless
 !tools
 !tsconfig.json

--- a/index.ts
+++ b/index.ts
@@ -199,6 +199,7 @@ import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import { ipKeyGenerator } from "express-rate-limit";
 import { normalizeProxyClientIpForRateLimit } from "./utils/proxy-client-ip.js";
 import { getForwardedPublicBaseUrl } from "./utils/forwarded-public-base-url.js";
+import { determineTransportMode, TransportMode } from "./server/transport-mode.js";
 import { normalizeGitLabApiUrl } from "./utils/url.js";
 import {
   estimateMergeCommitCount,
@@ -613,15 +614,6 @@ const logger = pino({
     },
   },
 });
-
-/**
- * Available transport modes for MCP server
- */
-enum TransportMode {
-  STDIO = "stdio",
-  SSE = "sse",
-  STREAMABLE_HTTP = "streamable-http",
-}
 
 /**
  * Read version from package.json
@@ -11957,29 +11949,6 @@ async function handleToolCall(params: any) {
  */
 const colorGreen = "\x1b[32m";
 const colorReset = "\x1b[0m";
-
-/**
- * Determine the transport mode based on environment variables and availability
- *
- * Transport mode priority (highest to lowest):
- * 1. STREAMABLE_HTTP
- * 2. SSE
- * 3. STDIO
- */
-function determineTransportMode(): TransportMode {
-  // Check for streamable-http support (highest priority)
-  if (STREAMABLE_HTTP) {
-    return TransportMode.STREAMABLE_HTTP;
-  }
-
-  // Check for SSE support (medium priority)
-  if (SSE) {
-    return TransportMode.SSE;
-  }
-
-  // Default to stdio (lowest priority)
-  return TransportMode.STDIO;
-}
 
 /**
  * Start server with stdio transport

--- a/server/transport-mode.ts
+++ b/server/transport-mode.ts
@@ -1,0 +1,24 @@
+import { SSE, STREAMABLE_HTTP } from "../config.js";
+
+/**
+ * Available transport modes for MCP server.
+ */
+export enum TransportMode {
+  STDIO = "stdio",
+  SSE = "sse",
+  STREAMABLE_HTTP = "streamable-http",
+}
+
+/**
+ * Determine the transport mode based on environment variables and availability.
+ *
+ * Transport mode priority (highest to lowest):
+ * 1. STREAMABLE_HTTP
+ * 2. SSE
+ * 3. STDIO
+ */
+export function determineTransportMode(): TransportMode {
+  if (STREAMABLE_HTTP) return TransportMode.STREAMABLE_HTTP;
+  if (SSE) return TransportMode.SSE;
+  return TransportMode.STDIO;
+}


### PR DESCRIPTION
## Summary

Part of #516.

This is a small behavior-preserving server refactor:

- moves `TransportMode` and transport selection priority into `server/transport-mode.ts`
- keeps all startup functions in `index.ts`
- preserves the existing priority: Streamable HTTP > SSE > stdio

## Verification

- `rtk npm run build`
- `rtk npm run test:remote-auth`
- `rtk npm run test:mcp-oauth`
- `node --import tsx/esm --test test/streamable-http-static-token-auth.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with no change to transport priority or startup paths; only module layout and Docker include rules.
> 
> **Overview**
> Moves **`TransportMode`** and **`determineTransportMode()`** out of `index.ts` into **`server/transport-mode.ts`**, with `index.ts` importing them for startup routing. Selection order is unchanged: Streamable HTTP → SSE → stdio.
> 
> **`.dockerignore`** now whitelists the **`server`** directory so Docker image builds include the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64953e4c945e2ad2aab8e1e9d79f1f8fa1b4579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->