### PR TITLE
fix(ci): avoid top-level oneOf in get_ci_catalog_resource input_schema (Fixes #550)

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -381,16 +381,17 @@ const GetCiCatalogResourceOptionsSchema = z.object({
   include_readme: z.coerce.boolean().optional().describe("Include version README content"),
 });
 
-export const GetCiCatalogResourceSchema = z.union([
-  GetCiCatalogResourceOptionsSchema.extend({
-    id: z.string().min(1).describe("CI/CD Catalog resource global ID. Required when full_path is omitted."),
-    full_path: z.string().min(1).optional().describe("CI/CD Catalog resource full project path. Required when id is omitted."),
-  }),
-  GetCiCatalogResourceOptionsSchema.extend({
-    id: z.string().min(1).optional().describe("CI/CD Catalog resource global ID. Required when full_path is omitted."),
-    full_path: z.string().min(1).describe("CI/CD Catalog resource full project path. Required when id is omitted."),
-  }),
-]).refine(args => Boolean(args.id) !== Boolean(args.full_path), {
+// NOTE: Keep this as a single z.object(...).refine(...) rather than a
+// z.union([...]). A top-level union serializes to JSON Schema with `oneOf`
+// at the root of input_schema, which the Anthropic Messages API (Claude
+// Code, Kiro, etc.) rejects with:
+//   "input_schema does not support oneOf, allOf, or anyOf at the top level"
+// The id/full_path "exactly one of" constraint is enforced at runtime via
+// .refine() instead. See issue #550.
+export const GetCiCatalogResourceSchema = GetCiCatalogResourceOptionsSchema.extend({
+  id: z.string().min(1).optional().describe("CI/CD Catalog resource global ID. Required when full_path is omitted."),
+  full_path: z.string().min(1).optional().describe("CI/CD Catalog resource full project path. Required when id is omitted."),
+}).refine(args => Boolean(args.id) !== Boolean(args.full_path), {
   message: "Provide exactly one of id or full_path",
 });
 


### PR DESCRIPTION
## Problem

`get_ci_catalog_resource`'s `input_schema` has `oneOf` at the top level, which the **Anthropic Messages API** (Claude Code, Kiro, and other MCP clients) rejects:

```
tools.<N>.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

This is reported in #550. Because every enabled tool is serialized on every request, this single tool breaks the **entire** MCP server for affected clients once it appears in the tool list — the reported tool index (`tools.78`, `tools.62`, …) just moves around as users toggle other tools. Current workaround is pinning to `2.1.25` (before #537 added the CI catalog tools).

## Root cause

`GetCiCatalogResourceSchema` is a `z.union([...])`:

```ts
export const GetCiCatalogResourceSchema = z.union([
  GetCiCatalogResourceOptionsSchema.extend({ id: z.string().min(1), full_path: z.string().min(1).optional() }),
  GetCiCatalogResourceOptionsSchema.extend({ id: z.string().min(1).optional(), full_path: z.string().min(1) }),
]).refine(...);
```

`zod-to-json-schema` serializes a top-level union into `{ "oneOf": [...] }` at the root of `input_schema` — exactly what Anthropic forbids.

## Fix

Flatten the union into a single `z.object(...).refine(...)`. `id` and `full_path` are both optional at the schema level; the "exactly one of" constraint is still enforced at runtime via `.refine()`:

```ts
export const GetCiCatalogResourceSchema = GetCiCatalogResourceOptionsSchema.extend({
  id: z.string().min(1).optional()...,
  full_path: z.string().min(1).optional()...,
}).refine(args => Boolean(args.id) !== Boolean(args.full_path), {
  message: "Provide exactly one of id or full_path",
});
```

Generated `input_schema` now has `type: "object"` at the root with **no** `oneOf`, while runtime validation is unchanged.

## Verification

- `tsc` compiles clean.
- Serialized JSON Schema top-level keys: `['type', 'properties', 'additionalProperties']`, `type: "object"`, `oneOf/anyOf/allOf` all `undefined`.
- Runtime `.refine()` behavior unchanged:
  - `{ id }` → valid ✅
  - `{ full_path }` → valid ✅
  - `{}` (neither) → rejected ✅
  - `{ id, full_path }` (both) → rejected ✅

Fixes #550