### PR TITLE
fix: remove top-level anyOf/oneOf/allOf from tool input schemas for Anthropic API compatibility

### DIFF
--- a/utils/schema.ts
+++ b/utils/schema.ts
@@ -124,6 +124,20 @@ export const toJSONSchema = (schema: z.ZodTypeAny) => {
             }
           }
         }
+        // Collect required fields shared across ALL variants (intersection)
+        const requiredSets = variants.map(
+          (v: any) => new Set<string>(Array.isArray(v.required) ? v.required : [])
+        );
+        const sharedRequired = [...requiredSets[0]].filter(
+          field => requiredSets.every((s: Set<string>) => s.has(field))
+        );
+        if (sharedRequired.length > 0) {
+          const existing = new Set<string>(Array.isArray(fixedSchema.required) ? fixedSchema.required : []);
+          for (const field of sharedRequired) {
+            existing.add(field);
+          }
+          fixedSchema.required = [...existing];
+        }
         delete fixedSchema[combiner];
       }
     }

--- a/utils/schema.ts
+++ b/utils/schema.ts
@@ -107,18 +107,25 @@ export const toJSONSchema = (schema: z.ZodTypeAny) => {
 
   const fixedSchema = fixNullableOptional(jsonSchema, true);
 
-  if (!fixedSchema.properties && Array.isArray(fixedSchema.anyOf)) {
-    const variants = fixedSchema.anyOf.filter(
-      (item: any) => item?.type === "object" && item.properties
-    );
-    if (variants.length === fixedSchema.anyOf.length) {
-      fixedSchema.type = "object";
-      fixedSchema.properties = variants.reduce((properties: any, item: any) => {
-        Object.entries(item.properties).forEach(([key, value]) => {
-          if (!properties[key]) properties[key] = value;
-        });
-        return properties;
-      }, {});
+  // Flatten top-level anyOf/oneOf into a single object schema for Anthropic API compatibility.
+  // The Anthropic API rejects tool input_schema with top-level oneOf/allOf/anyOf.
+  for (const combiner of ["anyOf", "oneOf", "allOf"] as const) {
+    if (Array.isArray(fixedSchema[combiner])) {
+      const variants = fixedSchema[combiner].filter(
+        (item: any) => item?.type === "object" && item.properties
+      );
+      if (variants.length > 0 && variants.length === fixedSchema[combiner].length) {
+        fixedSchema.type = "object";
+        fixedSchema.properties = fixedSchema.properties || {};
+        for (const variant of variants) {
+          for (const [key, value] of Object.entries(variant.properties)) {
+            if (!fixedSchema.properties[key]) {
+              fixedSchema.properties[key] = value;
+            }
+          }
+        }
+        delete fixedSchema[combiner];
+      }
     }
   }
 

--- a/utils/schema.ts
+++ b/utils/schema.ts
@@ -124,16 +124,29 @@ export const toJSONSchema = (schema: z.ZodTypeAny) => {
             }
           }
         }
-        // Collect required fields shared across ALL variants (intersection)
+        // Compute required fields based on combiner semantics:
+        // - allOf: union (all schemas apply, so all requirements apply)
+        // - anyOf/oneOf: intersection (only shared requirements are universal)
         const requiredSets = variants.map(
           (v: any) => new Set<string>(Array.isArray(v.required) ? v.required : [])
         );
-        const sharedRequired = [...requiredSets[0]].filter(
-          field => requiredSets.every((s: Set<string>) => s.has(field))
-        );
-        if (sharedRequired.length > 0) {
+        let mergedRequired: string[];
+        if (combiner === "allOf") {
+          // Union: any field required in any variant is required
+          const all = new Set<string>();
+          for (const s of requiredSets) {
+            for (const field of s) all.add(field);
+          }
+          mergedRequired = [...all];
+        } else {
+          // Intersection: only fields required in ALL variants
+          mergedRequired = [...requiredSets[0]].filter(
+            field => requiredSets.every((s: Set<string>) => s.has(field))
+          );
+        }
+        if (mergedRequired.length > 0) {
           const existing = new Set<string>(Array.isArray(fixedSchema.required) ? fixedSchema.required : []);
-          for (const field of sharedRequired) {
+          for (const field of mergedRequired) {
             existing.add(field);
           }
           fixedSchema.required = [...existing];


### PR DESCRIPTION
## Summary

Fixes the `toJSONSchema()` utility to properly flatten and remove top-level `anyOf`/`oneOf`/`allOf` from tool input schemas. The Anthropic API rejects tool definitions that use these JSON Schema constructs at the top level of `input_schema`, breaking all Anthropic-based MCP clients (Kiro IDE, Claude Code, Claude Desktop, etc.) starting from v2.1.25.

## Problem

The existing flattening logic in `utils/schema.ts` merged anyOf variant properties into a single object but never deleted the `anyOf` key itself, leaving it in the final output. This caused the Anthropic API to reject the tool list with:

```
tools.209.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

Affected tool: `get_ci_catalog_resource` (uses `z.union()` for mutually exclusive `id`/`full_path` parameters).

## Fix

Replaced the incomplete flattening block with a generic handler that loops over all three combiners (`anyOf`, `oneOf`, `allOf`), merges variant properties into a flat object schema, and deletes the combiner key. This runs in the shared `toJSONSchema()` utility so any future union schemas are handled automatically.

## Validation

- All existing tests pass (including CI catalog tool tests)
- TypeScript compiles cleanly
- Verified all 200+ tool schemas produce clean `type: "object"` output with no top-level combiners

Fixes #552
Fixes #550
[test-output.md](https://github.com/user-attachments/files/29304032/test-output.md)
