### PR TITLE
[codex] Log degraded streamable health checks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13188,10 +13188,17 @@ async function startStreamableHTTPServer(): Promise<void> {
 
   // Health check endpoint
   app.get("/health", (_req: Request, res: Response) => {
-    const isHealthy = Object.keys(streamableTransports).length < MAX_SESSIONS;
+    const activeSessions = Object.keys(streamableTransports).length;
+    const isHealthy = activeSessions < MAX_SESSIONS;
+    if (!isHealthy) {
+      logger.warn(
+        { activeSessions, maxSessions: MAX_SESSIONS },
+        "Health check degraded: active session capacity reached"
+      );
+    }
     res.status(isHealthy ? 200 : 503).json({
       status: isHealthy ? "healthy" : "degraded",
-      activeSessions: Object.keys(streamableTransports).length,
+      activeSessions,
       maxSessions: MAX_SESSIONS,
       uptime: process.uptime(),
     });

--- a/test/streamable-http-concurrent-session.test.ts
+++ b/test/streamable-http-concurrent-session.test.ts
@@ -123,3 +123,75 @@ describe("Streamable HTTP concurrent session requests", { timeout: 20_000 }, () 
     }
   });
 });
+
+describe("Streamable HTTP health check capacity logging", { timeout: 20_000 }, () => {
+  let mockGitLab: MockGitLabServer;
+  let server: ServerInstance;
+  let mcpUrl: string;
+  let baseUrl: string;
+  let output = "";
+
+  before(async () => {
+    const mockPort = await findMockServerPort(9370);
+    mockGitLab = new MockGitLabServer({
+      port: mockPort,
+      validTokens: [MOCK_TOKEN],
+    });
+    await mockGitLab.start();
+
+    const port = await findAvailablePort(3470);
+    server = await launchServer({
+      mode: TransportMode.STREAMABLE_HTTP,
+      port,
+      timeout: 10_000,
+      env: {
+        STREAMABLE_HTTP: "true",
+        REMOTE_AUTHORIZATION: "true",
+        GITLAB_API_URL: `${mockGitLab.getUrl()}/api/v4`,
+        MAX_SESSIONS: "1",
+      },
+    });
+
+    server.process.stdout?.on("data", data => {
+      output += data.toString();
+    });
+    server.process.stderr?.on("data", data => {
+      output += data.toString();
+    });
+
+    baseUrl = `http://${HOST}:${port}`;
+    mcpUrl = `${baseUrl}/mcp`;
+  });
+
+  after(async () => {
+    cleanupServers([server]);
+    if (mockGitLab) await mockGitLab.stop();
+  });
+
+  test("logs active session capacity when health check is degraded", async () => {
+    const client = new CustomHeaderClient({ Authorization: `Bearer ${MOCK_TOKEN}` });
+    await client.connect(mcpUrl);
+
+    try {
+      const response = await fetch(`${baseUrl}/health`);
+      const body = (await response.json()) as {
+        status: string;
+        activeSessions: number;
+        maxSessions: number;
+      };
+
+      assert.strictEqual(response.status, 503);
+      assert.strictEqual(body.status, "degraded");
+      assert.strictEqual(body.activeSessions, 1);
+      assert.strictEqual(body.maxSessions, 1);
+
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      assert.match(output, /Health check degraded/);
+      assert.match(output, /activeSessions.*1/);
+      assert.match(output, /maxSessions.*1/);
+    } finally {
+      await client.disconnect();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Log a warning when the Streamable HTTP `/health` endpoint returns degraded due to active sessions reaching `MAX_SESSIONS`.
- Include `activeSessions` and `maxSessions` in the warning so operators can diagnose liveness restarts from previous container logs.
- Add a regression test that fills session capacity, verifies `/health` returns 503, and asserts the degraded health log is emitted.

## Why
When Kubernetes liveness probes hit `/health` after capacity is exhausted, the container may be restarted and only `kubectl logs --previous` remains available. The previous logs did not clearly explain why `/health` returned 503.

## Validation
- `npm run build && node --import tsx/esm --test test/streamable-http-concurrent-session.test.ts`
- `git diff --check`
- `npx prettier --check test/streamable-http-concurrent-session.test.ts`

## Notes
- `npm run lint` currently fails before linting because ESLint 9 expects `eslint.config.js`, while this repository still has `.eslintrc.json`.
- `npm run format:check -- index.ts test/streamable-http-concurrent-session.test.ts` runs the repository-wide script glob first and reports existing formatting warnings across many files, so I avoided broad formatting churn.