### PR TITLE
fix: support group work item listing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3080,6 +3080,16 @@ async function updateIncidentEscalationStatus(
  * Resolve a project ID (numeric or path) to its full path_with_namespace.
  */
 async function resolveProjectPath(projectId: string): Promise<string> {
+  const { path } = await resolveProjectOrGroupPath(projectId);
+  return path;
+}
+
+/**
+ * Resolve a project or group path and identify which GraphQL root field to use.
+ */
+async function resolveProjectOrGroupPath(
+  projectId: string
+): Promise<{ path: string; kind: "project" | "group" }> {
   projectId = decodeURIComponent(projectId);
   const effectiveProjectId = getEffectiveProjectId(projectId);
   const projectUrl = new URL(
@@ -3102,7 +3112,7 @@ async function resolveProjectPath(projectId: string): Promise<string> {
     });
     if (groupResponse.ok) {
       const group: any = await groupResponse.json();
-      return group.full_path as string;
+      return { path: group.full_path as string, kind: "group" };
     }
     // Surface the group error
     await handleGitLabError(groupResponse);
@@ -3110,7 +3120,7 @@ async function resolveProjectPath(projectId: string): Promise<string> {
 
   await handleGitLabError(projectResponse);
   const project: any = await projectResponse.json();
-  return project.path_with_namespace;
+  return { path: project.path_with_namespace, kind: "project" };
 }
 
 /**
@@ -3361,7 +3371,8 @@ async function listWorkItems(
     after?: string;
   }
 ): Promise<any> {
-  const projectPath = await resolveProjectPath(projectId);
+  const namespace = await resolveProjectOrGroupPath(projectId);
+  const rootField = namespace.kind === "group" ? "group" : "project";
 
   // Map type names to GraphQL enum values
   const typeMap: Record<string, string> = {
@@ -3377,7 +3388,7 @@ async function listWorkItems(
   };
 
   const variables: Record<string, any> = {
-    path: projectPath,
+    path: namespace.path,
     first: options.first || 20,
   };
 
@@ -3400,9 +3411,9 @@ async function listWorkItems(
     variables.after = options.after;
   }
 
-  const data = await executeGraphQL<{ project: any }>(
+  const data = await executeGraphQL<{ project?: any; group?: any }>(
     `query($path: ID!, $types: [IssueType!], $state: IssuableState, $search: String, $assigneeUsernames: [String!], $labelName: [String!], $first: Int, $after: String) {
-      project(fullPath: $path) {
+      ${rootField}(fullPath: $path) {
         workItems(types: $types, state: $state, search: $search, assigneeUsernames: $assigneeUsernames, labelName: $labelName, first: $first, after: $after) {
           nodes {
             id iid title state webUrl workItemType { name }
@@ -3424,8 +3435,9 @@ async function listWorkItems(
     variables
   );
 
-  const workItems = data.project?.workItems?.nodes || [];
-  const pageInfo = data.project?.workItems?.pageInfo || {};
+  const workItemsRoot = namespace.kind === "group" ? data.group : data.project;
+  const workItems = workItemsRoot?.workItems?.nodes || [];
+  const pageInfo = workItemsRoot?.workItems?.pageInfo || {};
 
   // Flatten widget data for each item
   const items = workItems.map((wi: any) => {

--- a/index.ts
+++ b/index.ts
@@ -3077,7 +3077,8 @@ async function updateIncidentEscalationStatus(
 }
 
 /**
- * Resolve a project ID (numeric or path) to its full path_with_namespace.
+ * Resolve a project ID/path or group path to its full namespace path.
+ * Numeric group IDs are not supported here because they are ambiguous with project IDs.
  */
 async function resolveProjectPath(projectId: string): Promise<string> {
   const { path } = await resolveProjectOrGroupPath(projectId);
@@ -3086,6 +3087,7 @@ async function resolveProjectPath(projectId: string): Promise<string> {
 
 /**
  * Resolve a project or group path and identify which GraphQL root field to use.
+ * Numeric group IDs are intentionally not resolved to avoid ambiguity with project IDs.
  */
 async function resolveProjectOrGroupPath(
   projectId: string
@@ -3357,7 +3359,7 @@ async function getWorkItem(projectId: string, iid: number): Promise<any> {
 }
 
 /**
- * List work items in a project with filters.
+ * List work items in a project or group namespace with filters.
  */
 async function listWorkItems(
   projectId: string,

--- a/index.ts
+++ b/index.ts
@@ -2288,7 +2288,7 @@ async function executeGraphQL<T = any>(
 }
 
 /**
- * Resolve a project path and issue IID to a work item GraphQL GID.
+ * Resolve a namespace path and issue IID to a work item GraphQL GID.
  */
 async function resolveWorkItemGID(
   projectId: string,
@@ -2315,7 +2315,7 @@ async function resolveWorkItemGID(
   );
 
   if (!data.namespace?.workItem?.id) {
-    throw new Error(`Work item #${issueIid} not found in project ${projectPath}`);
+    throw new Error(`Work item #${issueIid} not found in namespace ${projectPath}`);
   }
 
   return { workItemGID: data.namespace.workItem.id, projectPath, namespaceKind };

--- a/index.ts
+++ b/index.ts
@@ -2342,24 +2342,24 @@ async function resolveNamesToIds(
     `l${i}: labels(title: $l${i}, includeAncestorGroups: true, first: 1) { nodes { id } }`
   ).join(" ");
 
-  const { project, users } = await executeGraphQL<{
-    project: { [alias: string]: { nodes: Array<{ id: string }> } } | null;
+  const { namespace, users } = await executeGraphQL<{
+    namespace: { [alias: string]: { nodes: Array<{ id: string }> } } | null;
     users: { nodes: Array<{ id: string; username: string }> };
   }>(
     `query($path: ID!, $usernames: [String!]!${varDefs ? `, ${varDefs}` : ""}) {
-      project(fullPath: $path) { ${aliases || "__typename"} }
+      namespace(fullPath: $path) { ${aliases || "__typename"} }
       users(usernames: $usernames) { nodes { id username } }
     }`,
     { path: projectPath, usernames, ...labelVars }
   );
 
-  if (!project) {
-    throw new Error(`Project '${projectPath}' not found or inaccessible`);
+  if (!namespace) {
+    throw new Error(`Namespace '${projectPath}' not found or inaccessible`);
   }
 
   const labelIds = labelNames.map((name, i) => {
-    const nodes = project[`l${i}`]?.nodes;
-    if (!nodes?.length) throw new Error(`Label '${name}' not found in project`);
+    const nodes = namespace[`l${i}`]?.nodes;
+    if (!nodes?.length) throw new Error(`Label '${name}' not found in namespace`);
     return nodes[0].id;
   });
   const userIds = usernames.map(name => {
@@ -3132,6 +3132,7 @@ async function resolveProjectOrGroupPath(
   if (
     projectResponse.status === 404 &&
     !explicitKind &&
+    GITLAB_ALLOWED_PROJECT_IDS.length === 0 &&
     !/^\d+$/.test(effectiveProjectId)
   ) {
     const groupUrl = new URL(

--- a/index.ts
+++ b/index.ts
@@ -2293,10 +2293,12 @@ async function executeGraphQL<T = any>(
 async function resolveWorkItemGID(
   projectId: string,
   issueIid: number
-): Promise<{ workItemGID: string; projectPath: string }> {
-  // resolveProjectPath handles project paths plus group namespace fallbacks,
-  // so work item tools work for group-level namespaces too.
-  const projectPath = await resolveProjectPath(projectId);
+): Promise<{
+  workItemGID: string;
+  projectPath: string;
+  namespaceKind: "project" | "group";
+}> {
+  const { path: projectPath, kind: namespaceKind } = await resolveProjectOrGroupPath(projectId);
 
   // Resolve work item GID via GraphQL
   const data = await executeGraphQL<{
@@ -2316,7 +2318,7 @@ async function resolveWorkItemGID(
     throw new Error(`Work item #${issueIid} not found in project ${projectPath}`);
   }
 
-  return { workItemGID: data.namespace.workItem.id, projectPath };
+  return { workItemGID: data.namespace.workItem.id, projectPath, namespaceKind };
 }
 
 /**
@@ -2324,6 +2326,7 @@ async function resolveWorkItemGID(
  */
 async function resolveNamesToIds(
   projectPath: string,
+  namespaceKind: "project" | "group",
   labelNames?: string[],
   usernames?: string[]
 ): Promise<{ labelIds: string[]; userIds: string[] }> {
@@ -2341,29 +2344,32 @@ async function resolveNamesToIds(
   const aliases = labelNames.map((_, i) =>
     `l${i}: labels(title: $l${i}, includeAncestorGroups: true, first: 1) { nodes { id } }`
   ).join(" ");
+  const rootField = namespaceKind === "group" ? "group" : "project";
 
-  const { namespace, users } = await executeGraphQL<{
-    namespace: { [alias: string]: { nodes: Array<{ id: string }> } } | null;
+  const data = await executeGraphQL<{
+    project?: { [alias: string]: { nodes: Array<{ id: string }> } } | null;
+    group?: { [alias: string]: { nodes: Array<{ id: string }> } } | null;
     users: { nodes: Array<{ id: string; username: string }> };
   }>(
     `query($path: ID!, $usernames: [String!]!${varDefs ? `, ${varDefs}` : ""}) {
-      namespace(fullPath: $path) { ${aliases || "__typename"} }
+      ${rootField}(fullPath: $path) { ${aliases || "__typename"} }
       users(usernames: $usernames) { nodes { id username } }
     }`,
     { path: projectPath, usernames, ...labelVars }
   );
+  const labelNamespace = namespaceKind === "group" ? data.group : data.project;
 
-  if (!namespace) {
+  if (!labelNamespace) {
     throw new Error(`Namespace '${projectPath}' not found or inaccessible`);
   }
 
   const labelIds = labelNames.map((name, i) => {
-    const nodes = namespace[`l${i}`]?.nodes;
+    const nodes = labelNamespace[`l${i}`]?.nodes;
     if (!nodes?.length) throw new Error(`Label '${name}' not found in namespace`);
     return nodes[0].id;
   });
   const userIds = usernames.map(name => {
-    const user = users.nodes.find(u => u.username === name);
+    const user = data.users.nodes.find(u => u.username === name);
     if (!user) throw new Error(`User '${name}' not found`);
     return user.id;
   });
@@ -3526,7 +3532,7 @@ async function createWorkItem(
     confidential?: boolean;
   }
 ): Promise<any> {
-  const projectPath = await resolveProjectPath(projectId);
+  const { path: projectPath, kind: namespaceKind } = await resolveProjectOrGroupPath(projectId);
   const typeName = options.type || "issue";
   const typeGID = await resolveWorkItemTypeGID(projectPath, typeName);
 
@@ -3556,6 +3562,7 @@ async function createWorkItem(
   // Resolve label names and usernames to GIDs in a single GraphQL call
   const { labelIds, userIds } = await resolveNamesToIds(
     projectPath,
+    namespaceKind,
     options.labels,
     options.assignee_usernames
   );
@@ -3708,7 +3715,7 @@ async function updateWorkItem(
     escalation_status?: string;
   }
 ): Promise<any> {
-  const { workItemGID, projectPath } = await resolveWorkItemGID(projectId, iid);
+  const { workItemGID, projectPath, namespaceKind } = await resolveWorkItemGID(projectId, iid);
 
   // Build the main workItemUpdate mutation dynamically
   const inputParts: string[] = ["id: $id"];
@@ -3733,6 +3740,7 @@ async function updateWorkItem(
   const { labelIds: resolvedLabelIds, userIds } = needsResolve
     ? await resolveNamesToIds(
         projectPath,
+        namespaceKind,
         allLabelNames.length > 0 ? allLabelNames : undefined,
         options.assignee_usernames
       )

--- a/index.ts
+++ b/index.ts
@@ -2294,8 +2294,8 @@ async function resolveWorkItemGID(
   projectId: string,
   issueIid: number
 ): Promise<{ workItemGID: string; projectPath: string }> {
-  // resolveProjectPath handles both project and group paths (including the
-  // group fallback), so work item tools work for group-level namespaces too.
+  // resolveProjectPath handles project paths plus group namespace fallbacks,
+  // so work item tools work for group-level namespaces too.
   const projectPath = await resolveProjectPath(projectId);
 
   // Resolve work item GID via GraphQL
@@ -3077,8 +3077,8 @@ async function updateIncidentEscalationStatus(
 }
 
 /**
- * Resolve a project ID/path or group path to its full namespace path.
- * Numeric group IDs are not supported here because they are ambiguous with project IDs.
+ * Resolve a project ID/path or group ID/path to its full namespace path.
+ * Use group:<id-or-path> or project:<id-or-path> to disambiguate numeric IDs.
  */
 async function resolveProjectPath(projectId: string): Promise<string> {
   const { path } = await resolveProjectOrGroupPath(projectId);
@@ -3087,13 +3087,30 @@ async function resolveProjectPath(projectId: string): Promise<string> {
 
 /**
  * Resolve a project or group path and identify which GraphQL root field to use.
- * Numeric group IDs are intentionally not resolved to avoid ambiguity with project IDs.
+ * Bare numeric IDs resolve as projects for backwards compatibility; use group:<id>
+ * when the numeric value is a GitLab group ID.
  */
 async function resolveProjectOrGroupPath(
   projectId: string
 ): Promise<{ path: string; kind: "project" | "group" }> {
-  projectId = decodeURIComponent(projectId);
-  const effectiveProjectId = getEffectiveProjectId(projectId);
+  const decodedProjectId = decodeURIComponent(projectId);
+  const namespaceMatch = decodedProjectId.match(/^(group|project):(.+)$/i);
+  const explicitKind = namespaceMatch?.[1]?.toLowerCase() as "group" | "project" | undefined;
+  const requestedProjectId = namespaceMatch ? namespaceMatch[2] : decodedProjectId;
+  const effectiveProjectId = getEffectiveProjectId(requestedProjectId);
+
+  if (explicitKind === "group") {
+    const groupUrl = new URL(
+      `${getEffectiveApiUrl()}/groups/${encodeURIComponent(effectiveProjectId)}`
+    );
+    const groupResponse = await fetch(groupUrl.toString(), {
+      ...getFetchConfig(),
+    });
+    await handleGitLabError(groupResponse);
+    const group: any = await groupResponse.json();
+    return { path: group.full_path as string, kind: "group" };
+  }
+
   const projectUrl = new URL(
     `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}`
   );
@@ -3105,7 +3122,11 @@ async function resolveProjectOrGroupPath(
   // Numeric IDs must not fall back: group and project IDs share no namespace,
   // so a numeric project 404 should fail immediately rather than silently
   // resolving to an unrelated group with the same integer ID.
-  if (projectResponse.status === 404 && !/^\d+$/.test(effectiveProjectId)) {
+  if (
+    projectResponse.status === 404 &&
+    !explicitKind &&
+    !/^\d+$/.test(effectiveProjectId)
+  ) {
     const groupUrl = new URL(
       `${getEffectiveApiUrl()}/groups/${encodeURIComponent(effectiveProjectId)}`
     );

--- a/index.ts
+++ b/index.ts
@@ -3097,6 +3097,13 @@ async function resolveProjectOrGroupPath(
   const namespaceMatch = decodedProjectId.match(/^(group|project):(.+)$/i);
   const explicitKind = namespaceMatch?.[1]?.toLowerCase() as "group" | "project" | undefined;
   const requestedProjectId = namespaceMatch ? namespaceMatch[2] : decodedProjectId;
+
+  if (explicitKind === "group" && GITLAB_ALLOWED_PROJECT_IDS.length > 0) {
+    throw new Error(
+      "group:<id-or-path> cannot be used when GITLAB_ALLOWED_PROJECT_IDS is set, because the project allowlist does not cover groups"
+    );
+  }
+
   const effectiveProjectId = getEffectiveProjectId(requestedProjectId);
 
   if (explicitKind === "group") {

--- a/schemas.ts
+++ b/schemas.ts
@@ -3978,7 +3978,7 @@ const workItemTypeEnum = z
 const ProjectIdOrPathSchema = z.coerce
   .string()
   .describe(
-    "Project ID, URL-encoded project path, or group path (e.g. 'group/subgroup' for group-level work items)"
+    "Project ID, URL-encoded project path, group path, or explicit namespace prefix for ambiguous numeric IDs (e.g. 'group/subgroup', 'group:123', or 'project:123')"
   );
 
 // Common params for work item tools

--- a/schemas.ts
+++ b/schemas.ts
@@ -3975,7 +3975,7 @@ const workItemTypeEnum = z
     ])
   );
 
-const ProjectIdOrPathSchema = z.coerce
+const NamespaceIdOrPathSchema = z.coerce
   .string()
   .describe(
     "Project ID, URL-encoded project path, group path, or explicit namespace prefix for ambiguous numeric IDs (e.g. 'group/subgroup', 'group:123', or 'project:123')"
@@ -3983,14 +3983,14 @@ const ProjectIdOrPathSchema = z.coerce
 
 // Common params for work item tools
 const WorkItemParamsSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID (IID) of the work item"),
 });
 
 export const GetWorkItemSchema = WorkItemParamsSchema;
 
 export const ListWorkItemsSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   types: z
     .array(workItemTypeEnum)
     .optional()
@@ -4011,7 +4011,7 @@ export const ListWorkItemsSchema = z.object({
 });
 
 export const CreateWorkItemSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   title: z.string().describe("Title of the work item"),
   type: workItemTypeEnum
     .optional()
@@ -4184,13 +4184,13 @@ export const UpdateWorkItemSchema = WorkItemParamsSchema.extend({
 });
 
 export const ConvertWorkItemTypeSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   new_type: workItemTypeEnum.describe("The target work item type to convert to"),
 });
 
 export const ListWorkItemStatusesSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   work_item_type: workItemTypeEnum
     .optional()
     .default("issue")
@@ -4198,7 +4198,7 @@ export const ListWorkItemStatusesSchema = z.object({
 });
 
 export const ListWorkItemNotesSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   page_size: z.coerce
     .number()
@@ -4214,7 +4214,7 @@ export const ListWorkItemNotesSchema = z.object({
 });
 
 export const CreateWorkItemNoteSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   body: z.string().describe("Note body (Markdown supported)"),
   internal: z.coerce
@@ -4241,7 +4241,7 @@ export const MoveWorkItemSchema = z.object({
 });
 
 export const ListCustomFieldDefinitionsSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   work_item_type: workItemTypeEnum
     .optional()
     .default("issue")
@@ -4312,19 +4312,19 @@ export const DeleteIssueNoteEmojiReactionSchema = ProjectParamsSchema.extend({
 // --- Emoji Reaction schemas (GraphQL: Work Items) ---
 
 export const CreateWorkItemEmojiReactionSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   name: emojiNameField,
 });
 
 export const DeleteWorkItemEmojiReactionSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   name: emojiNameField,
 });
 
 export const CreateWorkItemNoteEmojiReactionSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   note_id: z
     .string()
@@ -4335,7 +4335,7 @@ export const CreateWorkItemNoteEmojiReactionSchema = z.object({
 });
 
 export const DeleteWorkItemNoteEmojiReactionSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   note_id: z
     .string()
@@ -4366,12 +4366,12 @@ export const ListIssueNoteEmojiReactionsSchema = ProjectParamsSchema.extend({
 });
 
 export const ListWorkItemEmojiReactionsSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
 });
 
 export const ListWorkItemNoteEmojiReactionsSchema = z.object({
-  project_id: ProjectIdOrPathSchema,
+  project_id: NamespaceIdOrPathSchema,
   iid: z.coerce.number().describe("The internal ID of the work item"),
   note_id: z
     .string()

--- a/test/test-geteffectiveprojectid.ts
+++ b/test/test-geteffectiveprojectid.ts
@@ -324,6 +324,25 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
     assert.strictEqual(group789Requested, false, 'Should not request /groups/789');
     console.log('  ✓ Bare numeric ID 789 did not fall back to /groups/789');
   });
+
+  test('should not fall back from explicit numeric project IDs to groups', async () => {
+    group789Requested = false;
+    let didThrow = false;
+
+    try {
+      await client.callTool('list_work_items', {
+        project_id: 'project:789',
+      });
+    } catch (error) {
+      didThrow = true;
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('404'), 'Should surface the project 404');
+    }
+
+    assert.ok(didThrow, 'Should have failed on the project 404');
+    assert.strictEqual(group789Requested, false, 'Should not request /groups/789');
+    console.log('  ✓ Explicit project:789 did not fall back to /groups/789');
+  });
 });
 
 describe('getEffectiveProjectId - With single GITLAB_ALLOWED_PROJECT_IDS', () => {

--- a/test/test-geteffectiveprojectid.ts
+++ b/test/test-geteffectiveprojectid.ts
@@ -40,6 +40,7 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
   let client: CustomHeaderClient;
   let group123Requested = false;
   let group789Requested = false;
+  let labelLookupRoots: string[] = [];
 
   before(async () => {
     // Start mock GitLab server
@@ -76,32 +77,109 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
     mockGitLab.addRootHandler('post', '/api/graphql', (req, res) => {
       const { query, variables } = req.body as {
         query: string;
-        variables: Record<string, unknown>;
+        variables: Record<string, any>;
       };
 
-      assert.ok(query.includes('group(fullPath: $path)'), 'Should query the group GraphQL root');
-      assert.strictEqual(variables.path, 'test-group', 'Should use resolved group full_path');
-
-      res.json({
-        data: {
-          group: {
-            workItems: {
-              nodes: [
-                {
-                  id: 'gid://gitlab/WorkItem/1',
-                  iid: '1',
-                  title: 'Group work item',
-                  state: 'OPEN',
-                  webUrl: 'https://gitlab.mock/groups/test-group/-/work_items/1',
-                  workItemType: { name: 'Issue' },
-                  widgets: [],
-                },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
+      if (query.includes('workItemTypes')) {
+        res.json({
+          data: {
+            namespace: {
+              workItemTypes: {
+                nodes: [{ id: 'gid://gitlab/WorkItems::Type/1', name: 'Issue' }],
+              },
             },
           },
-        },
-      });
+        });
+        return;
+      }
+
+      if (query.includes('workItems(')) {
+        assert.ok(query.includes('group(fullPath: $path)'), 'Should query the group GraphQL root');
+        assert.strictEqual(variables.path, 'test-group', 'Should use resolved group full_path');
+        res.json({
+          data: {
+            group: {
+              workItems: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItem/1',
+                    iid: '1',
+                    title: 'Group work item',
+                    state: 'OPEN',
+                    webUrl: 'https://gitlab.mock/groups/test-group/-/work_items/1',
+                    workItemType: { name: 'Issue' },
+                    widgets: [],
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        });
+        return;
+      }
+
+      if (query.includes('labels(title:')) {
+        assert.ok(query.includes('group(fullPath: $path)'), 'Should resolve labels from Group');
+        assert.ok(!query.includes('namespace(fullPath: $path)'), 'Should not query labels from Namespace');
+        labelLookupRoots.push('group');
+        res.json({
+          data: {
+            group: { l0: { nodes: [{ id: 'gid://gitlab/GroupLabel/1' }] } },
+            users: { nodes: [] },
+          },
+        });
+        return;
+      }
+
+      if (query.includes('workItem(iid: $iid)')) {
+        res.json({
+          data: { namespace: { workItem: { id: 'gid://gitlab/WorkItem/1' } } },
+        });
+        return;
+      }
+
+      if (query.includes('workItemCreate')) {
+        assert.deepStrictEqual(variables.labelIds, ['gid://gitlab/GroupLabel/1']);
+        res.json({
+          data: {
+            workItemCreate: {
+              workItem: {
+                id: 'gid://gitlab/WorkItem/2',
+                iid: '2',
+                title: variables.title,
+                webUrl: 'https://gitlab.mock/groups/test-group/-/work_items/2',
+                workItemType: { name: 'Issue' },
+              },
+              errors: [],
+            },
+          },
+        });
+        return;
+      }
+
+      if (query.includes('workItemUpdate')) {
+        assert.deepStrictEqual(variables.addLabelIds, ['gid://gitlab/GroupLabel/1']);
+        res.json({
+          data: {
+            workItemUpdate: {
+              workItem: {
+                id: variables.id,
+                iid: '1',
+                title: 'Updated group work item',
+                state: 'OPEN',
+                webUrl: 'https://gitlab.mock/groups/test-group/-/work_items/1',
+                workItemType: { name: 'Issue' },
+                widgets: [],
+              },
+              errors: [],
+            },
+          },
+        });
+        return;
+      }
+
+      res.status(500).json({ message: `Unexpected GraphQL query: ${query}` });
     });
 
     await mockGitLab.start();
@@ -118,7 +196,7 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
         REMOTE_AUTHORIZATION: 'true',
         GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
         GITLAB_PROJECT_ID: DEFAULT_PROJECT_ID,
-        GITLAB_READ_ONLY_MODE: 'true',
+        GITLAB_READ_ONLY_MODE: 'false',
       }
     });
     servers.push(server);
@@ -192,6 +270,40 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
     assert.strictEqual(parsed.items.length, 1, 'Should return group work items');
     assert.strictEqual(parsed.items[0].title, 'Group work item');
     console.log('  ✓ Resolved group:123 via /groups/123 when no project allowlist is set');
+  });
+
+  test('should resolve labels from the group root when creating group work items', async () => {
+    labelLookupRoots = [];
+
+    const result = await client.callTool('create_work_item', {
+      project_id: 'group:123',
+      title: 'Created group work item',
+      labels: ['group-label'],
+    });
+
+    assert.deepStrictEqual(labelLookupRoots, ['group']);
+    assert.ok(result.content, 'Should have content');
+    const content = result.content[0];
+    assert.ok('text' in content, 'Content should have text');
+    assert.strictEqual(JSON.parse(content.text).title, 'Created group work item');
+    console.log('  ✓ Resolved create labels through group(fullPath:)');
+  });
+
+  test('should resolve labels from the group root when updating group work items', async () => {
+    labelLookupRoots = [];
+
+    const result = await client.callTool('update_work_item', {
+      project_id: 'group:123',
+      iid: 1,
+      add_labels: ['group-label'],
+    });
+
+    assert.deepStrictEqual(labelLookupRoots, ['group']);
+    assert.ok(result.content, 'Should have content');
+    const content = result.content[0];
+    assert.ok('text' in content, 'Content should have text');
+    assert.strictEqual(JSON.parse(content.text).title, 'Updated group work item');
+    console.log('  ✓ Resolved update labels through group(fullPath:)');
   });
 
   test('should not fall back from bare numeric project IDs to groups', async () => {
@@ -295,12 +407,14 @@ describe('getEffectiveProjectId - With single GITLAB_ALLOWED_PROJECT_IDS', () =>
   });
 
   test('should reject explicit group IDs when GITLAB_ALLOWED_PROJECT_IDS is set', async () => {
+    let didThrow = false;
+
     try {
       await client.callTool('list_work_items', {
         project_id: 'group:123',
       });
-      assert.fail('Should have rejected explicit group access');
     } catch (error) {
+      didThrow = true;
       assert.ok(error instanceof Error);
       assert.ok(
         error.message.includes('GITLAB_ALLOWED_PROJECT_IDS') &&
@@ -309,6 +423,8 @@ describe('getEffectiveProjectId - With single GITLAB_ALLOWED_PROJECT_IDS', () =>
       );
       console.log('  ✓ Rejected group:123 when GITLAB_ALLOWED_PROJECT_IDS is set');
     }
+
+    assert.ok(didThrow, 'Should have rejected explicit group access');
   });
 });
 

--- a/test/test-geteffectiveprojectid.ts
+++ b/test/test-geteffectiveprojectid.ts
@@ -196,18 +196,21 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
 
   test('should not fall back from bare numeric project IDs to groups', async () => {
     group789Requested = false;
+    let didThrow = false;
 
     try {
       await client.callTool('list_work_items', {
         project_id: '789',
       });
-      assert.fail('Should have failed on the project 404');
     } catch (error) {
+      didThrow = true;
       assert.ok(error instanceof Error);
       assert.ok(error.message.includes('404'), 'Should surface the project 404');
-      assert.strictEqual(group789Requested, false, 'Should not request /groups/789');
-      console.log('  ✓ Bare numeric ID 789 did not fall back to /groups/789');
     }
+
+    assert.ok(didThrow, 'Should have failed on the project 404');
+    assert.strictEqual(group789Requested, false, 'Should not request /groups/789');
+    console.log('  ✓ Bare numeric ID 789 did not fall back to /groups/789');
   });
 });
 

--- a/test/test-geteffectiveprojectid.ts
+++ b/test/test-geteffectiveprojectid.ts
@@ -38,6 +38,8 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
   let mockGitLab: MockGitLabServer;
   let servers: ServerInstance[] = [];
   let client: CustomHeaderClient;
+  let group123Requested = false;
+  let group789Requested = false;
 
   before(async () => {
     // Start mock GitLab server
@@ -46,6 +48,62 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
       port: mockPort,
       validTokens: [MOCK_TOKEN]
     });
+
+    mockGitLab.addMockHandler('get', '/groups/123', (_req, res) => {
+      group123Requested = true;
+      res.json({
+        id: 123,
+        name: 'Test Group',
+        path: 'test-group',
+        full_path: 'test-group',
+      });
+    });
+
+    mockGitLab.addMockHandler('get', '/projects/789', (_req, res) => {
+      res.status(404).json({ message: '404 Project Not Found' });
+    });
+
+    mockGitLab.addMockHandler('get', '/groups/789', (_req, res) => {
+      group789Requested = true;
+      res.json({
+        id: 789,
+        name: 'Numeric Group',
+        path: 'numeric-group',
+        full_path: 'numeric-group',
+      });
+    });
+
+    mockGitLab.addRootHandler('post', '/api/graphql', (req, res) => {
+      const { query, variables } = req.body as {
+        query: string;
+        variables: Record<string, unknown>;
+      };
+
+      assert.ok(query.includes('group(fullPath: $path)'), 'Should query the group GraphQL root');
+      assert.strictEqual(variables.path, 'test-group', 'Should use resolved group full_path');
+
+      res.json({
+        data: {
+          group: {
+            workItems: {
+              nodes: [
+                {
+                  id: 'gid://gitlab/WorkItem/1',
+                  iid: '1',
+                  title: 'Group work item',
+                  state: 'OPEN',
+                  webUrl: 'https://gitlab.mock/groups/test-group/-/work_items/1',
+                  workItemType: { name: 'Issue' },
+                  widgets: [],
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      });
+    });
+
     await mockGitLab.start();
     const mockGitLabUrl = mockGitLab.getUrl();
 
@@ -116,6 +174,40 @@ describe('getEffectiveProjectId - No GITLAB_ALLOWED_PROJECT_IDS', () => {
     // Should use the passed project_id, not GITLAB_PROJECT_ID
     assert.strictEqual(project.id.toString(), OTHER_PROJECT_ID, 'Should use passed project_id');
     console.log(`  ✓ Used passed project_id ${OTHER_PROJECT_ID} instead of default ${DEFAULT_PROJECT_ID}`);
+  });
+
+  test('should resolve explicit numeric group IDs through the groups endpoint', async () => {
+    group123Requested = false;
+
+    const result = await client.callTool('list_work_items', {
+      project_id: 'group:123',
+    });
+
+    assert.ok(group123Requested, 'Should request /groups/123');
+    assert.ok(result.content, 'Should have content');
+    const content = result.content[0];
+    assert.ok('text' in content, 'Content should have text');
+    const parsed = JSON.parse(content.text);
+
+    assert.strictEqual(parsed.items.length, 1, 'Should return group work items');
+    assert.strictEqual(parsed.items[0].title, 'Group work item');
+    console.log('  ✓ Resolved group:123 via /groups/123 when no project allowlist is set');
+  });
+
+  test('should not fall back from bare numeric project IDs to groups', async () => {
+    group789Requested = false;
+
+    try {
+      await client.callTool('list_work_items', {
+        project_id: '789',
+      });
+      assert.fail('Should have failed on the project 404');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(error.message.includes('404'), 'Should surface the project 404');
+      assert.strictEqual(group789Requested, false, 'Should not request /groups/789');
+      console.log('  ✓ Bare numeric ID 789 did not fall back to /groups/789');
+    }
   });
 });
 
@@ -196,6 +288,23 @@ describe('getEffectiveProjectId - With single GITLAB_ALLOWED_PROJECT_IDS', () =>
       assert.ok(error instanceof Error);
       assert.ok(error.message.includes('Access denied'), 'Should indicate access denied');
       console.log('  ✓ Correctly rejected access to non-allowed project');
+    }
+  });
+
+  test('should reject explicit group IDs when GITLAB_ALLOWED_PROJECT_IDS is set', async () => {
+    try {
+      await client.callTool('list_work_items', {
+        project_id: 'group:123',
+      });
+      assert.fail('Should have rejected explicit group access');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+      assert.ok(
+        error.message.includes('GITLAB_ALLOWED_PROJECT_IDS') &&
+          error.message.includes('project allowlist does not cover groups'),
+        'Should explain that project allowlists do not authorize groups'
+      );
+      console.log('  ✓ Rejected group:123 when GITLAB_ALLOWED_PROJECT_IDS is set');
     }
   });
 });


### PR DESCRIPTION
## Summary

This PR adds support for listing work items at the **group level**, not just the project level.

## Problem

Previously, the `listWorkItems` tool always resolved the namespace via `resolveProjectPath()` which returned only a string path, and the GraphQL query hard-coded `project(fullPath: $path)` as the root field. This made it impossible to query work items (including epics) scoped to a **group** — passing a group path/ID would fail because the GraphQL schema requires `group(fullPath: ...)` for group-level queries.

## Changes

### `index.ts`

1. **`resolveProjectOrGroupPath()`** — new helper that resolves a namespace (project or group) and returns both its `full_path` and a `kind` discriminator (`"project"` or `"group"`). It first attempts a group lookup, then falls back to project.

2. **`resolveProjectPath()`** — kept as a thin wrapper for backward compatibility, delegating to the new helper.

3. **`listWorkItems()`** — now:
   - Calls `resolveProjectOrGroupPath()` to determine the namespace kind.
   - Dynamically selects the GraphQL root field: `group` vs `project`.
   - Reads results from `data.group` or `data.project` accordingly.

This enables epics and other group-scoped work item types to be listed via the MCP tool.