### PR TITLE
refactor: extract streamable request helpers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -152,6 +152,13 @@ import { createDownloadToken } from "./utils/download-token.js";
 import { determineTransportMode, TransportMode } from "./server/transport-mode.js";
 import { formatPrometheusMetrics } from "./server/metrics.js";
 import { SERVER_VERSION } from "./server/version.js";
+import {
+  isInitializationRequestBody,
+  isUnauthenticatedDiscoveryRequestBody,
+  readMcpSessionIdHeader,
+  redactSessionIdForLog,
+} from "./server/request-helpers.js";
+export { readMcpSessionIdHeader } from "./server/request-helpers.js";
 import { normalizeGitLabApiUrl } from "./utils/url.js";
 import {
   estimateMergeCommitCount,
@@ -1199,72 +1206,6 @@ function validateConfiguration(): void {
 
 let OAUTH_ACCESS_TOKEN: string | null = null;
 let oauthClient: GitLabOAuth | null = null;
-
-/**
- * Produce a safe short form of a session id for logs. Legacy UUIDs pass
- * through; stateless sealed sids are truncated to the "v1.sid." prefix
- * plus a handful of bytes of the ciphertext so operators can correlate
- * flows without the log line carrying the sealed bearer token.
- */
-function redactSessionIdForLog(sid: string | undefined): string {
-  if (!sid) return "<none>";
-  if (sid.startsWith("v1.sid.")) return "v1.sid.<redacted>";
-  // UUIDs / other formats are low-sensitivity; show first 8 chars.
-  return sid.length > 8 ? `${sid.slice(0, 8)}…` : sid;
-}
-
-/**
- * Detect whether an MCP JSON-RPC request body represents an "initialize"
- * request. Accepts both single-message and batch forms. Returns false on any
- * unexpected shape — callers treat an ambiguous body as non-init, which is
- * the safer default (it means the SDK will fail loudly rather than silently
- * spawning a new session).
- */
-function isInitializationRequestBody(body: unknown): boolean {
-  if (!body) return false;
-  const isInitObj = (m: unknown): boolean =>
-    typeof m === "object" && m !== null && (m as { method?: unknown }).method === "initialize";
-  if (Array.isArray(body)) return body.some(isInitObj);
-  return isInitObj(body);
-}
-
-function isUnauthenticatedDiscoveryRequestBody(body: unknown): boolean {
-  if (!body) return false;
-  const isDiscoveryMethod = (m: unknown): boolean => {
-    if (typeof m !== "object" || m === null) return false;
-    const method = (m as { method?: unknown }).method;
-    return (
-      method === "initialize" || method === "notifications/initialized" || method === "tools/list"
-    );
-  };
-  if (Array.isArray(body)) return body.every(isDiscoveryMethod);
-  return isDiscoveryMethod(body);
-}
-
-/**
- * Normalize an `Mcp-Session-Id` header value.
- *
- * Node's HTTP types allow any request header to surface as `string[]` when
- * the client sends it more than once. Casting to `string` and calling
- * `.startsWith()` on an array throws `TypeError: startsWith is not a
- * function`, which Express converts to a 500 — silently turning malformed
- * requests into server errors and breaking the 401/404 semantics we
- * carefully distinguish in stateless mode. A duplicated `Mcp-Session-Id` is
- * also ill-formed at the protocol level: there is no well-defined way to
- * pick between two values, so we reject arrays rather than guess.
- *
- * Empty-string is normalized to `undefined` so call sites can use truthy
- * checks and `?? undefined`-style fallbacks uniformly.
- *
- * Exported for unit tests; otherwise used only by the /mcp handlers below.
- */
-export function readMcpSessionIdHeader(req: {
-  headers: Record<string, string | string[] | undefined>;
-}): string | undefined {
-  const raw = req.headers["mcp-session-id"];
-  if (typeof raw !== "string") return undefined;
-  return raw.length > 0 ? raw : undefined;
-}
 
 /**
  * Loaded once at startup. Null when OAUTH_STATELESS_MODE is disabled.

--- a/server/request-helpers.ts
+++ b/server/request-helpers.ts
@@ -1,0 +1,63 @@
+/**
+ * Produce a safe short form of a session id for logs. Legacy UUIDs pass
+ * through; stateless sealed sids are truncated to the "v1.sid." prefix
+ * plus a handful of bytes of the ciphertext so operators can correlate
+ * flows without the log line carrying the sealed bearer token.
+ */
+export function redactSessionIdForLog(sid: string | undefined): string {
+  if (!sid) return "<none>";
+  if (sid.startsWith("v1.sid.")) return "v1.sid.<redacted>";
+  // UUIDs / other formats are low-sensitivity; show first 8 chars.
+  return sid.length > 8 ? `${sid.slice(0, 8)}…` : sid;
+}
+
+/**
+ * Detect whether an MCP JSON-RPC request body represents an "initialize"
+ * request. Accepts both single-message and batch forms. Returns false on any
+ * unexpected shape — callers treat an ambiguous body as non-init, which is
+ * the safer default (it means the SDK will fail loudly rather than silently
+ * spawning a new session).
+ */
+export function isInitializationRequestBody(body: unknown): boolean {
+  if (!body) return false;
+  const isInitObj = (m: unknown): boolean =>
+    typeof m === "object" && m !== null && (m as { method?: unknown }).method === "initialize";
+  if (Array.isArray(body)) return body.some(isInitObj);
+  return isInitObj(body);
+}
+
+export function isUnauthenticatedDiscoveryRequestBody(body: unknown): boolean {
+  if (!body) return false;
+  const isDiscoveryMethod = (m: unknown): boolean => {
+    if (typeof m !== "object" || m === null) return false;
+    const method = (m as { method?: unknown }).method;
+    return (
+      method === "initialize" || method === "notifications/initialized" || method === "tools/list"
+    );
+  };
+  if (Array.isArray(body)) return body.every(isDiscoveryMethod);
+  return isDiscoveryMethod(body);
+}
+
+/**
+ * Normalize an `Mcp-Session-Id` header value.
+ *
+ * Node's HTTP types allow any request header to surface as `string[]` when
+ * the client sends it more than once. Casting to `string` and calling
+ * `.startsWith()` on an array throws `TypeError: startsWith is not a
+ * function`, which Express converts to a 500 — silently turning malformed
+ * requests into server errors and breaking the 401/404 semantics we
+ * carefully distinguish in stateless mode. A duplicated `Mcp-Session-Id` is
+ * also ill-formed at the protocol level: there is no well-defined way to
+ * pick between two values, so we reject arrays rather than guess.
+ *
+ * Empty-string is normalized to `undefined` so call sites can use truthy
+ * checks and `?? undefined`-style fallbacks uniformly.
+ */
+export function readMcpSessionIdHeader(req: {
+  headers: Record<string, string | string[] | undefined>;
+}): string | undefined {
+  const raw = req.headers["mcp-session-id"];
+  if (typeof raw !== "string") return undefined;
+  return raw.length > 0 ? raw : undefined;
+}

--- a/test/server/request-helpers.test.ts
+++ b/test/server/request-helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import {
+  isInitializationRequestBody,
+  isUnauthenticatedDiscoveryRequestBody,
+  readMcpSessionIdHeader,
+  redactSessionIdForLog,
+} from "../../server/request-helpers.js";
+
+describe("streamable request helpers", () => {
+  test("redacts stateless session ids and truncates legacy ids", () => {
+    assert.strictEqual(redactSessionIdForLog(undefined), "<none>");
+    assert.strictEqual(redactSessionIdForLog("v1.sid.secret-payload"), "v1.sid.<redacted>");
+    assert.strictEqual(redactSessionIdForLog("123456789abcdef"), "12345678…");
+    assert.strictEqual(redactSessionIdForLog("short"), "short");
+  });
+
+  test("detects initialize requests in single and batch bodies", () => {
+    assert.strictEqual(isInitializationRequestBody({ method: "initialize" }), true);
+    assert.strictEqual(
+      isInitializationRequestBody([{ method: "tools/list" }, { method: "initialize" }]),
+      true
+    );
+    assert.strictEqual(isInitializationRequestBody({ method: "tools/list" }), false);
+    assert.strictEqual(isInitializationRequestBody(null), false);
+  });
+
+  test("allows only discovery methods in unauthenticated discovery bodies", () => {
+    assert.strictEqual(isUnauthenticatedDiscoveryRequestBody({ method: "tools/list" }), true);
+    assert.strictEqual(
+      isUnauthenticatedDiscoveryRequestBody([
+        { method: "initialize" },
+        { method: "notifications/initialized" },
+        { method: "tools/list" },
+      ]),
+      true
+    );
+    assert.strictEqual(
+      isUnauthenticatedDiscoveryRequestBody([{ method: "tools/list" }, { method: "call_tool" }]),
+      false
+    );
+    assert.strictEqual(isUnauthenticatedDiscoveryRequestBody(undefined), false);
+  });
+
+  test("normalizes Mcp-Session-Id headers", () => {
+    assert.strictEqual(readMcpSessionIdHeader({ headers: { "mcp-session-id": "sid-1" } }), "sid-1");
+    assert.strictEqual(readMcpSessionIdHeader({ headers: { "mcp-session-id": "" } }), undefined);
+    assert.strictEqual(
+      readMcpSessionIdHeader({ headers: { "mcp-session-id": ["sid-1", "sid-2"] } }),
+      undefined
+    );
+    assert.strictEqual(readMcpSessionIdHeader({ headers: {} }), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Part of #516.

This is a small behavior-preserving extraction:

- moves Streamable HTTP request-shape helpers into `server/request-helpers.ts`
- keeps auth/session state and route handling in `index.ts`
- re-exports `readMcpSessionIdHeader` from `index.ts` for compatibility
- adds direct unit coverage for redaction, initialize detection, unauthenticated discovery detection, and session-id header normalization

## Verification

- `rtk npm run build`
- `node --import tsx/esm --test test/server/request-helpers.test.ts`
- `node --import tsx/esm --test test/streamable-http-unauthenticated-discovery.test.ts`
- `rtk npm run test:stateless`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with new unit tests; no changes to auth routing or session handling logic beyond moving shared helpers.
> 
> **Overview**
> Moves Streamable HTTP request-shape utilities out of `index.ts` into **`server/request-helpers.ts`**: session-id log redaction, `initialize` / unauthenticated discovery body detection, and **`Mcp-Session-Id`** header normalization (rejecting duplicate/array headers and empty strings).
> 
> `index.ts` now imports those helpers and **re-exports `readMcpSessionIdHeader`** so existing consumers keep the same entry point. **`test/server/request-helpers.test.ts`** adds direct coverage, and **`test:mock`** runs it in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a292ff296214f203c0f3a8b3d228516889031f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->