### PR TITLE
Reduce default GitLab MCP tool surface

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -134,6 +134,8 @@ command = lib.getExe inputs.gitlab-mcp.packages.${system}.default;
 - `--api-url` - GitLab API URL (`GITLAB_API_URL` 대체)
 - `--read-only=true` - 읽기 전용 모드 활성화 (`GITLAB_READ_ONLY_MODE` 대체, deprecated — `--permission-mode=readonly` 권장)
 - `--permission-mode` - 권한 수준: `readonly`, `modify`(삭제 도구 비활성), `full` (`GITLAB_PERMISSION_MODE` 대체, 기본값 `full`)
+- `--toolsets=all` - 지정한 툴셋 활성화 (`GITLAB_TOOLSETS` 대체, 미설정 시 lean `core` 기본값 사용)
+- `--tools=list_issues` - 개별 도구 추가 (`GITLAB_TOOLS` 대체)
 - `--use-wiki=true` - 위키 API 활성화 (`USE_GITLAB_WIKI` 대체, 레거시 — `GITLAB_TOOLSETS=wiki` 권장)
 - `--use-milestone=true` - 마일스톤 API 활성화 (`USE_MILESTONE` 대체, 레거시 — `GITLAB_TOOLSETS=milestones` 권장)
 - `--use-pipeline=true` - 파이프라인 API 활성화 (`USE_PIPELINE` 대체, 레거시 — `GITLAB_TOOLSETS=pipelines` 권장)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Some MCP clients (like GitHub Copilot CLI) have issues with environment variable
 - `--token` - GitLab Personal Access Token (replaces `GITLAB_PERSONAL_ACCESS_TOKEN`)
 - `--api-url` - GitLab API URL (replaces `GITLAB_API_URL`)
 - `--read-only=true` - Enable read-only mode (replaces `GITLAB_READ_ONLY_MODE`)
+- `--toolsets=all` - Enable named toolsets (replaces `GITLAB_TOOLSETS`; unset uses the lean `core` default)
+- `--tools=list_issues` - Add individual tools (replaces `GITLAB_TOOLS`)
 - `--use-wiki=true` - Enable wiki API (replaces `USE_GITLAB_WIKI`)
 - `--use-milestone=true` - Enable milestone API (replaces `USE_MILESTONE`)
 - `--use-pipeline=true` - Enable pipeline API (replaces `USE_PIPELINE`)

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Some MCP clients (like GitHub Copilot CLI) have issues with environment variable
 - `--api-url` - GitLab API URL (replaces `GITLAB_API_URL`)
 - `--read-only=true` - Enable read-only mode (replaces `GITLAB_READ_ONLY_MODE`, deprecated — prefer `--permission-mode=readonly`)
 - `--permission-mode` - Permission level: `readonly`, `modify` (no delete tools), or `full` (replaces `GITLAB_PERMISSION_MODE`, default `full`)
+- `--toolsets=all` - Enable named toolsets (replaces `GITLAB_TOOLSETS`; unset uses the lean `core` default)
+- `--tools=list_issues` - Add individual tools (replaces `GITLAB_TOOLS`)
 - `--use-wiki=true` - Enable wiki API (replaces `USE_GITLAB_WIKI`, legacy — prefer `GITLAB_TOOLSETS=wiki`)
 - `--use-milestone=true` - Enable milestone API (replaces `USE_MILESTONE`, legacy — prefer `GITLAB_TOOLSETS=milestones`)
 - `--use-pipeline=true` - Enable pipeline API (replaces `USE_PIPELINE`, legacy — prefer `GITLAB_TOOLSETS=pipelines`)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,6 +134,8 @@ command = lib.getExe inputs.gitlab-mcp.packages.${system}.default;
 - `--api-url` - GitLab API URL（替代 `GITLAB_API_URL`）
 - `--read-only=true` - 启用只读模式（替代 `GITLAB_READ_ONLY_MODE`，已弃用 — 推荐 `--permission-mode=readonly`）
 - `--permission-mode` - 权限级别：`readonly`、`modify`（禁用删除工具）或 `full`（替代 `GITLAB_PERMISSION_MODE`，默认 `full`）
+- `--toolsets=all` - 启用指定工具集（替代 `GITLAB_TOOLSETS`；未设置时使用精简 `core` 默认值）
+- `--tools=list_issues` - 添加单个工具（替代 `GITLAB_TOOLS`）
 - `--use-wiki=true` - 启用 Wiki API（替代 `USE_GITLAB_WIKI`，旧版 — 推荐 `GITLAB_TOOLSETS=wiki`）
 - `--use-milestone=true` - 启用里程碑 API（替代 `USE_MILESTONE`，旧版 — 推荐 `GITLAB_TOOLSETS=milestones`）
 - `--use-pipeline=true` - 启用流水线 API（替代 `USE_PIPELINE`，旧版 — 推荐 `GITLAB_TOOLSETS=pipelines`）

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -322,14 +322,15 @@ Set to `true` to expose only read-only tools.
 
 ### `GITLAB_TOOLSETS`
 
-Comma-separated list of toolset IDs to enable.
+Comma-separated list of toolset IDs to enable. If unset, the server exposes the lean `core` toolset plus the always-on `discover_tools` meta-tool.
 
 For agent-specific tool surfaces, see
 [Custom Agents and Multiple PAT Setup](../auth/custom-agent-multiple-pat.md).
 
-Special value:
+Special values:
 
-- `all`
+- `all` — enable every toolset.
+- `merge_requests,issues,repositories,branches,projects,labels,ci,groups,users` — restore the pre-lean default set.
 
 ### `GITLAB_TOOLS`
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -441,14 +441,15 @@ server to make any outbound request beyond your GitLab instance.
 
 ### `GITLAB_TOOLSETS`
 
-Comma-separated list of toolset IDs to enable.
+Comma-separated list of toolset IDs to enable. If unset, the server exposes the lean `core` toolset plus the always-on `discover_tools` meta-tool.
 
 For agent-specific tool surfaces, see
 [Custom Agents and Multiple PAT Setup](../auth/custom-agent-multiple-pat.md).
 
-Special value:
+Special values:
 
-- `all`
+- `all` — enable every toolset.
+- `GITLAB_TOOLSETS=merge_requests,issues,repositories,branches,projects,labels,ci,groups,users` — restores the pre-lean default set.
 
 ### `GITLAB_TOOLS`
 

--- a/docs/getting-started/cli-arguments.md
+++ b/docs/getting-started/cli-arguments.md
@@ -32,6 +32,8 @@ CLI arguments take precedence over environment variables.
 | `--token`              | `GITLAB_PERSONAL_ACCESS_TOKEN` | GitLab Personal Access Token.                       |
 | `--api-url`            | `GITLAB_API_URL`               | GitLab API URL (e.g., `https://gitlab.com/api/v4`). |
 | `--read-only=true`     | `GITLAB_READ_ONLY_MODE`        | Enable read-only mode.                              |
+| `--toolsets=all`       | `GITLAB_TOOLSETS`              | Enable named toolsets. Unset uses lean `core`.      |
+| `--tools=list_issues`  | `GITLAB_TOOLS`                 | Add individual tools on top of enabled toolsets.    |
 | `--use-wiki=true`      | `USE_GITLAB_WIKI`              | Enable wiki API tools.                              |
 | `--use-milestone=true` | `USE_MILESTONE`                | Enable milestone API tools.                         |
 | `--use-pipeline=true`  | `USE_PIPELINE`                 | Enable pipeline API tools.                          |

--- a/docs/getting-started/cli-arguments.md
+++ b/docs/getting-started/cli-arguments.md
@@ -43,6 +43,8 @@ No global install? Pin `npx` to the previous stable release and keep the server 
 | `--api-url`            | `GITLAB_API_URL`               | GitLab API URL (e.g., `https://gitlab.com/api/v4`). |
 | `--read-only=true`     | `GITLAB_READ_ONLY_MODE`        | Enable read-only mode (deprecated — prefer `--permission-mode=readonly`). |
 | `--permission-mode`    | `GITLAB_PERMISSION_MODE`       | `readonly`, `modify` (no delete tools), or `full`.  |
+| `--toolsets=all`       | `GITLAB_TOOLSETS`              | Enable named toolsets. Unset uses lean `core`.      |
+| `--tools=list_issues`  | `GITLAB_TOOLS`                 | Add individual tools on top of enabled toolsets.    |
 | `--use-wiki=true`      | `USE_GITLAB_WIKI`              | Enable wiki API tools.                              |
 | `--use-milestone=true` | `USE_MILESTONE`                | Enable milestone API tools.                         |
 | `--use-pipeline=true`  | `USE_PIPELINE`                 | Enable pipeline API tools.                          |

--- a/docs/tools/branches.md
+++ b/docs/tools/branches.md
@@ -2,6 +2,9 @@
 
 Branch management, commit listing/inspection, file blame, and CI commit-status manipulation.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=branches` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`create_branch`](#create_branch) — ✏️ Writes

--- a/docs/tools/ci.md
+++ b/docs/tools/ci.md
@@ -2,6 +2,9 @@
 
 Validate `.gitlab-ci.yml` snippets and project pipeline configs.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=ci` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`validate_ci_lint`](#validate_ci_lint) — 📖 Read-only

--- a/docs/tools/core.md
+++ b/docs/tools/core.md
@@ -1,0 +1,660 @@
+# Core
+
+Lean default starter set for common MR, issue, repository, branch, project, label, and identity workflows.
+
+## Tools in this group
+
+- [`list_merge_requests`](#list_merge_requests) — 📖 Read-only
+- [`get_merge_request`](#get_merge_request) — 📖 Read-only
+- [`get_merge_request_approval_state`](#get_merge_request_approval_state) — 📖 Read-only
+- [`list_merge_request_changed_files`](#list_merge_request_changed_files) — 📖 Read-only
+- [`get_merge_request_file_diff`](#get_merge_request_file_diff) — 📖 Read-only
+- [`list_merge_request_diffs`](#list_merge_request_diffs) — 📖 Read-only
+- [`get_merge_request_diffs`](#get_merge_request_diffs) — 📖 Read-only
+- [`mr_discussions`](#mr_discussions) — 📖 Read-only
+- [`create_merge_request`](#create_merge_request) — ✏️ Writes
+- [`create_merge_request_thread`](#create_merge_request_thread) — ✏️ Writes
+- [`resolve_merge_request_thread`](#resolve_merge_request_thread) — ✏️ Writes
+- [`update_merge_request`](#update_merge_request) — ✏️ Writes
+- [`list_issues`](#list_issues) — 📖 Read-only
+- [`my_issues`](#my_issues) — 📖 Read-only
+- [`get_issue`](#get_issue) — 📖 Read-only
+- [`create_issue`](#create_issue) — ✏️ Writes
+- [`update_issue`](#update_issue) — ✏️ Writes
+- [`create_issue_note`](#create_issue_note) — ✏️ Writes
+- [`list_issue_discussions`](#list_issue_discussions) — 📖 Read-only
+- [`update_issue_description_patch`](#update_issue_description_patch) — ✏️ Writes
+- [`get_file_contents`](#get_file_contents) — 📖 Read-only
+- [`get_repository_tree`](#get_repository_tree) — 📖 Read-only
+- [`search_repositories`](#search_repositories) — 📖 Read-only
+- [`get_branch`](#get_branch) — 📖 Read-only
+- [`list_branches`](#list_branches) — 📖 Read-only
+- [`list_commits`](#list_commits) — 📖 Read-only
+- [`get_commit`](#get_commit) — 📖 Read-only
+- [`get_commit_diff`](#get_commit_diff) — 📖 Read-only
+- [`get_file_blame`](#get_file_blame) — 📖 Read-only
+- [`get_project`](#get_project) — 📖 Read-only
+- [`list_projects`](#list_projects) — 📖 Read-only
+- [`list_project_members`](#list_project_members) — 📖 Read-only
+- [`list_labels`](#list_labels) — 📖 Read-only
+- [`whoami`](#whoami) — 📖 Read-only
+- [`health_check`](#health_check) — 📖 Read-only
+
+---
+
+### `list_merge_requests`
+
+*📖 Read-only*
+
+List merge requests (without project_id: user's MRs; with project_id: project MRs)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or URL-encoded path (optional - if not provided, lists all merge requests the user has access to) |
+| `assignee_id` | string |  | Return MRs assigned to the given user ID (integer), 'none', or 'any'. Mutually exclusive with assignee_username. |
+| `assignee_username` | string |  | Returns merge requests assigned to the given username. Mutually exclusive with assignee_id. |
+| `author_id` | string |  | Returns merge requests created by the given user ID (integer). Mutually exclusive with author_username. |
+| `author_username` | string |  | Returns merge requests created by the given username. Mutually exclusive with author_id. |
+| `reviewer_id` | string |  | Returns merge requests which have the user as a reviewer. Must be an integer, 'none', or 'any'. Mutually exclusive with reviewer_username. |
+| `reviewer_username` | string |  | Returns merge requests which have the user as a reviewer by username. Mutually exclusive with reviewer_id. |
+| `approved_by_usernames` | array<string> |  | Returns merge requests approved by the given usernames (array). |
+| `created_after` | string |  | Return merge requests created after the given time |
+| `created_before` | string |  | Return merge requests created before the given time |
+| `updated_after` | string |  | Return merge requests updated after the given time |
+| `updated_before` | string |  | Return merge requests updated before the given time |
+| `labels` | array<string> |  | Array of label names |
+| `milestone` | string |  | Milestone title |
+| `scope` | enum (`created_by_me` \| `assigned_to_me` \| `all`) |  | Return merge requests from a specific scope |
+| `search` | string |  | Search for specific terms |
+| `state` | enum (`opened` \| `closed` \| `locked` \| `merged` \| `all`) |  | Return merge requests with a specific state |
+| `order_by` | enum (`created_at` \| `updated_at` \| `priority` \| `label_priority` \| `milestone_due` \| `popularity`) |  | Return merge requests ordered by the given field |
+| `sort` | enum (`asc` \| `desc`) |  | Return merge requests sorted in ascending or descending order |
+| `target_branch` | string |  | Return merge requests targeting a specific branch |
+| `source_branch` | string |  | Return merge requests from a specific source branch |
+| `wip` | enum (`yes` \| `no`) |  | Filter merge requests against their wip status |
+| `with_labels_details` | boolean |  | Return more details for each label |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `get_merge_request`
+
+*📖 Read-only*
+
+Get details of a merge request (mergeRequestIid or branchName required)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+
+### `get_merge_request_approval_state`
+
+*📖 Read-only*
+
+Get merge request approval details including approvers
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string | ✓ | The IID of the merge request |
+
+### `list_merge_request_changed_files`
+
+*📖 Read-only*
+
+List changed file paths in a merge request without diff content (mergeRequestIid or branchName required)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `excluded_file_patterns` | array<string> |  | Array of regex patterns to exclude files. Examples: ["^vendor/", "\.pb\.go$"] |
+
+### `get_merge_request_file_diff`
+
+*📖 Read-only*
+
+Get diffs for specific files from a merge request (mergeRequestIid or branchName required)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `file_paths` | array<string> | ✓ | List of file paths to retrieve diffs for (e.g. ['src/api/users.ts', 'src/repo/user.go']). Call list_merge_request_changed_files first to get the full list of changed paths. |
+| `unidiff` | boolean |  | Present diff in the unified diff format. Default is false. |
+
+### `list_merge_request_diffs`
+
+*📖 Read-only*
+
+List merge request diffs with pagination (mergeRequestIid or branchName required)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+| `unidiff` | boolean |  | Present diffs in the unified diff format. Default is false. Introduced in GitLab 16.5. |
+
+### `get_merge_request_diffs`
+
+*📖 Read-only*
+
+Get the changes/diffs of a merge request (mergeRequestIid or branchName required)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `view` | enum (`inline` \| `parallel`) |  | Diff view type |
+| `excluded_file_patterns` | array<string> |  | Array of regex patterns to exclude files from the diff results. Each pattern is a JavaScript-compatible regular expression that matches file paths to ignore. Examples: ["^vendor/", "^test/mocks/", "\.spec\.ts$", "package-lock\.json"] |
+
+### `mr_discussions`
+
+*📖 Read-only*
+
+List discussion items for a merge request
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string | ✓ | The IID of a merge request |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `create_merge_request`
+
+*✏️ Writes*
+
+Create a new merge request
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `title` | string | ✓ | Merge request title |
+| `description` | string |  | Merge request description |
+| `source_branch` | string | ✓ | Branch containing changes |
+| `target_branch` | string | ✓ | Branch to merge into |
+| `target_project_id` | string |  | Numeric ID of the target project. |
+| `assignee_ids` | array<number> |  | The ID of the users to assign the MR to |
+| `reviewer_ids` | array<number> |  | The ID of the users to assign as reviewers of the MR |
+| `labels` | array<string> |  | Labels for the MR |
+| `draft` | boolean |  | Create as draft merge request |
+| `allow_collaboration` | boolean |  | Allow commits from upstream members |
+| `remove_source_branch` | boolean \| null |  | Flag indicating if a merge request should remove the source branch when merging. |
+| `squash` | boolean \| null |  | If true, squash all commits into a single commit on merge. |
+
+### `create_merge_request_thread`
+
+*✏️ Writes*
+
+Create a new thread on a merge request
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string | ✓ | The IID of a merge request |
+| `body` | string | ✓ | The content of the thread |
+| `position` | object |  | Position when creating a diff note |
+| `created_at` | string |  | Date the thread was created at (ISO 8601 format) |
+
+### `resolve_merge_request_thread`
+
+*✏️ Writes*
+
+Resolve a thread on a merge request
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string | ✓ | The IID of a merge request |
+| `discussion_id` | string | ✓ | The ID of a thread |
+| `resolved` | boolean | ✓ | Whether to resolve the thread |
+
+### `update_merge_request`
+
+*✏️ Writes*
+
+Update a merge request (mergeRequestIid or branchName required)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `title` | string |  | The title of the merge request |
+| `description` | string |  | The description of the merge request |
+| `target_branch` | string |  | The target branch |
+| `assignee_ids` | array<number> |  | The ID of the users to assign the MR to |
+| `reviewer_ids` | array<number> |  | The ID of the users to assign as reviewers of the MR |
+| `labels` | array<string> |  | Labels for the MR |
+| `state_event` | enum (`close` \| `reopen`) |  | New state (close/reopen) for the MR |
+| `remove_source_branch` | boolean |  | Flag indicating if the source branch should be removed |
+| `squash` | boolean |  | Squash commits into a single commit when merging |
+| `draft` | boolean |  | Work in progress merge request |
+
+### `list_issues`
+
+*📖 Read-only*
+
+List issues (default: created by current user; use scope='all' for all)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or URL-encoded path (optional - if not provided, lists issues across all accessible projects) |
+| `assignee_id` | string |  | Return issues assigned to the given user ID (user id, none, or any). Mutually exclusive with assignee_username. |
+| `assignee_username` | array<string> |  | Return issues assigned to the given username. Mutually exclusive with assignee_id. |
+| `author_id` | string |  | Return issues created by the given user ID. Mutually exclusive with author_username. |
+| `author_username` | string |  | Return issues created by the given username. Mutually exclusive with author_id. |
+| `confidential` | boolean |  | Filter confidential or public issues |
+| `created_after` | string |  | Return issues created after the given time |
+| `created_before` | string |  | Return issues created before the given time |
+| `due_date` | string |  | Return issues that have the due date |
+| `labels` | array<string> |  | Array of label names |
+| `milestone` | string |  | Milestone title |
+| `issue_type` | enum (`issue` \| `incident` \| `test_case` \| `task`) |  | Filter to a given type of issue. One of issue, incident, test_case or task |
+| `iteration_id` | string |  | Return issues assigned to the given iteration ID. None returns issues that do not belong to an iteration. Any returns issues that belong to an iteration.  |
+| `scope` | enum (`created_by_me` \| `assigned_to_me` \| `all`) |  | Return issues from a specific scope |
+| `search` | string |  | Search for specific terms |
+| `state` | enum (`opened` \| `closed` \| `all`) |  | Return issues with a specific state |
+| `updated_after` | string |  | Return issues updated after the given time |
+| `updated_before` | string |  | Return issues updated before the given time |
+| `with_labels_details` | boolean |  | Return more details for each label |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `my_issues`
+
+*📖 Read-only*
+
+List issues assigned to the authenticated user
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or URL-encoded path (optional to search across all accessible projects) |
+| `state` | enum (`opened` \| `closed` \| `all`) |  | Return issues with a specific state (default: opened) |
+| `labels` | array<string> |  | Array of label names to filter by |
+| `milestone` | string |  | Milestone title to filter by |
+| `search` | string |  | Search for specific terms in title and description |
+| `created_after` | string |  | Return issues created after the given time (ISO 8601) |
+| `created_before` | string |  | Return issues created before the given time (ISO 8601) |
+| `updated_after` | string |  | Return issues updated after the given time (ISO 8601) |
+| `updated_before` | string |  | Return issues updated before the given time (ISO 8601) |
+| `per_page` | number |  | Number of items per page (default: 20, max: 100) |
+| `page` | number |  | Page number for pagination (default: 1) |
+
+### `get_issue`
+
+*📖 Read-only*
+
+Get details of a specific issue
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `issue_iid` | string | ✓ | The internal ID of the project issue |
+
+### `create_issue`
+
+*✏️ Writes*
+
+Create a new issue
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `title` | string | ✓ | Issue title |
+| `description` | string |  | Issue description |
+| `assignee_ids` | array<number> |  | Array of user IDs to assign |
+| `labels` | array<string> |  | Array of label names |
+| `milestone_id` | string |  | Milestone ID to assign |
+| `issue_type` | enum (`issue` \| `incident` \| `test_case` \| `task`) |  | The type of issue. One of issue, incident, test_case or task. |
+| `weight` | number |  | Weight of the issue (numeric, typically hours of work) |
+
+### `update_issue`
+
+*✏️ Writes*
+
+Update an issue
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `issue_iid` | string | ✓ | The internal ID of the project issue |
+| `title` | string |  | The title of the issue |
+| `description` | string |  | The description of the issue |
+| `assignee_ids` | array<number> |  | Array of user IDs to assign issue to |
+| `confidential` | boolean |  | Set the issue to be confidential |
+| `discussion_locked` | boolean |  | Flag to lock discussions |
+| `due_date` | string |  | Date the issue is due (YYYY-MM-DD) |
+| `labels` | array<string> |  | Array of label names |
+| `milestone_id` | string |  | Milestone ID to assign |
+| `state_event` | enum (`close` \| `reopen`) |  | Update issue state (close/reopen) |
+| `weight` | number |  | Weight of the issue (numeric, typically hours of work) |
+| `issue_type` | enum (`issue` \| `incident` \| `test_case` \| `task`) |  | The type of issue. One of issue, incident, test_case or task. |
+
+### `create_issue_note`
+
+*✏️ Writes*
+
+Add a note to an issue, optionally replying to a discussion thread
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `issue_iid` | string | ✓ | The IID of an issue |
+| `discussion_id` | string |  | The ID of a thread. If provided, replies to that thread; otherwise creates a top-level note |
+| `body` | string | ✓ | The content of the note or reply |
+| `created_at` | string |  | Date the note was created at (ISO 8601 format) |
+
+### `list_issue_discussions`
+
+*📖 Read-only*
+
+List discussions for an issue
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `issue_iid` | string | ✓ | The internal ID of the project issue |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `update_issue_description_patch`
+
+*✏️ Writes*
+
+Apply a patch (search/replace or unified diff) to an issue description. Reduces token usage by allowing small changes without sending the full description. Supports dry_run to preview changes and create_note to summarize updates.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `issue_iid` | string | ✓ | The internal ID of the project issue |
+| `patch_type` | enum (`search_replace` \| `unified_diff`) | ✓ | Type of patch format to apply |
+| `patch` | string | ✓ | The patch content to apply to the issue description |
+| `dry_run` | boolean |  | If true, preview changes without updating the issue |
+| `create_note` | boolean |  | If true, add a note summarizing the change after update |
+| `allow_multiple` | boolean |  | For search_replace: allow multiple matches to all be replaced (default: false — fail on duplicate) |
+
+### `get_file_contents`
+
+*📖 Read-only*
+
+Get contents of a file or directory from a GitLab project
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or URL-encoded path (optional; falls back to env) |
+| `file_path` | string |  | Path to the file or directory. Takes precedence over 'path' when both are provided |
+| `path` | string |  | Alias of file_path |
+| `ref` | string |  | Branch/tag/commit to get contents from |
+
+### `get_repository_tree`
+
+*📖 Read-only*
+
+List files and directories in a repository
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | The ID or URL-encoded path of the project |
+| `path` | string |  | The path inside the repository |
+| `ref` | string |  | The name of a repository branch or tag. Defaults to the default branch. |
+| `recursive` | boolean |  | Boolean value to get a recursive tree |
+| `per_page` | number |  | Number of results to show per page |
+| `page_token` | string |  | Token for keyset pagination. Use the next_page_token value returned in the previous response to retrieve the next page. |
+| `pagination` | string |  | Pagination method. Use 'keyset' for keyset-based pagination (required for repositories with many files). Non-keyset calls keep the legacy array response for backward compatibility; that legacy response shape is deprecated and may be removed in a future major release. Keyset calls return a structured response with items and next_page_token when more pages are available. |
+
+### `search_repositories`
+
+*📖 Read-only*
+
+Search for GitLab projects
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `search` | string |  | Search query |
+| `query` | string |  | Search query (alias for 'search') |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `get_branch`
+
+*📖 Read-only*
+
+Get branch details (commit, protection status)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `branch_name` | string | ✓ | Name of the branch |
+
+### `list_branches`
+
+*📖 Read-only*
+
+List branches in project with search filter
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `search` | string |  | Search term to filter branches by name |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `list_commits`
+
+*📖 Read-only*
+
+List repository commits with filtering options
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `ref_name` | string |  | The name of a repository branch, tag or revision range, or if not given the default branch |
+| `since` | string |  | Only commits after or on this date are returned in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ |
+| `until` | string |  | Only commits before or on this date are returned in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ |
+| `path` | string |  | The file path |
+| `author` | string |  | Search commits by commit author |
+| `all` | boolean |  | Retrieve every commit from the repository |
+| `with_stats` | boolean |  | Stats about each commit are added to the response |
+| `first_parent` | boolean |  | Follow only the first parent commit upon seeing a merge commit |
+| `order` | enum (`default` \| `topo`) |  | List commits in order |
+| `trailers` | boolean |  | Parse and include Git trailers for every commit |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `get_commit`
+
+*📖 Read-only*
+
+Get details of a specific commit
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `sha` | string | ✓ | The commit hash or name of a repository branch or tag |
+| `stats` | boolean |  | Include commit stats |
+
+### `get_commit_diff`
+
+*📖 Read-only*
+
+Get changes/diffs of a specific commit
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `sha` | string | ✓ | The commit hash or name of a repository branch or tag |
+| `full_diff` | boolean |  | Whether to return the full diff or only first page (default: false) |
+
+### `get_file_blame`
+
+*📖 Read-only*
+
+Get git blame for a file at a given ref. Each entry maps a contiguous range of source lines to the commit that last changed them (id, author, authored_date, message). Use range_start/range_end to limit blame to specific lines.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or complete URL-encoded path to project |
+| `file_path` | string | ✓ | The full path of the file to blame, relative to repo root |
+| `ref` | string | ✓ | The name of branch, tag or commit (required by GitLab blame API) |
+| `range_start` | integer |  | First line of the blame range (inclusive, 1-based). Both range[start] and range[end] must be set together. |
+| `range_end` | integer |  | Last line of the blame range (inclusive, 1-based). Both range[start] and range[end] must be set together. |
+
+### `get_project`
+
+*📖 Read-only*
+
+Get details of a specific project
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+
+### `list_projects`
+
+*📖 Read-only*
+
+List projects accessible by the current user
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `search` | string |  | Search term for projects |
+| `search_namespaces` | boolean |  | Needs to be true if search is full path |
+| `owned` | boolean |  | Filter for projects owned by current user |
+| `membership` | boolean |  | Filter for projects where current user is a member |
+| `simple` | boolean |  | Return only limited fields |
+| `archived` | boolean |  | Filter for archived projects |
+| `visibility` | enum (`public` \| `internal` \| `private`) |  | Filter by project visibility |
+| `order_by` | enum (`id` \| `name` \| `path` \| `created_at` \| `updated_at` \| `last_activity_at`) |  | Return projects ordered by field |
+| `sort` | enum (`asc` \| `desc`) |  | Return projects sorted in ascending or descending order |
+| `with_issues_enabled` | boolean |  | Filter projects with issues feature enabled |
+| `with_merge_requests_enabled` | boolean |  | Filter projects with merge requests feature enabled |
+| `min_access_level` | number |  | Filter by minimum access level |
+| `topic` | string |  | Filter by topic (projects tagged with this topic) |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `list_project_members`
+
+*📖 Read-only*
+
+List members of a GitLab project
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `query` | string |  | Search for members by name or username |
+| `user_ids` | array<number> |  | Filter by user IDs |
+| `skip_users` | array<number> |  | User IDs to exclude |
+| `include_inheritance` | boolean |  | Include inherited members. Defaults to false. |
+| `per_page` | number |  | Number of items per page (default: 20, max: 100) |
+| `page` | number |  | Page number for pagination (default: 1) |
+
+### `list_labels`
+
+*📖 Read-only*
+
+List labels for a project
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `with_counts` | boolean |  | Whether to include issue and merge request counts |
+| `include_ancestor_groups` | boolean |  | Include ancestor groups |
+| `search` | string |  | Keyword to filter labels by |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `whoami`
+
+*📖 Read-only*
+
+Get current authenticated user details
+
+**Parameters**
+
+_No parameters._
+
+### `health_check`
+
+*📖 Read-only*
+
+Verify server status and authentication
+
+**Parameters**
+
+_No parameters._

--- a/docs/tools/core.md
+++ b/docs/tools/core.md
@@ -1,0 +1,664 @@
+# Core
+
+Lean default starter set for common MR, issue, repository, branch, project, label, and identity workflows.
+
+## Tools in this group
+
+- [`list_merge_requests`](#list_merge_requests) — 📖 Read-only
+- [`get_merge_request`](#get_merge_request) — 📖 Read-only
+- [`get_merge_request_approval_state`](#get_merge_request_approval_state) — 📖 Read-only
+- [`list_merge_request_changed_files`](#list_merge_request_changed_files) — 📖 Read-only
+- [`get_merge_request_file_diff`](#get_merge_request_file_diff) — 📖 Read-only
+- [`list_merge_request_diffs`](#list_merge_request_diffs) — 📖 Read-only
+- [`get_merge_request_diffs`](#get_merge_request_diffs) — 📖 Read-only
+- [`mr_discussions`](#mr_discussions) — 📖 Read-only
+- [`create_merge_request`](#create_merge_request) — ✏️ Writes
+- [`create_merge_request_thread`](#create_merge_request_thread) — ✏️ Writes
+- [`resolve_merge_request_thread`](#resolve_merge_request_thread) — ✏️ Writes
+- [`update_merge_request`](#update_merge_request) — ✏️ Writes
+- [`list_issues`](#list_issues) — 📖 Read-only
+- [`my_issues`](#my_issues) — 📖 Read-only
+- [`get_issue`](#get_issue) — 📖 Read-only
+- [`create_issue`](#create_issue) — ✏️ Writes
+- [`update_issue`](#update_issue) — ✏️ Writes
+- [`create_issue_note`](#create_issue_note) — ✏️ Writes
+- [`list_issue_discussions`](#list_issue_discussions) — 📖 Read-only
+- [`update_issue_description_patch`](#update_issue_description_patch) — ✏️ Writes
+- [`get_file_contents`](#get_file_contents) — 📖 Read-only
+- [`get_repository_tree`](#get_repository_tree) — 📖 Read-only
+- [`search_repositories`](#search_repositories) — 📖 Read-only
+- [`get_branch`](#get_branch) — 📖 Read-only
+- [`list_branches`](#list_branches) — 📖 Read-only
+- [`list_commits`](#list_commits) — 📖 Read-only
+- [`get_commit`](#get_commit) — 📖 Read-only
+- [`get_commit_diff`](#get_commit_diff) — 📖 Read-only
+- [`get_file_blame`](#get_file_blame) — 📖 Read-only
+- [`get_project`](#get_project) — 📖 Read-only
+- [`list_projects`](#list_projects) — 📖 Read-only
+- [`list_project_members`](#list_project_members) — 📖 Read-only
+- [`list_labels`](#list_labels) — 📖 Read-only
+- [`whoami`](#whoami) — 📖 Read-only
+- [`health_check`](#health_check) — 📖 Read-only
+
+---
+
+### `list_merge_requests`
+
+*📖 Read-only*
+
+List merge requests (without project_id: user's MRs; with project_id: project MRs). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or URL-encoded path (optional - if not provided, lists all merge requests the user has access to) |
+| `assignee_id` | string |  | Return MRs assigned to the given user ID (integer), 'none', or 'any'. Mutually exclusive with assignee_username. |
+| `assignee_username` | string |  | Returns merge requests assigned to the given username. Mutually exclusive with assignee_id. |
+| `author_id` | string |  | Returns merge requests created by the given user ID (integer). Mutually exclusive with author_username. |
+| `author_username` | string |  | Returns merge requests created by the given username. Mutually exclusive with author_id. |
+| `reviewer_id` | string |  | Returns merge requests which have the user as a reviewer. Must be an integer, 'none', or 'any'. Mutually exclusive with reviewer_username. |
+| `reviewer_username` | string |  | Returns merge requests which have the user as a reviewer by username. Mutually exclusive with reviewer_id. |
+| `approved_by_usernames` | array<string> |  | Returns merge requests approved by the given usernames (array). |
+| `created_after` | string |  | Return merge requests created after the given time |
+| `created_before` | string |  | Return merge requests created before the given time |
+| `updated_after` | string |  | Return merge requests updated after the given time |
+| `updated_before` | string |  | Return merge requests updated before the given time |
+| `labels` | array<string> |  | Array of label names |
+| `milestone` | string |  | Milestone title |
+| `scope` | enum (`created_by_me` \| `assigned_to_me` \| `all`) |  | Return merge requests from a specific scope |
+| `search` | string |  | Search for specific terms |
+| `state` | enum (`opened` \| `closed` \| `locked` \| `merged` \| `all`) |  | Return merge requests with a specific state |
+| `order_by` | enum (`created_at` \| `updated_at` \| `priority` \| `label_priority` \| `milestone_due` \| `popularity`) |  | Return merge requests ordered by the given field |
+| `sort` | enum (`asc` \| `desc`) |  | Return merge requests sorted in ascending or descending order |
+| `target_branch` | string |  | Return merge requests targeting a specific branch |
+| `source_branch` | string |  | Return merge requests from a specific source branch |
+| `wip` | enum (`yes` \| `no`) |  | Filter merge requests against their wip status |
+| `with_labels_details` | boolean |  | Return more details for each label |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `get_merge_request`
+
+*📖 Read-only*
+
+Get details of a merge request (mergeRequestIid or branchName required). Set include_summaries=true for deployment/commit/approval summaries. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `include_summaries` | boolean |  | If true, include deployment_summary, commit_addition_summary and approval_summary (extra API calls, larger response). Default false to reduce token usage. |
+
+### `get_merge_request_approval_state`
+
+*📖 Read-only*
+
+Get merge request approval details including approvers. Use this to inspect approval rules and approvers before deciding whether a merge request can be merged; use `approve_merge_request` to change approval state. It is read-only and returns the approval-state response, while missing requests, unsupported GitLab versions, and permission failures are reported as errors.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string | ✓ | The IID of the merge request |
+
+### `list_merge_request_changed_files`
+
+*📖 Read-only*
+
+List changed file paths in a merge request without diff content (mergeRequestIid or branchName required). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `excluded_file_patterns` | array<string> |  | Array of regex patterns to exclude files. Examples: ["^vendor/", "\.pb\.go$"] |
+
+### `get_merge_request_file_diff`
+
+*📖 Read-only*
+
+Get diffs for specific files from a merge request (mergeRequestIid or branchName required). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `file_paths` | array<string> | ✓ | List of file paths to retrieve diffs for (e.g. ['src/api/users.ts', 'src/repo/user.go']). Call list_merge_request_changed_files first to get the full list of changed paths. |
+| `unidiff` | boolean |  | Present diff in the unified diff format. Default is false. |
+
+### `list_merge_request_diffs`
+
+*📖 Read-only*
+
+List merge request diffs with pagination (mergeRequestIid or branchName required). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+| `unidiff` | boolean |  | Present diffs in the unified diff format. Default is false. Introduced in GitLab 16.5. |
+
+### `get_merge_request_diffs`
+
+*📖 Read-only*
+
+Get the changes/diffs of a merge request (mergeRequestIid or branchName required). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `view` | enum (`inline` \| `parallel`) |  | Diff view type |
+| `excluded_file_patterns` | array<string> |  | Array of regex patterns to exclude files from the diff results. Each pattern is a JavaScript-compatible regular expression that matches file paths to ignore. Examples: ["^vendor/", "^test/mocks/", "\.spec\.ts$", "package-lock\.json"] |
+
+### `mr_discussions`
+
+*📖 Read-only*
+
+List discussion items for a merge request. Use this to list complete discussion threads for a merge request; use `get_merge_request_notes` when only flat notes are needed. It is read-only and returns threaded discussion items, while invalid merge request identifiers, missing resources, and permission failures are reported as errors.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string | ✓ | The IID of a merge request |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `create_merge_request`
+
+*✏️ Writes*
+
+Create a new merge request. Use this to open a new merge request from an existing source branch to a target branch; use `update_merge_request` after it exists. The operation creates remote review state, requires project access, and returns the new merge request or a validation, permission, branch, or duplicate-related error.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `title` | string | ✓ | Merge request title |
+| `description` | string |  | Merge request description |
+| `source_branch` | string | ✓ | Branch containing changes |
+| `target_branch` | string | ✓ | Branch to merge into |
+| `target_project_id` | string |  | Numeric ID of the target project. |
+| `assignee_ids` | array<number> |  | The ID of the users to assign the MR to |
+| `reviewer_ids` | array<number> |  | The ID of the users to assign as reviewers of the MR |
+| `labels` | array<string> |  | Labels for the MR |
+| `draft` | boolean |  | Create as draft merge request |
+| `allow_collaboration` | boolean |  | Allow commits from upstream members |
+| `remove_source_branch` | boolean \| null |  | Flag indicating if a merge request should remove the source branch when merging. |
+| `squash` | boolean \| null |  | If true, squash all commits into a single commit on merge. |
+
+### `create_merge_request_thread`
+
+*✏️ Writes*
+
+Create a new thread on a merge request. Use this to start a review thread on a merge request; use `create_merge_request_note` for an unthreaded note and `create_merge_request_discussion_note` to reply to an existing thread. The operation creates remote review content, requires note permission, and returns the discussion or a position/permission/validation error.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string | ✓ | The IID of a merge request |
+| `body` | string | ✓ | The content of the thread |
+| `position` | object |  | Position when creating a diff note |
+| `created_at` | string |  | Date the thread was created at (ISO 8601 format) |
+
+### `resolve_merge_request_thread`
+
+*✏️ Writes*
+
+Resolve a thread on a merge request. Use this to mark an existing merge request review thread resolved; use `update_merge_request_discussion_note` when the note text itself must change. The operation changes review state, requires permission to resolve discussions, and returns the updated discussion or a missing-thread/permission error.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string | ✓ | The IID of a merge request |
+| `discussion_id` | string | ✓ | The ID of a thread |
+| `resolved` | boolean | ✓ | Whether to resolve the thread |
+
+### `update_merge_request`
+
+*✏️ Writes*
+
+Update a merge request (mergeRequestIid or branchName required). Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `merge_request_iid` | string |  | The IID of a merge request |
+| `source_branch` | string |  | Source branch name |
+| `title` | string |  | The title of the merge request |
+| `description` | string |  | The description of the merge request |
+| `target_branch` | string |  | The target branch |
+| `assignee_ids` | array<number> |  | The ID of the users to assign the MR to |
+| `reviewer_ids` | array<number> |  | The ID of the users to assign as reviewers of the MR |
+| `labels` | array<string> |  | Labels for the MR |
+| `state_event` | enum (`close` \| `reopen`) |  | New state (close/reopen) for the MR |
+| `remove_source_branch` | boolean |  | Flag indicating if the source branch should be removed |
+| `squash` | boolean |  | Squash commits into a single commit when merging |
+| `draft` | boolean |  | Work in progress merge request |
+| `milestone_id` | string |  | Milestone ID to assign. Set to 0 to unassign. Null is treated as omitted. |
+
+### `list_issues`
+
+*📖 Read-only*
+
+List issues (default: created by current user; use scope='all' for all). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or URL-encoded path (optional - if not provided, lists issues across all accessible projects) |
+| `assignee_id` | string |  | Return issues assigned to the given user ID (user id, none, or any). Mutually exclusive with assignee_username. |
+| `assignee_username` | array<string> |  | Return issues assigned to the given username. Mutually exclusive with assignee_id. |
+| `author_id` | string |  | Return issues created by the given user ID. Mutually exclusive with author_username. |
+| `author_username` | string |  | Return issues created by the given username. Mutually exclusive with author_id. |
+| `confidential` | boolean |  | Filter confidential or public issues |
+| `created_after` | string |  | Return issues created after the given time |
+| `created_before` | string |  | Return issues created before the given time |
+| `due_date` | string |  | Return issues that have the due date |
+| `labels` | array<string> |  | Array of label names |
+| `milestone` | string |  | Milestone title |
+| `issue_type` | enum (`issue` \| `incident` \| `test_case` \| `task`) |  | Filter to a given type of issue. One of issue, incident, test_case or task |
+| `iteration_id` | string |  | Return issues assigned to the given iteration ID. None returns issues that do not belong to an iteration. Any returns issues that belong to an iteration.  |
+| `scope` | enum (`created_by_me` \| `assigned_to_me` \| `all`) |  | Return issues from a specific scope |
+| `search` | string |  | Search for specific terms |
+| `state` | enum (`opened` \| `closed` \| `all`) |  | Return issues with a specific state |
+| `updated_after` | string |  | Return issues updated after the given time |
+| `updated_before` | string |  | Return issues updated before the given time |
+| `with_labels_details` | boolean |  | Return more details for each label |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `my_issues`
+
+*📖 Read-only*
+
+List issues assigned to the authenticated user. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or URL-encoded path (optional to search across all accessible projects) |
+| `state` | enum (`opened` \| `closed` \| `all`) |  | Return issues with a specific state (default: opened) |
+| `labels` | array<string> |  | Array of label names to filter by |
+| `milestone` | string |  | Milestone title to filter by |
+| `search` | string |  | Search for specific terms in title and description |
+| `created_after` | string |  | Return issues created after the given time (ISO 8601) |
+| `created_before` | string |  | Return issues created before the given time (ISO 8601) |
+| `updated_after` | string |  | Return issues updated after the given time (ISO 8601) |
+| `updated_before` | string |  | Return issues updated before the given time (ISO 8601) |
+| `per_page` | number |  | Number of items per page (default: 20, max: 100) |
+| `page` | number |  | Page number for pagination (default: 1) |
+
+### `get_issue`
+
+*📖 Read-only*
+
+Get details of a specific issue. Returns a slim milestone by default; set full_response=true for the complete milestone object. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `issue_iid` | string | ✓ | The internal ID of the project issue |
+| `full_response` | boolean |  | If true, return the complete issue object including the full milestone description. Default returns a slim milestone (id, iid, title, state, web_url) to reduce token usage. |
+
+### `create_issue`
+
+*✏️ Writes*
+
+Create a new issue. Use this to open a new issue; use `update_issue` for an existing issue and `create_issue_note` to add discussion without changing issue fields. The operation creates remote project data, requires issue creation permission, and returns the new issue or a validation, permission, or duplicate-related error.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `title` | string | ✓ | Issue title |
+| `description` | string |  | Issue description |
+| `assignee_ids` | array<number> |  | Array of user IDs to assign |
+| `labels` | array<string> |  | Array of label names |
+| `milestone_id` | string |  | Milestone ID to assign |
+| `issue_type` | enum (`issue` \| `incident` \| `test_case` \| `task`) |  | The type of issue. One of issue, incident, test_case or task. |
+| `weight` | number |  | Weight of the issue (numeric, typically hours of work) |
+
+### `update_issue`
+
+*✏️ Writes*
+
+Update an issue. Returns a slim confirmation by default; set full_response=true for the complete updated issue object. Use this to change fields on an existing issue; use `update_issue_description_patch` for a targeted description edit that avoids sending the full body, and use `create_issue_note` for discussion. The operation mutates issue state, requires issue-edit permission, and returns the updated issue or a validation/permission/conflict error.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `issue_iid` | string | ✓ | The internal ID of the project issue |
+| `title` | string |  | The title of the issue |
+| `description` | string |  | The description of the issue |
+| `assignee_ids` | array<number> |  | Array of user IDs to assign issue to |
+| `confidential` | boolean |  | Set the issue to be confidential |
+| `discussion_locked` | boolean |  | Flag to lock discussions |
+| `due_date` | string |  | Date the issue is due (YYYY-MM-DD) |
+| `labels` | array<string> |  | Array of label names |
+| `milestone_id` | string |  | Milestone ID to assign |
+| `state_event` | enum (`close` \| `reopen`) |  | Update issue state (close/reopen) |
+| `weight` | number |  | Weight of the issue (numeric, typically hours of work) |
+| `issue_type` | enum (`issue` \| `incident` \| `test_case` \| `task`) |  | The type of issue. One of issue, incident, test_case or task. |
+| `full_response` | boolean |  | If true, return the complete updated issue object. Default returns a slim confirmation (iid, title, state, web_url, updated_at) to reduce token usage. |
+
+### `create_issue_note`
+
+*✏️ Writes*
+
+Add a note to an issue, optionally replying to a discussion thread. Use this to add a note to an existing issue, optionally as a reply to a discussion; use `update_issue` for issue fields and `create_note` only when the generic endpoint is required. The operation creates remote discussion content, requires note permission, and returns the note or a missing-issue/thread/permission error.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `issue_iid` | string | ✓ | The IID of an issue |
+| `discussion_id` | string |  | The ID of a thread. If provided, replies to that thread; otherwise creates a top-level note |
+| `body` | string | ✓ | The content of the note or reply |
+| `created_at` | string |  | Date the note was created at (ISO 8601 format) |
+
+### `list_issue_discussions`
+
+*📖 Read-only*
+
+List discussions for an issue. Use this to inspect threaded discussions for an issue; use `list_issues` for issue records and `get_issue` for one issue's fields. It is read-only and returns discussion items, while invalid identifiers, missing issues, and permission failures are reported as errors.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `issue_iid` | string | ✓ | The internal ID of the project issue |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `update_issue_description_patch`
+
+*✏️ Writes*
+
+Apply a patch (search/replace or unified diff) to an issue description. Reduces token usage by allowing small changes without sending the full description. Supports dry_run to preview changes and create_note to summarize updates. Use this for a targeted search/replace or unified-diff change to an issue description; use `dry_run` before applying an uncertain patch and `create_note` when an audit summary is wanted. It changes the issue description when not dry-running, requires issue-edit permission, and returns the patch result or a mismatch/validation/permission error.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `issue_iid` | string | ✓ | The internal ID of the project issue |
+| `patch_type` | enum (`search_replace` \| `unified_diff`) | ✓ | Type of patch format to apply |
+| `patch` | string | ✓ | The patch content to apply to the issue description |
+| `dry_run` | boolean |  | If true, preview changes without updating the issue |
+| `create_note` | boolean |  | If true, add a note summarizing the change after update |
+| `allow_multiple` | boolean |  | For search_replace: allow multiple matches to all be replaced (default: false — fail on duplicate) |
+
+### `get_file_contents`
+
+*📖 Read-only*
+
+Get contents of a file or directory from a GitLab project. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or URL-encoded path (optional; falls back to env) |
+| `file_path` | string |  | Path to the file or directory. Takes precedence over 'path' when both are provided |
+| `path` | string |  | Alias of file_path |
+| `ref` | string |  | Branch/tag/commit to get contents from |
+
+### `get_repository_tree`
+
+*📖 Read-only*
+
+List files and directories in a repository. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | The ID or URL-encoded path of the project |
+| `path` | string |  | The path inside the repository |
+| `ref` | string |  | The name of a repository branch or tag. Defaults to the default branch. |
+| `recursive` | boolean |  | Boolean value to get a recursive tree |
+| `per_page` | number |  | Number of results to show per page |
+| `page_token` | string |  | Token for keyset pagination. Use the next_page_token value returned in the previous response to retrieve the next page. |
+| `pagination` | string |  | Pagination method. Use 'keyset' for keyset-based pagination (required for repositories with many files). Non-keyset calls keep the legacy array response for backward compatibility; that legacy response shape is deprecated and may be removed in a future major release. Keyset calls return a structured response with items and next_page_token when more pages are available. |
+
+### `search_repositories`
+
+*📖 Read-only*
+
+Search for GitLab projects. Use this to discover matching content; choose a typed get or list tool when the target identifier is already known. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `search` | string |  | Search query |
+| `query` | string |  | Search query (alias for 'search') |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `get_branch`
+
+*📖 Read-only*
+
+Get branch details (commit, protection status). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `branch_name` | string | ✓ | Name of the branch |
+
+### `list_branches`
+
+*📖 Read-only*
+
+List branches in project with search filter. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `search` | string |  | Search term to filter branches by name |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `list_commits`
+
+*📖 Read-only*
+
+List repository commits with filtering options. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `ref_name` | string |  | The name of a repository branch, tag or revision range, or if not given the default branch |
+| `since` | string |  | Only commits after or on this date are returned in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ |
+| `until` | string |  | Only commits before or on this date are returned in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ |
+| `path` | string |  | The file path |
+| `author` | string |  | Search commits by commit author |
+| `all` | boolean |  | Retrieve every commit from the repository |
+| `with_stats` | boolean |  | Stats about each commit are added to the response |
+| `first_parent` | boolean |  | Follow only the first parent commit upon seeing a merge commit |
+| `order` | enum (`default` \| `topo`) |  | List commits in order |
+| `trailers` | boolean |  | Parse and include Git trailers for every commit |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `get_commit`
+
+*📖 Read-only*
+
+Get details of a specific commit. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `sha` | string | ✓ | The commit hash or name of a repository branch or tag |
+| `stats` | boolean |  | Include commit stats |
+
+### `get_commit_diff`
+
+*📖 Read-only*
+
+Get changes/diffs of a specific commit. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
+| `sha` | string | ✓ | The commit hash or name of a repository branch or tag |
+| `full_diff` | boolean |  | Whether to return the full diff or only first page (default: false) |
+
+### `get_file_blame`
+
+*📖 Read-only*
+
+Get git blame for a file at a given ref. Each entry maps a contiguous range of source lines to the commit that last changed them (id, author, authored_date, message). Use range_start/range_end to limit blame to specific lines.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string |  | Project ID or complete URL-encoded path to project |
+| `file_path` | string | ✓ | The full path of the file to blame, relative to repo root |
+| `ref` | string | ✓ | The name of branch, tag or commit (required by GitLab blame API) |
+| `range_start` | integer |  | First line of the blame range (inclusive, 1-based). Both range[start] and range[end] must be set together. |
+| `range_end` | integer |  | Last line of the blame range (inclusive, 1-based). Both range[start] and range[end] must be set together. |
+
+### `get_project`
+
+*📖 Read-only*
+
+Get details of a specific project. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+
+### `list_projects`
+
+*📖 Read-only*
+
+List projects accessible by the current user. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `search` | string |  | Search term for projects |
+| `search_namespaces` | boolean |  | Needs to be true if search is full path |
+| `owned` | boolean |  | Filter for projects owned by current user |
+| `membership` | boolean |  | Filter for projects where current user is a member |
+| `simple` | boolean |  | Return only limited fields |
+| `archived` | boolean |  | Filter for archived projects |
+| `visibility` | enum (`public` \| `internal` \| `private`) |  | Filter by project visibility |
+| `order_by` | enum (`id` \| `name` \| `path` \| `created_at` \| `updated_at` \| `last_activity_at`) |  | Return projects ordered by field |
+| `sort` | enum (`asc` \| `desc`) |  | Return projects sorted in ascending or descending order |
+| `with_issues_enabled` | boolean |  | Filter projects with issues feature enabled |
+| `with_merge_requests_enabled` | boolean |  | Filter projects with merge requests feature enabled |
+| `min_access_level` | number |  | Filter by minimum access level |
+| `topic` | string |  | Filter by topic (projects tagged with this topic) |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `list_project_members`
+
+*📖 Read-only*
+
+List members of a GitLab project. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `query` | string |  | Search for members by name or username |
+| `user_ids` | array<number> |  | Filter by user IDs |
+| `skip_users` | array<number> |  | User IDs to exclude |
+| `include_inheritance` | boolean |  | Include inherited members. Defaults to false. |
+| `per_page` | number |  | Number of items per page (default: 20, max: 100) |
+| `page` | number |  | Page number for pagination (default: 1) |
+
+### `list_labels`
+
+*📖 Read-only*
+
+List labels for a project. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `with_counts` | boolean |  | Whether to include issue and merge request counts |
+| `include_ancestor_groups` | boolean |  | Include ancestor groups |
+| `search` | string |  | Keyword to filter labels by |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `whoami`
+
+*📖 Read-only*
+
+Get current authenticated user details. Use this to identify the authenticated GitLab user; use `get_user` or `get_users` when looking up another user. It is read-only and returns the current user profile, while missing credentials or GitLab permission failures are reported as errors.
+
+**Parameters**
+
+_No parameters._
+
+### `health_check`
+
+*📖 Read-only*
+
+Verify server status and authentication. When authenticated, also reports the GitLab instance version from GET /api/v4/version (version, revision, enterprise). Version lookup failures do not fail the health check — those fields are omitted. Use this to verify server connectivity and authentication before making GitLab requests; use `whoami` when the authenticated user's identity is the goal. It does not mutate GitLab state and returns server/authentication status plus GitLab version details when available.
+
+**Parameters**
+
+_No parameters._

--- a/docs/tools/groups.md
+++ b/docs/tools/groups.md
@@ -2,6 +2,9 @@
 
 Create new groups and subgroups.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=groups` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`create_group`](#create_group) — ✏️ Writes

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -16,13 +16,14 @@ directly from `TOOLSET_DEFINITIONS` in
 
 | Status | Groups |
 |---|---|
-| **Default** — always exposed | [Projects & Namespaces](projects.md), [Projects & Files](repositories.md), [Branches & Commits](branches.md), [Groups](groups.md), [Merge Requests](merge-requests.md), [Issues](issues.md), [Labels](labels.md), [CI Lint](ci.md), [Users & Events](users.md) |
-| **Opt-in** — must be enabled | [Work Items](workitems.md), [Pipelines, Jobs & Deployments](pipelines.md) (also `USE_PIPELINE=true`), [Milestones](milestones.md) (also `USE_MILESTONE=true`), [Wiki](wiki.md) (also `USE_GITLAB_WIKI=true`), [Releases](releases.md), [Tags](tags.md), [Variables](variables.md), [Webhooks](webhooks.md), [Search](search.md), [Dependency Proxy](dependency-proxy.md), [Meta & GraphQL](meta.md) |
+| **Default** — always exposed | [Core](core.md) |
+| **Opt-in** — must be enabled | [Projects & Namespaces](projects.md), [Projects & Files](repositories.md), [Branches & Commits](branches.md), [Groups](groups.md), [Merge Requests](merge-requests.md), [Issues](issues.md), [Labels](labels.md), [Work Items](workitems.md), [CI Lint](ci.md), [Pipelines, Jobs & Deployments](pipelines.md) (also `USE_PIPELINE=true`), [Milestones](milestones.md) (also `USE_MILESTONE=true`), [Wiki](wiki.md) (also `USE_GITLAB_WIKI=true`), [Releases](releases.md), [Tags](tags.md), [Users & Events](users.md), [Variables](variables.md), [Webhooks](webhooks.md), [Search](search.md), [Dependency Proxy](dependency-proxy.md), [Meta & GraphQL](meta.md) |
 
 **How to enable opt-in groups** (any one is sufficient):
 
 - `GITLAB_TOOLSETS=<group,…>` — comma-separated toolset IDs.
 - `GITLAB_TOOLSETS=all` — enables every group.
+- `GITLAB_TOOLSETS=merge_requests,issues,repositories,branches,projects,labels,ci,groups,users` — restores the pre-lean default set.
 - `GITLAB_TOOLS=<tool,…>` — enables individual tools regardless of group.
 - `USE_PIPELINE=true` / `USE_MILESTONE=true` / `USE_GITLAB_WIKI=true` — legacy single-group flags (Pipelines, Milestones, Wiki only).
 - Call the `discover_tools` MCP tool at runtime to activate categories for the current session.
@@ -42,9 +43,53 @@ and [CLI Arguments](../getting-started/cli-arguments.md) for the full list.
 
 Each group has its own page with full parameter tables — click any tool name to jump to its details, or click the group title for the per-group view.
 
+### [Core](core.md)
+
+Lean default starter set for common MR, issue, repository, branch, project, label, and identity workflows. *(35 tools)*
+
+| Tool | What it does | R/W |
+|---|---|:-:|
+| [`list_merge_requests`](core.md#list_merge_requests) | List merge requests (without project_id: user's MRs; with project_id: project MRs) | 📖 |
+| [`get_merge_request`](core.md#get_merge_request) | Get details of a merge request (mergeRequestIid or branchName required) | 📖 |
+| [`get_merge_request_approval_state`](core.md#get_merge_request_approval_state) | Get merge request approval details including approvers | 📖 |
+| [`list_merge_request_changed_files`](core.md#list_merge_request_changed_files) | List changed file paths in a merge request without diff content (mergeRequestIid or branchName required) | 📖 |
+| [`get_merge_request_file_diff`](core.md#get_merge_request_file_diff) | Get diffs for specific files from a merge request (mergeRequestIid or branchName required) | 📖 |
+| [`list_merge_request_diffs`](core.md#list_merge_request_diffs) | List merge request diffs with pagination (mergeRequestIid or branchName required) | 📖 |
+| [`get_merge_request_diffs`](core.md#get_merge_request_diffs) | Get the changes/diffs of a merge request (mergeRequestIid or branchName required) | 📖 |
+| [`mr_discussions`](core.md#mr_discussions) | List discussion items for a merge request | 📖 |
+| [`create_merge_request`](core.md#create_merge_request) | Create a new merge request | ✏️ |
+| [`create_merge_request_thread`](core.md#create_merge_request_thread) | Create a new thread on a merge request | ✏️ |
+| [`resolve_merge_request_thread`](core.md#resolve_merge_request_thread) | Resolve a thread on a merge request | ✏️ |
+| [`update_merge_request`](core.md#update_merge_request) | Update a merge request (mergeRequestIid or branchName required) | ✏️ |
+| [`list_issues`](core.md#list_issues) | List issues (default: created by current user; use scope='all' for all) | 📖 |
+| [`my_issues`](core.md#my_issues) | List issues assigned to the authenticated user | 📖 |
+| [`get_issue`](core.md#get_issue) | Get details of a specific issue | 📖 |
+| [`create_issue`](core.md#create_issue) | Create a new issue | ✏️ |
+| [`update_issue`](core.md#update_issue) | Update an issue | ✏️ |
+| [`create_issue_note`](core.md#create_issue_note) | Add a note to an issue, optionally replying to a discussion thread | ✏️ |
+| [`list_issue_discussions`](core.md#list_issue_discussions) | List discussions for an issue | 📖 |
+| [`update_issue_description_patch`](core.md#update_issue_description_patch) | Apply a patch (search/replace or unified diff) to an issue description. Reduces token usage by allowing small changes without sending the full description. Supports dry_run to preview changes and create_note to summarize updates. | ✏️ |
+| [`get_file_contents`](core.md#get_file_contents) | Get contents of a file or directory from a GitLab project | 📖 |
+| [`get_repository_tree`](core.md#get_repository_tree) | List files and directories in a repository | 📖 |
+| [`search_repositories`](core.md#search_repositories) | Search for GitLab projects | 📖 |
+| [`get_branch`](core.md#get_branch) | Get branch details (commit, protection status) | 📖 |
+| [`list_branches`](core.md#list_branches) | List branches in project with search filter | 📖 |
+| [`list_commits`](core.md#list_commits) | List repository commits with filtering options | 📖 |
+| [`get_commit`](core.md#get_commit) | Get details of a specific commit | 📖 |
+| [`get_commit_diff`](core.md#get_commit_diff) | Get changes/diffs of a specific commit | 📖 |
+| [`get_file_blame`](core.md#get_file_blame) | Get git blame for a file at a given ref. Each entry maps a contiguous range of source lines to the commit that last changed them (id, author, authored_date, message). Use range_start/range_end to limit blame to specific lines. | 📖 |
+| [`get_project`](core.md#get_project) | Get details of a specific project | 📖 |
+| [`list_projects`](core.md#list_projects) | List projects accessible by the current user | 📖 |
+| [`list_project_members`](core.md#list_project_members) | List members of a GitLab project | 📖 |
+| [`list_labels`](core.md#list_labels) | List labels for a project | 📖 |
+| [`whoami`](core.md#whoami) | Get current authenticated user details | 📖 |
+| [`health_check`](core.md#health_check) | Verify server status and authentication | 📖 |
+
 ### [Projects & Namespaces](projects.md)
 
 Project/namespace listing, member queries, group iterations, and server health. *(10 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=projects` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -63,6 +108,8 @@ Project/namespace listing, member queries, group iterations, and server health. 
 
 Project search/creation/fork plus the Files API for reading and writing repository content without shelling out to git. *(7 tools)*
 
+> Opt-in. Enable via `GITLAB_TOOLSETS=repositories` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`search_repositories`](repositories.md#search_repositories) | Search for GitLab projects | 📖 |
@@ -76,6 +123,8 @@ Project search/creation/fork plus the Files API for reading and writing reposito
 ### [Branches & Commits](branches.md)
 
 Branch management, commit listing/inspection, file blame, and CI commit-status manipulation. *(15 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=branches` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -99,6 +148,8 @@ Branch management, commit listing/inspection, file blame, and CI commit-status m
 
 Create new groups and subgroups. *(1 tools)*
 
+> Opt-in. Enable via `GITLAB_TOOLSETS=groups` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`create_group`](groups.md#create_group) | Create new group or subgroup | ✏️ |
@@ -106,6 +157,8 @@ Create new groups and subgroups. *(1 tools)*
 ### [Merge Requests](merge-requests.md)
 
 MR lifecycle — create, update, merge, approve, plus diff/conflict inspection and the full discussion/note/draft API. *(43 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=merge_requests` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -157,6 +210,8 @@ MR lifecycle — create, update, merge, approve, plus diff/conflict inspection a
 
 Issue CRUD, links, discussions and notes, todos, and emoji reactions. *(24 tools)*
 
+> Opt-in. Enable via `GITLAB_TOOLSETS=issues` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`create_issue`](issues.md#create_issue) | Create a new issue | ✏️ |
@@ -187,6 +242,8 @@ Issue CRUD, links, discussions and notes, todos, and emoji reactions. *(24 tools
 ### [Labels](labels.md)
 
 Project label CRUD. *(5 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=labels` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -226,6 +283,8 @@ Modern unified API for issues, tasks, incidents, and other typed work items — 
 ### [CI Lint](ci.md)
 
 Validate `.gitlab-ci.yml` snippets and project pipeline configs. *(4 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=ci` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -333,6 +392,8 @@ Tag listing, creation, deletion, and signature inspection. *(5 tools)*
 
 User lookup, the authenticated user (`whoami`), event streams, and markdown attachment upload/download. *(7 tools)*
 
+> Opt-in. Enable via `GITLAB_TOOLSETS=users` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`get_users`](users.md#get_users) | Get GitLab user details by usernames | 📖 |
@@ -408,7 +469,7 @@ Server diagnostics, tool discovery, and the GraphQL escape hatch. *(2 tools)*
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`execute_graphql`](meta.md#execute_graphql) | Execute a GitLab GraphQL query | 📖 |
-| [`discover_tools`](meta.md#discover_tools) | Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy. Already-active categories are listed in the response. | 📖 |
+| [`discover_tools`](meta.md#discover_tools) | Discover and activate additional tool categories for this session. Available categories: core, merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy. Already-active categories are listed in the response. | 📖 |
 
 ---
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -16,13 +16,14 @@ directly from `TOOLSET_DEFINITIONS` in
 
 | Status | Groups |
 |---|---|
-| **Default** — always exposed | [Projects & Namespaces](projects.md), [Projects & Files](repositories.md), [Branches & Commits](branches.md), [Groups](groups.md), [Merge Requests](merge-requests.md), [Issues](issues.md), [Labels](labels.md), [CI Lint](ci.md), [Users & Events](users.md) |
-| **Opt-in** — must be enabled | [Work Items](workitems.md), [Pipelines, Jobs & Deployments](pipelines.md) (also `USE_PIPELINE=true`), [Milestones](milestones.md) (also `USE_MILESTONE=true`), [Wiki](wiki.md) (also `USE_GITLAB_WIKI=true`), [Releases](releases.md), [Tags](tags.md), [Variables](variables.md), [Webhooks](webhooks.md), [Search](search.md), [Dependency Proxy](dependency-proxy.md), [Vulnerabilities](vulnerabilities.md), [Meta & GraphQL](meta.md) |
+| **Default** — always exposed | [Core](core.md) |
+| **Opt-in** — must be enabled | [Projects & Namespaces](projects.md), [Projects & Files](repositories.md), [Branches & Commits](branches.md), [Groups](groups.md), [Merge Requests](merge-requests.md), [Issues](issues.md), [Labels](labels.md), [Work Items](workitems.md), [CI Lint](ci.md), [Pipelines, Jobs & Deployments](pipelines.md) (also `USE_PIPELINE=true`), [Milestones](milestones.md) (also `USE_MILESTONE=true`), [Wiki](wiki.md) (also `USE_GITLAB_WIKI=true`), [Releases](releases.md), [Tags](tags.md), [Users & Events](users.md), [Variables](variables.md), [Webhooks](webhooks.md), [Search](search.md), [Dependency Proxy](dependency-proxy.md), [Vulnerabilities](vulnerabilities.md), [Meta & GraphQL](meta.md) |
 
 **How to enable opt-in groups** (any one is sufficient):
 
 - `GITLAB_TOOLSETS=<group,…>` — comma-separated toolset IDs.
 - `GITLAB_TOOLSETS=all` — enables every group.
+- `GITLAB_TOOLSETS=merge_requests,issues,repositories,branches,projects,labels,ci,groups,users` — restores the pre-lean default set.
 - `GITLAB_TOOLS=<tool,…>` — enables individual tools regardless of group.
 - `USE_PIPELINE=true` / `USE_MILESTONE=true` / `USE_GITLAB_WIKI=true` — legacy single-group flags (Pipelines, Milestones, Wiki only).
 - Call the `discover_tools` MCP tool at runtime to activate categories for the current session.
@@ -47,9 +48,53 @@ and [CLI Arguments](../getting-started/cli-arguments.md) for the full list.
 
 Each group has its own page with full parameter tables — click any tool name to jump to its details, or click the group title for the per-group view.
 
+### [Core](core.md)
+
+Lean default starter set for common MR, issue, repository, branch, project, label, and identity workflows. *(35 tools)*
+
+| Tool | What it does | R/W |
+|---|---|:-:|
+| [`list_merge_requests`](core.md#list_merge_requests) | List merge requests (without project_id: user's MRs; with project_id: project MRs). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_merge_request`](core.md#get_merge_request) | Get details of a merge request (mergeRequestIid or branchName required). Set include_summaries=true for deployment/commit/approval summaries. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_merge_request_approval_state`](core.md#get_merge_request_approval_state) | Get merge request approval details including approvers. Use this to inspect approval rules and approvers before deciding whether a merge request can be merged; use `approve_merge_request` to change approval state. It is read-only and returns the approval-state response, while missing requests, unsupported GitLab versions, and permission failures are reported as errors. | 📖 |
+| [`list_merge_request_changed_files`](core.md#list_merge_request_changed_files) | List changed file paths in a merge request without diff content (mergeRequestIid or branchName required). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_merge_request_file_diff`](core.md#get_merge_request_file_diff) | Get diffs for specific files from a merge request (mergeRequestIid or branchName required). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`list_merge_request_diffs`](core.md#list_merge_request_diffs) | List merge request diffs with pagination (mergeRequestIid or branchName required). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_merge_request_diffs`](core.md#get_merge_request_diffs) | Get the changes/diffs of a merge request (mergeRequestIid or branchName required). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`mr_discussions`](core.md#mr_discussions) | List discussion items for a merge request. Use this to list complete discussion threads for a merge request; use `get_merge_request_notes` when only flat notes are needed. It is read-only and returns threaded discussion items, while invalid merge request identifiers, missing resources, and permission failures are reported as errors. | 📖 |
+| [`create_merge_request`](core.md#create_merge_request) | Create a new merge request. Use this to open a new merge request from an existing source branch to a target branch; use `update_merge_request` after it exists. The operation creates remote review state, requires project access, and returns the new merge request or a validation, permission, branch, or duplicate-related error. | ✏️ |
+| [`create_merge_request_thread`](core.md#create_merge_request_thread) | Create a new thread on a merge request. Use this to start a review thread on a merge request; use `create_merge_request_note` for an unthreaded note and `create_merge_request_discussion_note` to reply to an existing thread. The operation creates remote review content, requires note permission, and returns the discussion or a position/permission/validation error. | ✏️ |
+| [`resolve_merge_request_thread`](core.md#resolve_merge_request_thread) | Resolve a thread on a merge request. Use this to mark an existing merge request review thread resolved; use `update_merge_request_discussion_note` when the note text itself must change. The operation changes review state, requires permission to resolve discussions, and returns the updated discussion or a missing-thread/permission error. | ✏️ |
+| [`update_merge_request`](core.md#update_merge_request) | Update a merge request (mergeRequestIid or branchName required). Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | ✏️ |
+| [`list_issues`](core.md#list_issues) | List issues (default: created by current user; use scope='all' for all). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`my_issues`](core.md#my_issues) | List issues assigned to the authenticated user. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_issue`](core.md#get_issue) | Get details of a specific issue. Returns a slim milestone by default; set full_response=true for the complete milestone object. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`create_issue`](core.md#create_issue) | Create a new issue. Use this to open a new issue; use `update_issue` for an existing issue and `create_issue_note` to add discussion without changing issue fields. The operation creates remote project data, requires issue creation permission, and returns the new issue or a validation, permission, or duplicate-related error. | ✏️ |
+| [`update_issue`](core.md#update_issue) | Update an issue. Returns a slim confirmation by default; set full_response=true for the complete updated issue object. Use this to change fields on an existing issue; use `update_issue_description_patch` for a targeted description edit that avoids sending the full body, and use `create_issue_note` for discussion. The operation mutates issue state, requires issue-edit permission, and returns the updated issue or a validation/permission/conflict error. | ✏️ |
+| [`create_issue_note`](core.md#create_issue_note) | Add a note to an issue, optionally replying to a discussion thread. Use this to add a note to an existing issue, optionally as a reply to a discussion; use `update_issue` for issue fields and `create_note` only when the generic endpoint is required. The operation creates remote discussion content, requires note permission, and returns the note or a missing-issue/thread/permission error. | ✏️ |
+| [`list_issue_discussions`](core.md#list_issue_discussions) | List discussions for an issue. Use this to inspect threaded discussions for an issue; use `list_issues` for issue records and `get_issue` for one issue's fields. It is read-only and returns discussion items, while invalid identifiers, missing issues, and permission failures are reported as errors. | 📖 |
+| [`update_issue_description_patch`](core.md#update_issue_description_patch) | Apply a patch (search/replace or unified diff) to an issue description. Reduces token usage by allowing small changes without sending the full description. Supports dry_run to preview changes and create_note to summarize updates. Use this for a targeted search/replace or unified-diff change to an issue description; use `dry_run` before applying an uncertain patch and `create_note` when an audit summary is wanted. It changes the issue description when not dry-running, requires issue-edit permission, and returns the patch result or a mismatch/validation/permission error. | ✏️ |
+| [`get_file_contents`](core.md#get_file_contents) | Get contents of a file or directory from a GitLab project. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_repository_tree`](core.md#get_repository_tree) | List files and directories in a repository. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`search_repositories`](core.md#search_repositories) | Search for GitLab projects. Use this to discover matching content; choose a typed get or list tool when the target identifier is already known. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_branch`](core.md#get_branch) | Get branch details (commit, protection status). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`list_branches`](core.md#list_branches) | List branches in project with search filter. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`list_commits`](core.md#list_commits) | List repository commits with filtering options. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_commit`](core.md#get_commit) | Get details of a specific commit. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_commit_diff`](core.md#get_commit_diff) | Get changes/diffs of a specific commit. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`get_file_blame`](core.md#get_file_blame) | Get git blame for a file at a given ref. Each entry maps a contiguous range of source lines to the commit that last changed them (id, author, authored_date, message). Use range_start/range_end to limit blame to specific lines. | 📖 |
+| [`get_project`](core.md#get_project) | Get details of a specific project. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`list_projects`](core.md#list_projects) | List projects accessible by the current user. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`list_project_members`](core.md#list_project_members) | List members of a GitLab project. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`list_labels`](core.md#list_labels) | List labels for a project. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
+| [`whoami`](core.md#whoami) | Get current authenticated user details. Use this to identify the authenticated GitLab user; use `get_user` or `get_users` when looking up another user. It is read-only and returns the current user profile, while missing credentials or GitLab permission failures are reported as errors. | 📖 |
+| [`health_check`](core.md#health_check) | Verify server status and authentication. When authenticated, also reports the GitLab instance version from GET /api/v4/version (version, revision, enterprise). Version lookup failures do not fail the health check — those fields are omitted. Use this to verify server connectivity and authentication before making GitLab requests; use `whoami` when the authenticated user's identity is the goal. It does not mutate GitLab state and returns server/authentication status plus GitLab version details when available. | 📖 |
+
 ### [Projects & Namespaces](projects.md)
 
 Project/namespace listing, member queries, group iterations, and server health. *(11 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=projects` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -69,6 +114,8 @@ Project/namespace listing, member queries, group iterations, and server health. 
 
 Project search/creation/fork plus the Files API for reading and writing repository content without shelling out to git. *(7 tools)*
 
+> Opt-in. Enable via `GITLAB_TOOLSETS=repositories` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`search_repositories`](repositories.md#search_repositories) | Search for GitLab projects. Use this to discover matching content; choose a typed get or list tool when the target identifier is already known. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
@@ -82,6 +129,8 @@ Project search/creation/fork plus the Files API for reading and writing reposito
 ### [Branches & Commits](branches.md)
 
 Branch management, commit listing/inspection, file blame, and CI commit-status manipulation. *(15 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=branches` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -105,6 +154,8 @@ Branch management, commit listing/inspection, file blame, and CI commit-status m
 
 Create new groups and subgroups. *(1 tools)*
 
+> Opt-in. Enable via `GITLAB_TOOLSETS=groups` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`create_group`](groups.md#create_group) | Create new group or subgroup. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | ✏️ |
@@ -112,6 +163,8 @@ Create new groups and subgroups. *(1 tools)*
 ### [Merge Requests](merge-requests.md)
 
 MR lifecycle — create, update, merge, approve, plus diff/conflict inspection and the full discussion/note/draft API. *(44 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=merge_requests` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -164,6 +217,8 @@ MR lifecycle — create, update, merge, approve, plus diff/conflict inspection a
 
 Issue CRUD, links, discussions and notes, todos, and emoji reactions. *(24 tools)*
 
+> Opt-in. Enable via `GITLAB_TOOLSETS=issues` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`create_issue`](issues.md#create_issue) | Create a new issue. Use this to open a new issue; use `update_issue` for an existing issue and `create_issue_note` to add discussion without changing issue fields. The operation creates remote project data, requires issue creation permission, and returns the new issue or a validation, permission, or duplicate-related error. | ✏️ |
@@ -194,6 +249,8 @@ Issue CRUD, links, discussions and notes, todos, and emoji reactions. *(24 tools
 ### [Labels](labels.md)
 
 Project label CRUD. *(5 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=labels` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -233,6 +290,8 @@ Modern unified API for issues, tasks, incidents, and other typed work items — 
 ### [CI Lint](ci.md)
 
 Validate `.gitlab-ci.yml` snippets and project pipeline configs. *(4 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=ci` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
@@ -385,6 +444,8 @@ Tag listing, creation, deletion, and signature inspection. *(5 tools)*
 
 User lookup, the authenticated user (`whoami`), event streams, and markdown attachment upload/download. *(7 tools)*
 
+> Opt-in. Enable via `GITLAB_TOOLSETS=users` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`get_users`](users.md#get_users) | Get GitLab user details by usernames. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | 📖 |
@@ -476,7 +537,7 @@ Server diagnostics, tool discovery, and the GraphQL escape hatch. *(2 tools)*
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`execute_graphql`](meta.md#execute_graphql) | Execute a GitLab GraphQL query. Use this only when a supported GitLab REST tool does not cover the requested operation; prefer a typed tool when one exists. The query is sent directly to GitLab and can include mutations when permission allows, so callers must treat it as potentially state-changing and handle GraphQL errors in the returned response. | 📖 |
-| [`discover_tools`](meta.md#discover_tools) | Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data. | 📖 |
+| [`discover_tools`](meta.md#discover_tools) | Discover and activate additional tool categories for this session. Available categories: core, merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data. | 📖 |
 
 ---
 

--- a/docs/tools/issues.md
+++ b/docs/tools/issues.md
@@ -2,6 +2,9 @@
 
 Issue CRUD, links, discussions and notes, todos, and emoji reactions.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=issues` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`create_issue`](#create_issue) — ✏️ Writes

--- a/docs/tools/labels.md
+++ b/docs/tools/labels.md
@@ -2,6 +2,9 @@
 
 Project label CRUD.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=labels` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`list_labels`](#list_labels) — 📖 Read-only

--- a/docs/tools/merge-requests.md
+++ b/docs/tools/merge-requests.md
@@ -2,6 +2,9 @@
 
 MR lifecycle — create, update, merge, approve, plus diff/conflict inspection and the full discussion/note/draft API.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=merge_requests` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`merge_merge_request`](#merge_merge_request) — ✏️ Writes

--- a/docs/tools/meta.md
+++ b/docs/tools/meta.md
@@ -29,7 +29,7 @@ Execute a GitLab GraphQL query
 
 *📖 Read-only*
 
-Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy. Already-active categories are listed in the response.
+Discover and activate additional tool categories for this session. Available categories: core, merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy. Already-active categories are listed in the response.
 
 **Parameters**
 

--- a/docs/tools/meta.md
+++ b/docs/tools/meta.md
@@ -29,7 +29,7 @@ Execute a GitLab GraphQL query. Use this only when a supported GitLab REST tool 
 
 *📖 Read-only*
 
-Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data.
+Discover and activate additional tool categories for this session. Available categories: core, merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data.
 
 **Parameters**
 

--- a/docs/tools/projects.md
+++ b/docs/tools/projects.md
@@ -2,6 +2,9 @@
 
 Project/namespace listing, member queries, group iterations, and server health.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=projects` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`get_project`](#get_project) — 📖 Read-only

--- a/docs/tools/repositories.md
+++ b/docs/tools/repositories.md
@@ -2,6 +2,9 @@
 
 Project search/creation/fork plus the Files API for reading and writing repository content without shelling out to git.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=repositories` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`search_repositories`](#search_repositories) — 📖 Read-only

--- a/docs/tools/users.md
+++ b/docs/tools/users.md
@@ -2,6 +2,9 @@
 
 User lookup, the authenticated user (`whoami`), event streams, and markdown attachment upload/download.
 
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=users` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
 ## Tools in this group
 
 - [`get_users`](#get_users) — 📖 Read-only

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - Resolve Issue Thread: features/resolve-issue-thread.md
   - Tools:
       - Overview: tools/index.md
+      - Core: tools/core.md
       - Projects & Namespaces: tools/projects.md
       - Projects & Files: tools/repositories.md
       - Branches & Commits: tools/branches.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Resolve Issue Thread: features/resolve-issue-thread.md
   - Tools:
       - Overview: tools/index.md
+      - Core: tools/core.md
       - Projects & Namespaces: tools/projects.md
       - Projects & Files: tools/repositories.md
       - Branches & Commits: tools/branches.md

--- a/scripts/generate-tool-docs.ts
+++ b/scripts/generate-tool-docs.ts
@@ -52,6 +52,11 @@ function computeToggleNote(id: ToolsetId): string | undefined {
 }
 
 const GROUP_META: Record<ToolsetId, GroupMeta> = {
+  core: {
+    title: "Core",
+    blurb:
+      "Lean default starter set for common MR, issue, repository, branch, project, label, and identity workflows.",
+  },
   merge_requests: {
     title: "Merge Requests",
     blurb:
@@ -138,6 +143,7 @@ const GROUP_META: Record<ToolsetId, GroupMeta> = {
 };
 
 const GROUP_ORDER: ToolsetId[] = [
+  "core",
   "projects",
   "repositories",
   "branches",
@@ -268,7 +274,9 @@ function buildGroupPage(id: ToolsetId, toolNames: string[]): string {
   for (const name of toolNames) {
     const tool = allTools.find(t => t.name === name);
     if (!tool) {
-      throw new Error(`Tool '${name}' referenced in toolset '${id}' but missing from allTools registry`);
+      throw new Error(
+        `Tool '${name}' referenced in toolset '${id}' but missing from allTools registry`
+      );
     }
     lines.push(toolSection(name, tool.description, tool.inputSchema as JsonSchema));
   }
@@ -301,6 +309,7 @@ function buildToggleSection(groupedToolsList: Array<[ToolsetId, string[]]>): str
     "",
     "- `GITLAB_TOOLSETS=<group,…>` — comma-separated toolset IDs.",
     "- `GITLAB_TOOLSETS=all` — enables every group.",
+    "- `GITLAB_TOOLSETS=merge_requests,issues,repositories,branches,projects,labels,ci,groups,users` — restores the pre-lean default set.",
     "- `GITLAB_TOOLS=<tool,…>` — enables individual tools regardless of group.",
     "- `USE_PIPELINE=true` / `USE_MILESTONE=true` / `USE_GITLAB_WIKI=true` —" +
       " legacy single-group flags (Pipelines, Milestones, Wiki only).",

--- a/scripts/generate-tool-docs.ts
+++ b/scripts/generate-tool-docs.ts
@@ -52,6 +52,11 @@ function computeToggleNote(id: ToolsetId): string | undefined {
 }
 
 const GROUP_META: Record<ToolsetId, GroupMeta> = {
+  core: {
+    title: "Core",
+    blurb:
+      "Lean default starter set for common MR, issue, repository, branch, project, label, and identity workflows.",
+  },
   merge_requests: {
     title: "Merge Requests",
     blurb:
@@ -143,6 +148,7 @@ const GROUP_META: Record<ToolsetId, GroupMeta> = {
 };
 
 const GROUP_ORDER: ToolsetId[] = [
+  "core",
   "projects",
   "repositories",
   "branches",
@@ -274,7 +280,9 @@ function buildGroupPage(id: ToolsetId, toolNames: string[]): string {
   for (const name of toolNames) {
     const tool = allTools.find(t => t.name === name);
     if (!tool) {
-      throw new Error(`Tool '${name}' referenced in toolset '${id}' but missing from allTools registry`);
+      throw new Error(
+        `Tool '${name}' referenced in toolset '${id}' but missing from allTools registry`
+      );
     }
     lines.push(toolSection(name, tool.description, tool.inputSchema as JsonSchema));
   }
@@ -307,6 +315,7 @@ function buildToggleSection(groupedToolsList: Array<[ToolsetId, string[]]>): str
     "",
     "- `GITLAB_TOOLSETS=<group,…>` — comma-separated toolset IDs.",
     "- `GITLAB_TOOLSETS=all` — enables every group.",
+    "- `GITLAB_TOOLSETS=merge_requests,issues,repositories,branches,projects,labels,ci,groups,users` — restores the pre-lean default set.",
     "- `GITLAB_TOOLS=<tool,…>` — enables individual tools regardless of group.",
     "- `USE_PIPELINE=true` / `USE_MILESTONE=true` / `USE_GITLAB_WIKI=true` —" +
       " legacy single-group flags (Pipelines, Milestones, Wiki only).",

--- a/skills/gitlab-mcp/SKILL.md
+++ b/skills/gitlab-mcp/SKILL.md
@@ -5,30 +5,34 @@ description: Use this skill when working with the GitLab MCP server tools for me
 
 # gitlab-mcp
 
-GitLab MCP server providing 173 tools: 171 tools across 16 toolsets, plus `execute_graphql` and the always-available `discover_tools` meta-tool.
+GitLab MCP server providing 204 tools total: 202 tools across 20 toolsets, plus `execute_graphql` and the always-available `discover_tools` meta-tool.
 
 ## Toolsets
 
-| Toolset                   | Default | Enable with                                          |
-| ------------------------- | ------- | ---------------------------------------------------- |
-| merge_requests (41 tools) | yes     | -                                                    |
-| issues (23 tools)         | yes     | -                                                    |
-| repositories (7 tools)    | yes     | -                                                    |
-| branches (6 tools)        | yes     | -                                                    |
-| projects (8 tools)        | yes     | -                                                    |
-| labels (5 tools)          | yes     | -                                                    |
-| ci (2 tools)              | yes     | -                                                    |
-| users (5 tools)           | yes     | -                                                    |
-| pipelines (19 tools)      | no      | `USE_PIPELINE=true` or `GITLAB_TOOLSETS=pipelines`   |
-| milestones (9 tools)      | no      | `USE_MILESTONE=true` or `GITLAB_TOOLSETS=milestones` |
-| wiki (10 tools)           | no      | `USE_GITLAB_WIKI=true` or `GITLAB_TOOLSETS=wiki`     |
-| releases (7 tools)        | no      | `GITLAB_TOOLSETS=releases`                           |
-| tags (5 tools)            | no      | `GITLAB_TOOLSETS=tags`                               |
-| workitems (18 tools)      | no      | `GITLAB_TOOLSETS=workitems`                          |
-| webhooks (3 tools)        | no      | `GITLAB_TOOLSETS=webhooks`                           |
-| search (3 tools)          | no      | `GITLAB_TOOLSETS=search`                             |
+| Toolset                    | Default | Enable with                                          |
+| -------------------------- | ------- | ---------------------------------------------------- |
+| core (35 tools)            | yes     | default lean starter set                             |
+| merge_requests (43 tools)  | no      | `GITLAB_TOOLSETS=merge_requests`                     |
+| issues (24 tools)          | no      | `GITLAB_TOOLSETS=issues`                             |
+| repositories (7 tools)     | no      | `GITLAB_TOOLSETS=repositories`                       |
+| branches (15 tools)        | no      | `GITLAB_TOOLSETS=branches`                           |
+| projects (10 tools)        | no      | `GITLAB_TOOLSETS=projects`                           |
+| labels (5 tools)           | no      | `GITLAB_TOOLSETS=labels`                             |
+| ci (4 tools)               | no      | `GITLAB_TOOLSETS=ci`                                 |
+| groups (1 tool)            | no      | `GITLAB_TOOLSETS=groups`                             |
+| users (7 tools)            | no      | `GITLAB_TOOLSETS=users`                              |
+| pipelines (19 tools)       | no      | `USE_PIPELINE=true` or `GITLAB_TOOLSETS=pipelines`   |
+| milestones (9 tools)       | no      | `USE_MILESTONE=true` or `GITLAB_TOOLSETS=milestones` |
+| wiki (10 tools)            | no      | `USE_GITLAB_WIKI=true` or `GITLAB_TOOLSETS=wiki`     |
+| releases (7 tools)         | no      | `GITLAB_TOOLSETS=releases`                           |
+| tags (5 tools)             | no      | `GITLAB_TOOLSETS=tags`                               |
+| workitems (18 tools)       | no      | `GITLAB_TOOLSETS=workitems`                          |
+| webhooks (3 tools)         | no      | `GITLAB_TOOLSETS=webhooks`                           |
+| search (3 tools)           | no      | `GITLAB_TOOLSETS=search`                             |
+| variables (10 tools)       | no      | `GITLAB_TOOLSETS=variables`                          |
+| dependency_proxy (4 tools) | no      | `GITLAB_TOOLSETS=dependency_proxy`                   |
 
-Enable all: `GITLAB_TOOLSETS=all`. Use `GITLAB_TOOLS` to enable individual tools outside their toolset. `discover_tools` can activate opt-in categories for the current session.
+Enable all: `GITLAB_TOOLSETS=all`. Restore the pre-lean default with `GITLAB_TOOLSETS=merge_requests,issues,repositories,branches,projects,labels,ci,groups,users`. Use `GITLAB_TOOLS` to enable individual tools outside their toolset. `discover_tools` can activate opt-in categories for the current session.
 
 ## Key Workflows
 

--- a/skills/gitlab-mcp/SKILL.md
+++ b/skills/gitlab-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill when working with the GitLab MCP server tools for me
 
 # gitlab-mcp
 
-GitLab MCP server providing 258 tools: 256 tools across 20 toolsets, plus `execute_graphql` and the always-available `discover_tools` meta-tool.
+GitLab MCP server providing 258 tools: 256 tools across 21 toolsets, plus `execute_graphql` and the always-available `discover_tools` meta-tool.
 
 For exact generated parameter tables, see `docs/tools/`. Use this file for workflow shape and high-signal parameter hints.
 
@@ -13,15 +13,16 @@ For exact generated parameter tables, see `docs/tools/`. Use this file for workf
 
 | Toolset | Default | Enable with |
 |---|---|---|
-| merge_requests (44 tools) | yes | - |
-| issues (24 tools) | yes | - |
-| repositories (7 tools) | yes | - |
-| branches (15 tools) | yes | - |
-| projects (11 tools) | yes | - |
-| labels (5 tools) | yes | - |
-| ci (4 tools) | yes | - |
-| groups (1 tool) | yes | - |
-| users (7 tools) | yes | - |
+| core (35 tools) | yes | default lean starter set |
+| merge_requests (44 tools) | no | `GITLAB_TOOLSETS=merge_requests` |
+| issues (24 tools) | no | `GITLAB_TOOLSETS=issues` |
+| repositories (7 tools) | no | `GITLAB_TOOLSETS=repositories` |
+| branches (15 tools) | no | `GITLAB_TOOLSETS=branches` |
+| projects (11 tools) | no | `GITLAB_TOOLSETS=projects` |
+| labels (5 tools) | no | `GITLAB_TOOLSETS=labels` |
+| ci (4 tools) | no | `GITLAB_TOOLSETS=ci` |
+| groups (1 tool) | no | `GITLAB_TOOLSETS=groups` |
+| users (7 tools) | no | `GITLAB_TOOLSETS=users` |
 | pipelines (56 tools) | no | `USE_PIPELINE=true` or `GITLAB_TOOLSETS=pipelines` |
 | milestones (17 tools) | no | `USE_MILESTONE=true` or `GITLAB_TOOLSETS=milestones` |
 | wiki (10 tools) | no | `USE_GITLAB_WIKI=true` or `GITLAB_TOOLSETS=wiki` |
@@ -34,10 +35,11 @@ For exact generated parameter tables, see `docs/tools/`. Use this file for workf
 | dependency_proxy (4 tools) | no | `GITLAB_TOOLSETS=dependency_proxy` |
 | vulnerabilities (4 tools) | no | `GITLAB_TOOLSETS=vulnerabilities` |
 
-Enable all: `GITLAB_TOOLSETS=all`. Use `GITLAB_TOOLS` to enable individual tools outside their toolset. `discover_tools` can list and activate opt-in categories for the current session. `execute_graphql` is not in a toolset; enable it explicitly with `GITLAB_TOOLS=execute_graphql`.
+Enable all: `GITLAB_TOOLSETS=all`. Restore the pre-lean default with `GITLAB_TOOLSETS=merge_requests,issues,repositories,branches,projects,labels,ci,groups,users`. Use `GITLAB_TOOLS` to enable individual tools outside their toolset. `discover_tools` can list and activate opt-in categories for the current session. `execute_graphql` is not in a toolset; enable it explicitly with `GITLAB_TOOLS=execute_graphql`.
 
-The per-toolset counts above sum to 258 because `get_branch` and `list_branches` are each listed
-in both `merge_requests` and `branches`; the unique tool count across all toolsets is 256.
+The per-toolset counts above sum to 293 because the 35 `core` tools are each also listed
+in their full category (`get_branch` and `list_branches` additionally appear in both
+`merge_requests` and `branches`); the unique tool count across all toolsets is 256.
 
 ## Key Workflows
 

--- a/test/test-ci-lint.ts
+++ b/test/test-ci-lint.ts
@@ -220,10 +220,11 @@ describe("GitLab CI lint tools", () => {
     assert.strictEqual(result.jobs[0].name, "include-job");
   });
 
-  test("CI lint tools are visible by default in read-only mode", async () => {
+  test("CI lint tools are visible when ci toolset is enabled in read-only mode", async () => {
     const tools = await listToolNames({
       GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
       GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+      GITLAB_TOOLSETS: "ci",
       GITLAB_READ_ONLY_MODE: "true",
     });
 

--- a/test/test-todos.ts
+++ b/test/test-todos.ts
@@ -221,10 +221,11 @@ describe("GitLab todos tools", () => {
     });
   });
 
-  test("todo tools are visible in the default issues toolset", async () => {
+  test("todo tools are visible when the issues toolset is enabled", async () => {
     const tools = await listToolNames({
       GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
       GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+      GITLAB_TOOLSETS: "issues",
     });
 
     assert.ok(tools.includes("list_todos"));
@@ -232,10 +233,11 @@ describe("GitLab todos tools", () => {
     assert.ok(tools.includes("mark_all_todos_done"));
   });
 
-  test("read-only mode keeps list_todos and hides todo mutations", async () => {
+  test("read-only mode keeps list_todos and hides todo mutations when issues are enabled", async () => {
     const tools = await listToolNames({
       GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
       GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+      GITLAB_TOOLSETS: "issues",
       GITLAB_READ_ONLY_MODE: "true",
     });
 

--- a/test/test-toolset-filtering.ts
+++ b/test/test-toolset-filtering.ts
@@ -16,11 +16,9 @@ import {
   TransportMode,
   HOST,
 } from "./utils/server-launcher.js";
-import {
-  MockGitLabServer,
-  findMockServerPort,
-} from "./utils/mock-gitlab-server.js";
+import { MockGitLabServer, findMockServerPort } from "./utils/mock-gitlab-server.js";
 import { CustomHeaderClient } from "./clients/custom-header-client.js";
+import { TOOLSET_DEFINITIONS } from "../tools/registry.js";
 
 const MOCK_TOKEN = "glpat-toolset-test-token";
 
@@ -29,79 +27,64 @@ const MOCK_PORT_BASE = 9200;
 const MCP_PORT_BASE = 3200;
 
 // Known tool counts per toolset (from TOOLSET_DEFINITIONS)
-const TOOLSET_TOOL_COUNTS: Record<string, number> = {
-  merge_requests: 41,
-  issues: 24,
-  repositories: 7,
-  branches: 15,
-  projects: 10,
-  labels: 5,
-  ci: 4,
-  pipelines: 19,
-  milestones: 9,
-  wiki: 10,
-  releases: 7,
-  tags: 5,
-  users: 7,
-  search: 3,
-  workitems: 18,
-  webhooks: 3,
-  groups: 1,
-  variables: 10,
-  dependency_proxy: 4,
-};
+const TOOLSET_TOOL_COUNTS: Record<string, number> = Object.fromEntries(
+  TOOLSET_DEFINITIONS.map(def => [def.id, def.tools.size])
+);
 
 const LEGACY_PIPELINE_CI_TOOL_COUNT = 2;
 const LEGACY_PIPELINE_TOOL_COUNT = TOOLSET_TOOL_COUNTS.pipelines + LEGACY_PIPELINE_CI_TOOL_COUNT;
 
-const DEFAULT_TOOLSETS = [
-  "merge_requests",
-  "issues",
-  "repositories",
-  "branches",
-  "projects",
-  "labels",
-  "ci",
-  "users",
-  "groups",
-];
+const DEFAULT_TOOLSETS = TOOLSET_DEFINITIONS.filter(def => def.isDefault).map(def => def.id);
 
-const NON_DEFAULT_TOOLSETS = [
-  "pipelines",
-  "milestones",
-  "wiki",
-  "releases",
-  "tags",
-  "workitems",
-  "webhooks",
-  "search",
-  "variables",
-  "dependency_proxy",
-];
+const NON_DEFAULT_TOOLSETS = TOOLSET_DEFINITIONS.filter(def => !def.isDefault).map(def => def.id);
 
 // discover_tools meta-tool is always force-injected (Step 5.5)
 const DISCOVER_TOOLS_COUNT = 1;
 
-const DEFAULT_TOOL_COUNT = DEFAULT_TOOLSETS.reduce(
-  (sum, id) => sum + TOOLSET_TOOL_COUNTS[id],
-  0
-) + DISCOVER_TOOLS_COUNT;
+function uniqueToolCount(toolsetIds: readonly string[]): number {
+  const names = new Set<string>();
+  for (const id of toolsetIds) {
+    const def = TOOLSET_DEFINITIONS.find(def => def.id === id);
+    if (!def) continue;
+    for (const tool of def.tools) names.add(tool);
+  }
+  return names.size;
+}
 
-const ALL_TOOLSET_TOOL_COUNT = Object.values(TOOLSET_TOOL_COUNTS).reduce(
-  (sum, c) => sum + c,
-  0
-) + DISCOVER_TOOLS_COUNT;
+const DEFAULT_TOOL_COUNT = uniqueToolCount(DEFAULT_TOOLSETS) + DISCOVER_TOOLS_COUNT;
+const ALL_TOOLSET_TOOL_COUNT =
+  uniqueToolCount(TOOLSET_DEFINITIONS.map(def => def.id)) + DISCOVER_TOOLS_COUNT;
 
 // Representative tools per toolset for spot-checking
 const TOOLSET_SAMPLE_TOOLS: Record<string, string[]> = {
+  core: ["list_merge_requests", "get_file_contents", "list_issues", "whoami"],
   merge_requests: ["merge_merge_request", "create_merge_request_thread", "list_draft_notes"],
   issues: ["create_issue", "list_issues", "create_note", "list_todos"],
   repositories: ["search_repositories", "get_file_contents", "push_files"],
-  branches: ["create_branch", "get_branch", "list_branches", "delete_branch", "list_commits", "list_commit_statuses", "create_commit_status"],
+  branches: [
+    "create_branch",
+    "get_branch",
+    "list_branches",
+    "delete_branch",
+    "list_commits",
+    "list_commit_statuses",
+    "create_commit_status",
+  ],
   projects: ["get_project", "update_project", "list_namespaces", "list_group_iterations"],
   labels: ["list_labels", "create_label"],
-  ci: ["validate_ci_lint", "validate_project_ci_lint", "list_ci_catalog_resources", "get_ci_catalog_resource"],
-  pipelines: ["list_pipelines", "create_pipeline", "cancel_pipeline_job", "list_deployments", "list_job_artifacts"],
+  ci: [
+    "validate_ci_lint",
+    "validate_project_ci_lint",
+    "list_ci_catalog_resources",
+    "get_ci_catalog_resource",
+  ],
+  pipelines: [
+    "list_pipelines",
+    "create_pipeline",
+    "cancel_pipeline_job",
+    "list_deployments",
+    "list_job_artifacts",
+  ],
   milestones: ["list_milestones", "create_milestone", "get_milestone_burndown_events"],
   wiki: ["list_wiki_pages", "create_wiki_page", "list_group_wiki_pages", "create_group_wiki_page"],
   releases: ["list_releases", "create_release", "download_release_asset"],
@@ -110,8 +93,19 @@ const TOOLSET_SAMPLE_TOOLS: Record<string, string[]> = {
   search: ["search_code", "search_project_code", "search_group_code"],
   webhooks: ["list_webhooks", "list_webhook_events", "get_webhook_event"],
   groups: ["create_group"],
-  variables: ["list_project_variables", "create_project_variable", "delete_project_variable", "list_group_variables", "create_group_variable", "delete_group_variable"],
-  dependency_proxy: ["get_dependency_proxy_settings", "list_dependency_proxy_blobs", "purge_dependency_proxy_cache"],
+  variables: [
+    "list_project_variables",
+    "create_project_variable",
+    "delete_project_variable",
+    "list_group_variables",
+    "create_group_variable",
+    "delete_group_variable",
+  ],
+  dependency_proxy: [
+    "get_dependency_proxy_settings",
+    "list_dependency_proxy_blobs",
+    "purge_dependency_proxy_cache",
+  ],
 };
 
 // --- Helpers ---
@@ -210,6 +204,22 @@ describe("Toolset Filtering", { concurrency: 1 }, () => {
       assertContainsNone(tools, TOOLSET_SAMPLE_TOOLS.search, "non-default search");
       assertContainsNone(tools, TOOLSET_SAMPLE_TOOLS.pipelines, "non-default pipelines");
       assertContainsNone(tools, TOOLSET_SAMPLE_TOOLS.wiki, "non-default wiki");
+    });
+
+    test("excludes advanced and destructive tools from the lean default", () => {
+      assertContainsNone(
+        tools,
+        [
+          "merge_merge_request",
+          "create_draft_note",
+          "delete_issue",
+          "push_files",
+          "create_label",
+          "validate_ci_lint",
+          "create_group",
+        ],
+        "advanced defaults"
+      );
     });
 
     test("excludes execute_graphql (not in any toolset)", () => {
@@ -470,10 +480,12 @@ describe("Toolset Filtering", { concurrency: 1 }, () => {
     after(() => cleanupServers([server]));
 
     test("excludes tools matching the denial regex", () => {
-      const denied = tools.filter(
-        (t) => t.startsWith("create_") || t.startsWith("delete_")
+      const denied = tools.filter(t => t.startsWith("create_") || t.startsWith("delete_"));
+      assert.strictEqual(
+        denied.length,
+        0,
+        `Should have no create_/delete_ tools, found: ${denied}`
       );
-      assert.strictEqual(denied.length, 0, `Should have no create_/delete_ tools, found: ${denied}`);
     });
 
     test("keeps non-matching issue tools", () => {

--- a/test/test-toolset-filtering.ts
+++ b/test/test-toolset-filtering.ts
@@ -16,11 +16,9 @@ import {
   TransportMode,
   HOST,
 } from "./utils/server-launcher.js";
-import {
-  MockGitLabServer,
-  findMockServerPort,
-} from "./utils/mock-gitlab-server.js";
+import { MockGitLabServer, findMockServerPort } from "./utils/mock-gitlab-server.js";
 import { CustomHeaderClient } from "./clients/custom-header-client.js";
+import { TOOLSET_DEFINITIONS } from "../tools/registry.js";
 
 const MOCK_TOKEN = "glpat-toolset-test-token";
 
@@ -29,82 +27,68 @@ const MOCK_PORT_BASE = 9200;
 const MCP_PORT_BASE = 3200;
 
 // Known tool counts per toolset (from TOOLSET_DEFINITIONS)
-const TOOLSET_TOOL_COUNTS: Record<string, number> = {
-  merge_requests: 42,
-  issues: 24,
-  repositories: 7,
-  branches: 15,
-  projects: 11,
-  labels: 5,
-  ci: 4,
-  pipelines: 56,
-  milestones: 17,
-  wiki: 10,
-  releases: 7,
-  tags: 5,
-  users: 7,
-  search: 3,
-  workitems: 18,
-  webhooks: 6,
-  groups: 1,
-  variables: 10,
-  dependency_proxy: 4,
-  vulnerabilities: 4,
-};
+const TOOLSET_TOOL_COUNTS: Record<string, number> = Object.fromEntries(
+  TOOLSET_DEFINITIONS.map(def => [def.id, def.tools.size])
+);
 
 const LEGACY_PIPELINE_CI_TOOL_COUNT = 2;
 const LEGACY_PIPELINE_TOOL_COUNT = TOOLSET_TOOL_COUNTS.pipelines + LEGACY_PIPELINE_CI_TOOL_COUNT;
 
-const DEFAULT_TOOLSETS = [
-  "merge_requests",
-  "issues",
-  "repositories",
-  "branches",
-  "projects",
-  "labels",
-  "ci",
-  "users",
-  "groups",
-];
-
-const NON_DEFAULT_TOOLSETS = [
-  "pipelines",
-  "milestones",
-  "wiki",
-  "releases",
-  "tags",
-  "workitems",
-  "webhooks",
-  "search",
-  "variables",
-  "dependency_proxy",
-  "vulnerabilities",
-];
+const DEFAULT_TOOLSETS = TOOLSET_DEFINITIONS.filter(def => def.isDefault).map(def => def.id);
 
 // discover_tools meta-tool is always force-injected (Step 5.5)
 const DISCOVER_TOOLS_COUNT = 1;
 
-const DEFAULT_TOOL_COUNT = DEFAULT_TOOLSETS.reduce(
-  (sum, id) => sum + TOOLSET_TOOL_COUNTS[id],
-  0
-) + DISCOVER_TOOLS_COUNT;
+function uniqueToolCount(toolsetIds: readonly string[]): number {
+  const names = new Set<string>();
+  for (const id of toolsetIds) {
+    const def = TOOLSET_DEFINITIONS.find(def => def.id === id);
+    if (!def) continue;
+    for (const tool of def.tools) names.add(tool);
+  }
+  return names.size;
+}
 
-const ALL_TOOLSET_TOOL_COUNT = Object.values(TOOLSET_TOOL_COUNTS).reduce(
-  (sum, c) => sum + c,
-  0
-) + DISCOVER_TOOLS_COUNT;
+const DEFAULT_TOOL_COUNT = uniqueToolCount(DEFAULT_TOOLSETS) + DISCOVER_TOOLS_COUNT;
+const ALL_TOOLSET_TOOL_COUNT =
+  uniqueToolCount(TOOLSET_DEFINITIONS.map(def => def.id)) + DISCOVER_TOOLS_COUNT;
 
 // Representative tools per toolset for spot-checking
 const TOOLSET_SAMPLE_TOOLS: Record<string, string[]> = {
+  core: ["list_merge_requests", "get_file_contents", "list_issues", "whoami"],
   merge_requests: ["merge_merge_request", "create_merge_request_thread", "list_draft_notes"],
   issues: ["create_issue", "list_issues", "create_note", "list_todos"],
   repositories: ["search_repositories", "get_file_contents", "push_files"],
-  branches: ["create_branch", "get_branch", "list_branches", "delete_branch", "list_commits", "list_commit_statuses", "create_commit_status"],
+  branches: [
+    "create_branch",
+    "get_branch",
+    "list_branches",
+    "delete_branch",
+    "list_commits",
+    "list_commit_statuses",
+    "create_commit_status",
+  ],
   projects: ["get_project", "update_project", "list_namespaces", "list_group_iterations"],
   labels: ["list_labels", "create_label"],
-  ci: ["validate_ci_lint", "validate_project_ci_lint", "list_ci_catalog_resources", "get_ci_catalog_resource"],
-  pipelines: ["list_pipelines", "create_pipeline", "cancel_pipeline_job", "list_deployments", "list_job_artifacts"],
-  milestones: ["list_milestones", "create_milestone", "list_group_milestones", "get_group_milestone_burndown_events"],
+  ci: [
+    "validate_ci_lint",
+    "validate_project_ci_lint",
+    "list_ci_catalog_resources",
+    "get_ci_catalog_resource",
+  ],
+  pipelines: [
+    "list_pipelines",
+    "create_pipeline",
+    "cancel_pipeline_job",
+    "list_deployments",
+    "list_job_artifacts",
+  ],
+  milestones: [
+    "list_milestones",
+    "create_milestone",
+    "list_group_milestones",
+    "get_group_milestone_burndown_events",
+  ],
   wiki: ["list_wiki_pages", "create_wiki_page", "list_group_wiki_pages", "create_group_wiki_page"],
   releases: ["list_releases", "create_release", "download_release_asset"],
   tags: ["list_tags", "create_tag", "get_tag_signature"],
@@ -112,8 +96,19 @@ const TOOLSET_SAMPLE_TOOLS: Record<string, string[]> = {
   search: ["search_code", "search_project_code", "search_group_code"],
   webhooks: ["list_webhooks", "create_webhook", "update_webhook", "delete_webhook", "list_webhook_events", "get_webhook_event"],
   groups: ["create_group"],
-  variables: ["list_project_variables", "create_project_variable", "delete_project_variable", "list_group_variables", "create_group_variable", "delete_group_variable"],
-  dependency_proxy: ["get_dependency_proxy_settings", "list_dependency_proxy_blobs", "purge_dependency_proxy_cache"],
+  variables: [
+    "list_project_variables",
+    "create_project_variable",
+    "delete_project_variable",
+    "list_group_variables",
+    "create_group_variable",
+    "delete_group_variable",
+  ],
+  dependency_proxy: [
+    "get_dependency_proxy_settings",
+    "list_dependency_proxy_blobs",
+    "purge_dependency_proxy_cache",
+  ],
 };
 
 // --- Helpers ---
@@ -212,6 +207,22 @@ describe("Toolset Filtering", { concurrency: 1 }, () => {
       assertContainsNone(tools, TOOLSET_SAMPLE_TOOLS.search, "non-default search");
       assertContainsNone(tools, TOOLSET_SAMPLE_TOOLS.pipelines, "non-default pipelines");
       assertContainsNone(tools, TOOLSET_SAMPLE_TOOLS.wiki, "non-default wiki");
+    });
+
+    test("excludes advanced and destructive tools from the lean default", () => {
+      assertContainsNone(
+        tools,
+        [
+          "merge_merge_request",
+          "create_draft_note",
+          "delete_issue",
+          "push_files",
+          "create_label",
+          "validate_ci_lint",
+          "create_group",
+        ],
+        "advanced defaults"
+      );
     });
 
     test("excludes execute_graphql (not in any toolset)", () => {
@@ -472,10 +483,12 @@ describe("Toolset Filtering", { concurrency: 1 }, () => {
     after(() => cleanupServers([server]));
 
     test("excludes tools matching the denial regex", () => {
-      const denied = tools.filter(
-        (t) => t.startsWith("create_") || t.startsWith("delete_")
+      const denied = tools.filter(t => t.startsWith("create_") || t.startsWith("delete_"));
+      assert.strictEqual(
+        denied.length,
+        0,
+        `Should have no create_/delete_ tools, found: ${denied}`
       );
-      assert.strictEqual(denied.length, 0, `Should have no create_/delete_ tools, found: ${denied}`);
     });
 
     test("keeps non-matching issue tools", () => {

--- a/tools/registry.ts
+++ b/tools/registry.ts
@@ -1479,6 +1479,7 @@ export const pipelineToolNames = new Set([
 // --- Toolset definitions ---
 
 export type ToolsetId =
+  | "core"
   | "merge_requests"
   | "issues"
   | "repositories"
@@ -1507,8 +1508,49 @@ export interface ToolsetDefinition {
 
 export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   {
-    id: "merge_requests",
+    id: "core",
     isDefault: true,
+    tools: new Set([
+      "list_merge_requests",
+      "get_merge_request",
+      "get_merge_request_approval_state",
+      "list_merge_request_changed_files",
+      "get_merge_request_file_diff",
+      "list_merge_request_diffs",
+      "get_merge_request_diffs",
+      "mr_discussions",
+      "create_merge_request",
+      "create_merge_request_thread",
+      "resolve_merge_request_thread",
+      "update_merge_request",
+      "list_issues",
+      "my_issues",
+      "get_issue",
+      "create_issue",
+      "update_issue",
+      "create_issue_note",
+      "list_issue_discussions",
+      "update_issue_description_patch",
+      "get_file_contents",
+      "get_repository_tree",
+      "search_repositories",
+      "get_branch",
+      "list_branches",
+      "list_commits",
+      "get_commit",
+      "get_commit_diff",
+      "get_file_blame",
+      "get_project",
+      "list_projects",
+      "list_project_members",
+      "list_labels",
+      "whoami",
+      "health_check",
+    ]),
+  },
+  {
+    id: "merge_requests",
+    isDefault: false,
     tools: new Set([
       "merge_merge_request",
       "approve_merge_request",
@@ -1557,7 +1599,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "issues",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "create_issue",
       "list_issues",
@@ -1587,7 +1629,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "repositories",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "search_repositories",
       "create_repository",
@@ -1600,7 +1642,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "branches",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "create_branch",
       "get_branch",
@@ -1621,7 +1663,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "projects",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "get_project",
       "list_projects",
@@ -1637,7 +1679,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "labels",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "list_labels",
       "get_label",
@@ -1648,7 +1690,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "ci",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "validate_ci_lint",
       "validate_project_ci_lint",
@@ -1658,7 +1700,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "groups",
-    isDefault: true,
+    isDefault: false,
     tools: new Set(["create_group"]),
   },
   {
@@ -1743,7 +1785,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "users",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "get_users",
       "get_user",
@@ -1820,15 +1862,17 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
 ] as const;
 
-// Derived lookup: tool name → toolset ID
+// Derived lookup: tool name → toolset IDs. Most tools belong to one category.
+// The default `core` toolset intentionally overlaps with the full opt-in
+// categories so users get a small starter surface without losing the ability
+// to enable complete categories later.
+export const TOOLSETS_BY_TOOL_NAME = new Map<string, Set<ToolsetId>>();
 export const TOOLSET_BY_TOOL_NAME = new Map<string, ToolsetId>();
 for (const def of TOOLSET_DEFINITIONS) {
   for (const tool of def.tools) {
-    if (TOOLSET_BY_TOOL_NAME.has(tool)) {
-      console.warn(
-        `Tool "${tool}" is defined in multiple toolsets: "${TOOLSET_BY_TOOL_NAME.get(tool)}" and "${def.id}"`
-      );
-    }
+    const toolsets = TOOLSETS_BY_TOOL_NAME.get(tool) ?? new Set<ToolsetId>();
+    toolsets.add(def.id);
+    TOOLSETS_BY_TOOL_NAME.set(tool, toolsets);
     TOOLSET_BY_TOOL_NAME.set(tool, def.id);
   }
 }
@@ -1905,8 +1949,11 @@ export function isToolInEnabledToolset(
   toolName: string,
   enabledToolsets: ReadonlySet<ToolsetId>
 ): boolean {
-  const toolsetId = TOOLSET_BY_TOOL_NAME.get(toolName);
+  const toolsetIds = TOOLSETS_BY_TOOL_NAME.get(toolName);
   // Tools not in any toolset (e.g. execute_graphql) are excluded by default
-  if (toolsetId === undefined) return false;
-  return enabledToolsets.has(toolsetId);
+  if (toolsetIds === undefined) return false;
+  for (const toolsetId of toolsetIds) {
+    if (enabledToolsets.has(toolsetId)) return true;
+  }
+  return false;
 }

--- a/tools/registry.ts
+++ b/tools/registry.ts
@@ -1828,6 +1828,7 @@ export const pipelineToolNames = new Set([
 // --- Toolset definitions ---
 
 export type ToolsetId =
+  | "core"
   | "merge_requests"
   | "issues"
   | "repositories"
@@ -1857,8 +1858,49 @@ export interface ToolsetDefinition {
 
 export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   {
-    id: "merge_requests",
+    id: "core",
     isDefault: true,
+    tools: new Set([
+      "list_merge_requests",
+      "get_merge_request",
+      "get_merge_request_approval_state",
+      "list_merge_request_changed_files",
+      "get_merge_request_file_diff",
+      "list_merge_request_diffs",
+      "get_merge_request_diffs",
+      "mr_discussions",
+      "create_merge_request",
+      "create_merge_request_thread",
+      "resolve_merge_request_thread",
+      "update_merge_request",
+      "list_issues",
+      "my_issues",
+      "get_issue",
+      "create_issue",
+      "update_issue",
+      "create_issue_note",
+      "list_issue_discussions",
+      "update_issue_description_patch",
+      "get_file_contents",
+      "get_repository_tree",
+      "search_repositories",
+      "get_branch",
+      "list_branches",
+      "list_commits",
+      "get_commit",
+      "get_commit_diff",
+      "get_file_blame",
+      "get_project",
+      "list_projects",
+      "list_project_members",
+      "list_labels",
+      "whoami",
+      "health_check",
+    ]),
+  },
+  {
+    id: "merge_requests",
+    isDefault: false,
     tools: new Set([
       "merge_merge_request",
       "approve_merge_request",
@@ -1908,7 +1950,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "issues",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "create_issue",
       "list_issues",
@@ -1938,7 +1980,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "repositories",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "search_repositories",
       "create_repository",
@@ -1951,7 +1993,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "branches",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "create_branch",
       "get_branch",
@@ -1972,7 +2014,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "projects",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "get_project",
       "list_projects",
@@ -1989,7 +2031,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "labels",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "list_labels",
       "get_label",
@@ -2000,7 +2042,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "ci",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "validate_ci_lint",
       "validate_project_ci_lint",
@@ -2010,7 +2052,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "groups",
-    isDefault: true,
+    isDefault: false,
     tools: new Set(["create_group"]),
   },
   {
@@ -2140,7 +2182,7 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
   {
     id: "users",
-    isDefault: true,
+    isDefault: false,
     tools: new Set([
       "get_users",
       "get_user",
@@ -2230,15 +2272,17 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
   },
 ] as const;
 
-// Derived lookup: tool name → toolset ID
+// Derived lookup: tool name → toolset IDs. Most tools belong to one category.
+// The default `core` toolset intentionally overlaps with the full opt-in
+// categories so users get a small starter surface without losing the ability
+// to enable complete categories later.
+export const TOOLSETS_BY_TOOL_NAME = new Map<string, Set<ToolsetId>>();
 export const TOOLSET_BY_TOOL_NAME = new Map<string, ToolsetId>();
 for (const def of TOOLSET_DEFINITIONS) {
   for (const tool of def.tools) {
-    if (TOOLSET_BY_TOOL_NAME.has(tool)) {
-      console.warn(
-        `Tool "${tool}" is defined in multiple toolsets: "${TOOLSET_BY_TOOL_NAME.get(tool)}" and "${def.id}"`
-      );
-    }
+    const toolsets = TOOLSETS_BY_TOOL_NAME.get(tool) ?? new Set<ToolsetId>();
+    toolsets.add(def.id);
+    TOOLSETS_BY_TOOL_NAME.set(tool, toolsets);
     TOOLSET_BY_TOOL_NAME.set(tool, def.id);
   }
 }
@@ -2324,8 +2368,11 @@ export function isToolInEnabledToolset(
   toolName: string,
   enabledToolsets: ReadonlySet<ToolsetId>
 ): boolean {
-  const toolsetId = TOOLSET_BY_TOOL_NAME.get(toolName);
+  const toolsetIds = TOOLSETS_BY_TOOL_NAME.get(toolName);
   // Tools not in any toolset (e.g. execute_graphql) are excluded by default
-  if (toolsetId === undefined) return false;
-  return enabledToolsets.has(toolsetId);
+  if (toolsetIds === undefined) return false;
+  for (const toolsetId of toolsetIds) {
+    if (enabledToolsets.has(toolsetId)) return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary
- add a lean `core` toolset as the only default toolset
- make the previous broad default toolsets opt-in via `GITLAB_TOOLSETS`/`discover_tools`
- update toolset docs and tests for overlapping toolsets

Default tools drop from 115 to 36, with approximate schema tokens down from 24.2k to 8.9k.

## Tests
- `npm run build`
- `node --import tsx/esm --test test/test-ci-lint.ts`
- `node --import tsx/esm --test test/test-todos.ts`
- `node --import tsx/esm --test test/test-toolset-filtering.ts`
- `npm run test:mock`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a **behavior-breaking default** for clients that assumed the old wide tool list without setting `GITLAB_TOOLSETS`; upgrades need the documented restore string or `GITLAB_TOOLSETS=all` to avoid missing tools.
> 
> **Overview**
> **Shrinks the default MCP tool surface** by introducing a **`core` toolset** (35 tools) as the only always-on group when `GITLAB_TOOLSETS` is unset, plus `discover_tools`. The former broad defaults (merge requests, issues, repositories, branches, projects, labels, CI, groups, users) are **opt-in** again.
> 
> Registry changes mark those categories `isDefault: false`, define overlapping tools in both `core` and the full toolsets, and use **`TOOLSETS_BY_TOOL_NAME`** so enabling a full category still exposes tools that also appear in `core`. Filtering tests now derive counts from `TOOLSET_DEFINITIONS` and assert advanced tools (merge, drafts, `push_files`, etc.) stay out of the lean default.
> 
> **Docs and operator UX** add `docs/tools/core.md`, CLI flags `--toolsets` / `--tools`, env-var guidance for `all` and a **pre-lean restore** toolset list, opt-in notes on group pages, and updated skill/MkDocs index. Tests for CI lint and todos require explicit `GITLAB_TOOLSETS=ci` / `issues`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b24f9289cbcefcfb0bfb6d0528c7614cca4980d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->