### PR TITLE
Fix code scanning alerts 37 and 44

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name || inputs.ref || github.sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,9 +1,8 @@
 name: MCP Registry Publish
 
 on:
-  workflow_run:
-    workflows: ["NPM Publish"]
-    types: [completed]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       ref:
@@ -20,14 +19,13 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout release commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.ref || github.sha }}
+          ref: ${{ github.event.release.tag_name || inputs.ref || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -77,12 +75,12 @@ jobs:
           PACKAGE_NAME="$(node -p 'require("./package.json").name')"
           PACKAGE_VERSION="$(node -p 'require("./package.json").version')"
 
-          for attempt in {1..12}; do
+          for attempt in {1..30}; do
             if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version; then
               exit 0
             fi
 
-            echo "Package ${PACKAGE_NAME}@${PACKAGE_VERSION} is not visible on npm yet. Retry ${attempt}/12..."
+            echo "Package ${PACKAGE_NAME}@${PACKAGE_VERSION} is not visible on npm yet. Retry ${attempt}/30..."
             sleep 10
           done
 

--- a/oauth-proxy.ts
+++ b/oauth-proxy.ts
@@ -110,6 +110,14 @@ const PENDING_AUTH_MAX_SIZE = 1000;
 const PENDING_AUTH_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const CLIENT_CACHE_MAX_SIZE = 1000;
 
+function singleQueryParam(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function invalidQueryParam(value: unknown): boolean {
+  return value != null && typeof value !== "string";
+}
+
 /**
  * Stateless-mode configuration for the OAuth provider.
  *
@@ -693,12 +701,23 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
       return;
     }
 
-    const code = req.query.code as string | undefined;
-    const state = req.query.state as string | undefined;
-    const error = req.query.error as string | undefined;
+    if (
+      invalidQueryParam(req.query.code) ||
+      invalidQueryParam(req.query.state) ||
+      invalidQueryParam(req.query.error) ||
+      invalidQueryParam(req.query.error_description)
+    ) {
+      res.status(400).send("Invalid query parameter");
+      return;
+    }
+
+    const code = singleQueryParam(req.query.code);
+    const state = singleQueryParam(req.query.state);
+    const error = singleQueryParam(req.query.error);
+    const errorDescription = singleQueryParam(req.query.error_description) ?? "(no description)";
 
     if (error) {
-      logger.error(`GitLab OAuth error: ${error} — ${req.query.error_description ?? "(no description)"}`);
+      logger.error(`GitLab OAuth error: ${error} — ${errorDescription}`);
       res.status(400).send("Authorization failed");
       return;
     }

--- a/test/stateless/callback-proxy.test.ts
+++ b/test/stateless/callback-proxy.test.ts
@@ -157,7 +157,7 @@ function makeFakeRes(): FakeRes {
   return res;
 }
 
-function fakeReq(query: Record<string, string>): ExpressRequest {
+function fakeReq(query: Record<string, unknown>): ExpressRequest {
   return { query } as unknown as ExpressRequest;
 }
 
@@ -365,6 +365,20 @@ describe("callback-proxy cross-pod flow (stateless)", () => {
       CLIENT_REDIRECT
     );
     assert.equal(tokens.access_token, "gl-access-123");
+  });
+
+  test("callback rejects repeated query parameters", async () => {
+    const pod = makeProvider(loadMaterial(secret()));
+    const cbRes = makeFakeRes();
+
+    await pod.handleCallback(
+      fakeReq({ code: "gitlab-code", state: ["one", "two"] }) as unknown as ExpressRequest,
+      cbRes as unknown as ExpressResponse
+    );
+
+    assert.equal(cbRes.statusCode, 400);
+    assert.equal(cbRes.body, "Invalid query parameter");
+    assert.equal(stub.calls.length, 0);
   });
 
   test("exchangeAuthorizationCode rejects wrong PKCE verifier", async () => {


### PR DESCRIPTION
## Summary
- reject non-string OAuth callback query parameters before stateless token parsing
- add regression coverage for repeated callback query params
- replace privileged `workflow_run` registry publish trigger with `release.published`/manual dispatch checkout

## Validation
- `npm run test:stateless`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint oauth-proxy.ts test/stateless/callback-proxy.test.ts` (0 errors; existing warnings only)
- `git diff --check`

## Notes
- addresses code scanning alerts #37 and #44
- `actionlint` is not installed locally, so workflow syntax should also be covered by CI/GitHub checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth callback handling (auth path) and changes when/how the registry publish workflow runs relative to npm releases.
> 
> **Overview**
> Hardens the **callback-proxy OAuth handler** so `code`, `state`, `error`, and `error_description` must be single string query values—repeated or non-string params return **400** before stateless parsing—addressing code scanning around unsafe query handling.
> 
> **MCP Registry Publish** no longer runs after the **NPM Publish** `workflow_run`; it triggers on **`release.published`** (or manual dispatch), checks out the **release tag** with **`persist-credentials: false`**, and waits up to **30** attempts for the npm package to appear (was 12).
> 
> Adds a **stateless callback test** for repeated `state` query values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7bf7c903bb8d52d3c40f31a97d1f25e6fa853c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->