### PR TITLE
refactor: extract download proxy route

### DIFF
--- a/downloads/proxy.ts
+++ b/downloads/proxy.ts
@@ -1,0 +1,197 @@
+import type { Agent } from "node:http";
+import type { Express, Request, Response } from "express";
+import type nodeFetch from "node-fetch";
+import { decryptDownloadToken } from "../utils/download-token.js";
+
+export interface DownloadProxyDependencies {
+  defaultApiUrl: string;
+  enableDynamicApiUrl: boolean;
+  maxRequestsPerMinute: number;
+  normalizeGitLabApiUrl: (url: string) => string;
+  getEffectiveProjectId: (projectId: string) => string;
+  getAgentFunctionForUrl: (apiUrl: string) => (parsedURL: URL) => Agent;
+  fetch: typeof nodeFetch;
+  logger: { error: (obj: unknown, message?: string) => void };
+}
+
+/**
+ * Register the /downloads/:type proxy endpoint on an Express app.
+ * Streams GitLab API responses directly to the client. Auth is read from
+ * an encrypted `_token` query param (self-contained URL) or from request headers.
+ */
+export function registerDownloadProxy(app: Express, deps: DownloadProxyDependencies): void {
+  const downloadRateLimits: Record<string, { count: number; resetAt: number }> = {};
+  let lastEviction = Date.now();
+
+  const checkDownloadRateLimit = (token: string): boolean => {
+    const now = Date.now();
+
+    // Evict expired entries every 60s to prevent unbounded growth
+    if (now - lastEviction > 60000) {
+      for (const key of Object.keys(downloadRateLimits)) {
+        if (now > downloadRateLimits[key].resetAt) delete downloadRateLimits[key];
+      }
+      lastEviction = now;
+    }
+
+    const entry = downloadRateLimits[token];
+    if (!entry || now > entry.resetAt) {
+      downloadRateLimits[token] = { count: 1, resetAt: now + 60000 };
+      return true;
+    }
+    if (entry.count >= deps.maxRequestsPerMinute) return false;
+    entry.count++;
+    return true;
+  };
+
+  app.get("/downloads/:type", async (req: Request, res: Response) => {
+    const headers: Record<string, string> = { Accept: "application/octet-stream" };
+    let rateLimitKey: string;
+
+    // Try embedded encrypted token first (self-contained URL), then headers
+    const encryptedToken = req.query._token as string | undefined;
+    let tokenApiUrl: string | undefined;
+    if (encryptedToken) {
+      const decrypted = decryptDownloadToken(encryptedToken);
+      if (!decrypted) {
+        res.status(401).json({ error: "Invalid or expired download token" });
+        return;
+      }
+      // Verify resource binding — token must match the requested type and params
+      if (decrypted.resourceType || decrypted.resourceParams) {
+        const { type } = req.params;
+        const queryParams: Record<string, string> = {};
+        for (const [k, v] of Object.entries(req.query)) {
+          if (k !== "_token" && typeof v === "string") queryParams[k] = v;
+        }
+        if (
+          decrypted.resourceType !== type ||
+          JSON.stringify(decrypted.resourceParams) !== JSON.stringify(queryParams)
+        ) {
+          res.status(403).json({ error: "Download token does not match the requested resource" });
+          return;
+        }
+      }
+      headers[decrypted.header] = decrypted.token;
+      rateLimitKey = decrypted.token;
+      tokenApiUrl = decrypted.apiUrl;
+    } else {
+      const privateToken = req.headers["private-token"] as string | undefined;
+      const jobToken = req.headers["job-token"] as string | undefined;
+      const authHeader = req.headers["authorization"] as string | undefined;
+
+      if (privateToken) {
+        headers["Private-Token"] = privateToken;
+        rateLimitKey = privateToken;
+      } else if (jobToken) {
+        headers["JOB-TOKEN"] = jobToken;
+        rateLimitKey = jobToken;
+      } else if (authHeader) {
+        headers["Authorization"] = authHeader;
+        rateLimitKey = authHeader;
+      } else {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+    }
+
+    if (!checkDownloadRateLimit(rateLimitKey)) {
+      res.status(429).json({ error: "Rate limit exceeded" });
+      return;
+    }
+
+    // API URL: prefer token-embedded URL, then X-GitLab-API-URL header, then default
+    let apiUrl = tokenApiUrl || deps.defaultApiUrl;
+    if (!tokenApiUrl) {
+      const dynamicApiUrl = (req.headers["x-gitlab-api-url"] as string | undefined)?.trim();
+      if (deps.enableDynamicApiUrl && dynamicApiUrl) {
+        try {
+          new URL(dynamicApiUrl);
+          apiUrl = deps.normalizeGitLabApiUrl(dynamicApiUrl);
+        } catch {
+          res.status(400).json({ error: "Invalid X-GitLab-API-URL" });
+          return;
+        }
+      }
+    }
+
+    const { type } = req.params;
+    let gitlabUrl: string;
+
+    try {
+      switch (type) {
+        case "job-artifacts": {
+          const { project_id, job_id } = req.query as Record<string, string>;
+          if (!project_id || !job_id) {
+            res.status(400).json({ error: "project_id and job_id are required" });
+            return;
+          }
+          const effectiveProjectId = deps.getEffectiveProjectId(decodeURIComponent(project_id));
+          gitlabUrl = `${apiUrl}/projects/${encodeURIComponent(effectiveProjectId)}/jobs/${job_id}/artifacts`;
+          break;
+        }
+        case "attachment": {
+          const { project_id, secret, filename } = req.query as Record<string, string>;
+          if (!project_id || !secret || !filename) {
+            res.status(400).json({ error: "project_id, secret, and filename are required" });
+            return;
+          }
+          const effectiveProjectId = deps.getEffectiveProjectId(decodeURIComponent(project_id));
+          gitlabUrl = `${apiUrl}/projects/${encodeURIComponent(effectiveProjectId)}/uploads/${secret}/${filename}`;
+          break;
+        }
+        case "release-asset": {
+          const { project_id, tag_name, direct_asset_path } = req.query as Record<string, string>;
+          if (!project_id || !tag_name || !direct_asset_path) {
+            res
+              .status(400)
+              .json({ error: "project_id, tag_name, and direct_asset_path are required" });
+            return;
+          }
+          const effectiveProjectId = deps.getEffectiveProjectId(decodeURIComponent(project_id));
+          gitlabUrl = `${apiUrl}/projects/${encodeURIComponent(effectiveProjectId)}/releases/${encodeURIComponent(tag_name)}/downloads/${direct_asset_path}`;
+          break;
+        }
+        default:
+          res.status(400).json({ error: `Unknown download type: ${type}` });
+          return;
+      }
+    } catch (e) {
+      // getEffectiveProjectId throws on access-denied
+      const message = e instanceof Error ? e.message : "Invalid parameters";
+      res.status(403).json({ error: message });
+      return;
+    }
+
+    try {
+      const agent = deps.getAgentFunctionForUrl(apiUrl);
+      const gitlabResponse = await deps.fetch(gitlabUrl, { headers, agent });
+
+      if (!gitlabResponse.ok) {
+        res.status(gitlabResponse.status).json({
+          error: `GitLab API error: ${gitlabResponse.status} ${gitlabResponse.statusText}`,
+        });
+        return;
+      }
+
+      const contentType = gitlabResponse.headers.get("content-type");
+      const contentDisposition = gitlabResponse.headers.get("content-disposition");
+      const contentLength = gitlabResponse.headers.get("content-length");
+
+      if (contentType) res.setHeader("Content-Type", contentType);
+      if (contentDisposition) res.setHeader("Content-Disposition", contentDisposition);
+      if (contentLength) res.setHeader("Content-Length", contentLength);
+
+      if (gitlabResponse.body) {
+        gitlabResponse.body.pipe(res);
+      } else {
+        res.status(502).json({ error: "No response body from GitLab" });
+      }
+    } catch (error) {
+      deps.logger.error({ err: error }, "Download proxy error");
+      if (!res.headersSent) {
+        res.status(502).json({ error: "Failed to proxy download from GitLab" });
+      }
+    }
+  });
+}

--- a/index.ts
+++ b/index.ts
@@ -126,7 +126,8 @@ import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import { ipKeyGenerator } from "express-rate-limit";
 import { normalizeProxyClientIpForRateLimit } from "./utils/proxy-client-ip.js";
 import { getForwardedPublicBaseUrl } from "./utils/forwarded-public-base-url.js";
-import { createDownloadToken, decryptDownloadToken } from "./utils/download-token.js";
+import { registerDownloadProxy } from "./downloads/proxy.js";
+import { createDownloadToken } from "./utils/download-token.js";
 import { normalizeGitLabApiUrl } from "./utils/url.js";
 import {
   estimateMergeCommitCount,
@@ -11923,191 +11924,6 @@ async function startStdioServer(): Promise<void> {
 }
 
 /**
- * Register the /downloads/:type proxy endpoint on an Express app.
- * Streams GitLab API responses directly to the client. Auth is read from
- * an encrypted `_token` query param (self-contained URL) or from request headers.
- */
-function registerDownloadProxy(
-  app: ReturnType<typeof express>,
-  maxRequestsPerMinute: number = Number.parseInt(process.env.MAX_REQUESTS_PER_MINUTE || "60", 10)
-): void {
-  const downloadRateLimits: Record<string, { count: number; resetAt: number }> = {};
-  let lastEviction = Date.now();
-
-  const checkDownloadRateLimit = (token: string): boolean => {
-    const now = Date.now();
-
-    // Evict expired entries every 60s to prevent unbounded growth
-    if (now - lastEviction > 60000) {
-      for (const key of Object.keys(downloadRateLimits)) {
-        if (now > downloadRateLimits[key].resetAt) delete downloadRateLimits[key];
-      }
-      lastEviction = now;
-    }
-
-    const entry = downloadRateLimits[token];
-    if (!entry || now > entry.resetAt) {
-      downloadRateLimits[token] = { count: 1, resetAt: now + 60000 };
-      return true;
-    }
-    if (entry.count >= maxRequestsPerMinute) return false;
-    entry.count++;
-    return true;
-  };
-
-  app.get("/downloads/:type", async (req: Request, res: Response) => {
-    const headers: Record<string, string> = { Accept: "application/octet-stream" };
-    let rateLimitKey: string;
-
-    // Try embedded encrypted token first (self-contained URL), then headers
-    const encryptedToken = req.query._token as string | undefined;
-    let tokenApiUrl: string | undefined;
-    if (encryptedToken) {
-      const decrypted = decryptDownloadToken(encryptedToken);
-      if (!decrypted) {
-        res.status(401).json({ error: "Invalid or expired download token" });
-        return;
-      }
-      // Verify resource binding — token must match the requested type and params
-      if (decrypted.resourceType || decrypted.resourceParams) {
-        const { type } = req.params;
-        const queryParams: Record<string, string> = {};
-        for (const [k, v] of Object.entries(req.query)) {
-          if (k !== "_token" && typeof v === "string") queryParams[k] = v;
-        }
-        if (
-          decrypted.resourceType !== type ||
-          JSON.stringify(decrypted.resourceParams) !== JSON.stringify(queryParams)
-        ) {
-          res.status(403).json({ error: "Download token does not match the requested resource" });
-          return;
-        }
-      }
-      headers[decrypted.header] = decrypted.token;
-      rateLimitKey = decrypted.token;
-      tokenApiUrl = decrypted.apiUrl;
-    } else {
-      const privateToken = req.headers["private-token"] as string | undefined;
-      const jobToken = req.headers["job-token"] as string | undefined;
-      const authHeader = req.headers["authorization"] as string | undefined;
-
-      if (privateToken) {
-        headers["Private-Token"] = privateToken;
-        rateLimitKey = privateToken;
-      } else if (jobToken) {
-        headers["JOB-TOKEN"] = jobToken;
-        rateLimitKey = jobToken;
-      } else if (authHeader) {
-        headers["Authorization"] = authHeader;
-        rateLimitKey = authHeader;
-      } else {
-        res.status(401).json({ error: "Authentication required" });
-        return;
-      }
-    }
-
-    if (!checkDownloadRateLimit(rateLimitKey)) {
-      res.status(429).json({ error: "Rate limit exceeded" });
-      return;
-    }
-
-    // API URL: prefer token-embedded URL, then X-GitLab-API-URL header, then default
-    let apiUrl = tokenApiUrl || GITLAB_API_URL;
-    if (!tokenApiUrl) {
-      const dynamicApiUrl = (req.headers["x-gitlab-api-url"] as string | undefined)?.trim();
-      if (ENABLE_DYNAMIC_API_URL && dynamicApiUrl) {
-        try {
-          new URL(dynamicApiUrl);
-          apiUrl = normalizeGitLabApiUrl(dynamicApiUrl);
-        } catch {
-          res.status(400).json({ error: "Invalid X-GitLab-API-URL" });
-          return;
-        }
-      }
-    }
-
-    const { type } = req.params;
-    let gitlabUrl: string;
-
-    try {
-      switch (type) {
-        case "job-artifacts": {
-          const { project_id, job_id } = req.query as Record<string, string>;
-          if (!project_id || !job_id) {
-            res.status(400).json({ error: "project_id and job_id are required" });
-            return;
-          }
-          const effectiveProjectId = getEffectiveProjectId(decodeURIComponent(project_id));
-          gitlabUrl = `${apiUrl}/projects/${encodeURIComponent(effectiveProjectId)}/jobs/${job_id}/artifacts`;
-          break;
-        }
-        case "attachment": {
-          const { project_id, secret, filename } = req.query as Record<string, string>;
-          if (!project_id || !secret || !filename) {
-            res.status(400).json({ error: "project_id, secret, and filename are required" });
-            return;
-          }
-          const effectiveProjectId = getEffectiveProjectId(decodeURIComponent(project_id));
-          gitlabUrl = `${apiUrl}/projects/${encodeURIComponent(effectiveProjectId)}/uploads/${secret}/${filename}`;
-          break;
-        }
-        case "release-asset": {
-          const { project_id, tag_name, direct_asset_path } = req.query as Record<string, string>;
-          if (!project_id || !tag_name || !direct_asset_path) {
-            res
-              .status(400)
-              .json({ error: "project_id, tag_name, and direct_asset_path are required" });
-            return;
-          }
-          const effectiveProjectId = getEffectiveProjectId(decodeURIComponent(project_id));
-          gitlabUrl = `${apiUrl}/projects/${encodeURIComponent(effectiveProjectId)}/releases/${encodeURIComponent(tag_name)}/downloads/${direct_asset_path}`;
-          break;
-        }
-        default:
-          res.status(400).json({ error: `Unknown download type: ${type}` });
-          return;
-      }
-    } catch (e) {
-      // getEffectiveProjectId throws on access-denied
-      const message = e instanceof Error ? e.message : "Invalid parameters";
-      res.status(403).json({ error: message });
-      return;
-    }
-
-    try {
-      const agent = clientPool.getAgentFunctionForUrl(apiUrl);
-      const gitlabResponse = await nodeFetch(gitlabUrl, { headers, agent });
-
-      if (!gitlabResponse.ok) {
-        res.status(gitlabResponse.status).json({
-          error: `GitLab API error: ${gitlabResponse.status} ${gitlabResponse.statusText}`,
-        });
-        return;
-      }
-
-      const contentType = gitlabResponse.headers.get("content-type");
-      const contentDisposition = gitlabResponse.headers.get("content-disposition");
-      const contentLength = gitlabResponse.headers.get("content-length");
-
-      if (contentType) res.setHeader("Content-Type", contentType);
-      if (contentDisposition) res.setHeader("Content-Disposition", contentDisposition);
-      if (contentLength) res.setHeader("Content-Length", contentLength);
-
-      if (gitlabResponse.body) {
-        gitlabResponse.body.pipe(res);
-      } else {
-        res.status(502).json({ error: "No response body from GitLab" });
-      }
-    } catch (error) {
-      logger.error({ err: error }, "Download proxy error");
-      if (!res.headersSent) {
-        res.status(502).json({ error: "Failed to proxy download from GitLab" });
-      }
-    }
-  });
-}
-
-/**
  * Start server with traditional SSE transport
  */
 async function startSSEServer(): Promise<void> {
@@ -12140,7 +11956,16 @@ async function startSSEServer(): Promise<void> {
     }
   });
 
-  registerDownloadProxy(app);
+  registerDownloadProxy(app, {
+    defaultApiUrl: GITLAB_API_URL,
+    enableDynamicApiUrl: ENABLE_DYNAMIC_API_URL,
+    maxRequestsPerMinute: Number.parseInt(process.env.MAX_REQUESTS_PER_MINUTE || "60", 10),
+    normalizeGitLabApiUrl,
+    getEffectiveProjectId,
+    getAgentFunctionForUrl: clientPool.getAgentFunctionForUrl.bind(clientPool),
+    fetch: nodeFetch,
+    logger,
+  });
 
   app.get("/health", (_: Request, res: Response) => {
     res.status(200).json({
@@ -12572,7 +12397,16 @@ async function startStreamableHTTPServer(): Promise<void> {
 
   app.use(express.json());
 
-  registerDownloadProxy(app);
+  registerDownloadProxy(app, {
+    defaultApiUrl: GITLAB_API_URL,
+    enableDynamicApiUrl: ENABLE_DYNAMIC_API_URL,
+    maxRequestsPerMinute: Number.parseInt(process.env.MAX_REQUESTS_PER_MINUTE || "60", 10),
+    normalizeGitLabApiUrl,
+    getEffectiveProjectId,
+    getAgentFunctionForUrl: clientPool.getAgentFunctionForUrl.bind(clientPool),
+    fetch: nodeFetch,
+    logger,
+  });
 
   // MCP OAuth — mount auth router and prepare bearer-auth middleware
   if (GITLAB_MCP_OAUTH) {


### PR DESCRIPTION
## Summary

Part of #516.

Stacked on #542 because this route extraction imports `utils/download-token.ts` from that PR.

This keeps the route refactor behavior-preserving:

- moves `/downloads/:type` Express proxy registration into `downloads/proxy.ts`
- injects existing dependencies from `index.ts` instead of importing shared server state
- keeps `buildDownloadUrl()` in `index.ts`
- keeps auth fallback order, rate limiting, resource binding, and response handling unchanged

## Verification

- `rtk npm run build`
- `node --import tsx/esm --test test/test-remote-downloads.ts`
- `node --import tsx/esm --test test/test-job-artifacts.ts`
- `tsx test/test-download-attachment.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extraction with explicit dependency injection; download auth and proxy logic are unchanged aside from module boundaries.
> 
> **Overview**
> Moves the **`/downloads/:type`** GitLab download proxy out of **`index.ts`** into **`downloads/proxy.ts`**, with no intended behavior change.
> 
> **`registerDownloadProxy`** now takes a **`DownloadProxyDependencies`** object (API URL defaults, dynamic API URL flag, rate limit, **`normalizeGitLabApiUrl`**, **`getEffectiveProjectId`**, HTTP agent, **`fetch`**, logger) instead of reading server globals. Both SSE and Streamable HTTP startup paths wire the same dependencies from **`index.ts`**.
> 
> **`buildDownloadUrl`** and **`createDownloadToken`** stay in **`index.ts`**; the proxy module only imports **`decryptDownloadToken`** for `_token` handling. Auth order, per-token rate limiting, resource binding checks, download types, and streaming responses are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 502282a5a9f32a35fbe338ec40c0aedb0d723741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->