### PR TITLE
refactor: extract server version helper

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -132,9 +132,9 @@ import fs from "node:fs";
 import { pipeline as streamPipeline } from "node:stream/promises";
 import os from "node:os";
 import nodeFetch from "node-fetch";
-import path, { dirname } from "node:path";
+import path from "node:path";
 import { CookieJar, parse as parseCookie } from "tough-cookie";
-import { fileURLToPath, URL } from "node:url";
+import { URL } from "node:url";
 import { z } from "zod";
 
 import { initializeOAuthClient, GitLabOAuth } from "./oauth.js";
@@ -151,6 +151,7 @@ import type { DownloadProxyDependencies } from "./downloads/proxy.js";
 import { createDownloadToken } from "./utils/download-token.js";
 import { determineTransportMode, TransportMode } from "./server/transport-mode.js";
 import { formatPrometheusMetrics } from "./server/metrics.js";
+import { SERVER_VERSION } from "./server/version.js";
 import { normalizeGitLabApiUrl } from "./utils/url.js";
 import {
   estimateMergeCommitCount,
@@ -567,22 +568,6 @@ import {
 import { createLogger } from "./utils/logger.js";
 
 const logger = createLogger();
-
-/**
- * Read version from package.json
- */
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const packageJsonPath = path.resolve(__dirname, "../package.json");
-let SERVER_VERSION = "unknown";
-try {
-  if (fs.existsSync(packageJsonPath)) {
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-    SERVER_VERSION = packageJson.version || SERVER_VERSION;
-  }
-} catch {
-  // Intentionally ignored: version read failure is non-critical
-}
 
 const SERVER_NAME = process.env.MCP_SERVER_NAME?.trim() || "zereight-gitlab-mcp-server";
 

--- a/server/version.ts
+++ b/server/version.ts
@@ -17,7 +17,10 @@ export const SERVER_VERSION: string = (() => {
     try {
       if (fs.existsSync(packageJsonPath)) {
         const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-        return packageJson.version || "unknown";
+        const version = packageJson.version;
+        if (typeof version === "string" && version.length > 0) {
+          return version;
+        }
       }
     } catch {
       // Intentionally ignored: version read failure is non-critical.

--- a/server/version.ts
+++ b/server/version.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const packageJsonPaths = [
+  // Source file under tsx/node:test: server/version.ts -> ../package.json
+  path.resolve(__dirname, "../package.json"),
+  // Built file: build/server/version.js -> ../../package.json
+  path.resolve(__dirname, "../../package.json"),
+];
+
+export const SERVER_VERSION: string = (() => {
+  for (const packageJsonPath of packageJsonPaths) {
+    try {
+      if (fs.existsSync(packageJsonPath)) {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+        return packageJson.version || "unknown";
+      }
+    } catch {
+      // Intentionally ignored: version read failure is non-critical.
+    }
+  }
+  return "unknown";
+})();

--- a/test/server/version.test.ts
+++ b/test/server/version.test.ts
@@ -1,0 +1,15 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SERVER_VERSION } from "../../server/version.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJsonPath = path.resolve(__dirname, "../../package.json");
+const packageVersion = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")).version;
+
+test("SERVER_VERSION matches package.json", () => {
+  assert.strictEqual(SERVER_VERSION, packageVersion);
+});


### PR DESCRIPTION
## Summary

Part of #516.

This is a small behavior-preserving extraction:

- moves package version loading into `server/version.ts`
- keeps health endpoint behavior unchanged
- supports both source/test imports and built output path resolution
- adds a direct unit test that `SERVER_VERSION` matches `package.json`

## Verification

- `rtk npm run build`
- `node --import tsx/esm --test test/server/version.test.ts`
- `node -e "import('./build/server/version.js').then(m => { if (!m.SERVER_VERSION || m.SERVER_VERSION === 'unknown') process.exit(1); console.log(m.SERVER_VERSION); })"`
- `rtk npm run test:remote-auth`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with no auth or API logic changes; version is still read from `package.json` for health and MCP metadata.
> 
> **Overview**
> Moves **package version loading** out of `index.ts` into a dedicated `server/version.ts` module that exports `SERVER_VERSION`, so the main entry no longer reads `package.json` inline.
> 
> The helper resolves `package.json` from **either** the compiled layout (`build/server/version.js` → repo root) or when loaded from source/tests (`server/version.ts` → parent), falling back to `"unknown"` if read fails. `index.ts` now imports `SERVER_VERSION` for the MCP server `version` field and the `/health` JSON `version` field—behavior is intended to stay the same.
> 
> Adds `test/server/version.test.ts` (asserts `SERVER_VERSION` matches root `package.json`) and includes it in the `test:mock` script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1f1d0b040c58b8279731d1b713f0cb5cca8bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->