### PR TITLE
feat: support `render_html` on wiki tools to expose `front_matter` custom titles

### DIFF
--- a/docs/tools/wiki.md
+++ b/docs/tools/wiki.md
@@ -32,6 +32,7 @@ List wiki pages in a project
 |---|---|:-:|---|
 | `project_id` | string | ✓ | Project ID or URL-encoded path |
 | `with_content` | boolean |  | Include content of the wiki pages |
+| `render_html` | boolean |  | Return rendered HTML content and include front_matter (e.g., the custom title) |
 | `page` | number |  | Page number for pagination (default: 1) |
 | `per_page` | number |  | Number of items per page (max: 100, default: 20) |
 
@@ -47,6 +48,7 @@ Get details of a specific wiki page
 |---|---|:-:|---|
 | `project_id` | string | ✓ | Project ID or URL-encoded path |
 | `slug` | string | ✓ | Slug of the wiki page (will be URL-encoded internally) |
+| `render_html` | boolean |  | Return rendered HTML content and include front_matter (e.g., the custom title) |
 
 ### `create_wiki_page`
 
@@ -104,6 +106,7 @@ List wiki pages in a group
 |---|---|:-:|---|
 | `group_id` | string | ✓ | Group ID or URL-encoded path |
 | `with_content` | boolean |  | Include content of the wiki pages |
+| `render_html` | boolean |  | Return rendered HTML content and include front_matter (e.g., the custom title) |
 | `page` | number |  | Page number for pagination (default: 1) |
 | `per_page` | number |  | Number of items per page (max: 100, default: 20) |
 
@@ -119,6 +122,7 @@ Get details of a specific group wiki page
 |---|---|:-:|---|
 | `group_id` | string | ✓ | Group ID or URL-encoded path |
 | `slug` | string | ✓ | Slug of the wiki page (will be URL-encoded internally) |
+| `render_html` | boolean |  | Return rendered HTML content and include front_matter (e.g., the custom title) |
 
 ### `create_group_wiki_page`
 

--- a/index.ts
+++ b/index.ts
@@ -6647,6 +6647,8 @@ async function listWikiPages(
   if (options.per_page) url.searchParams.append("per_page", options.per_page.toString());
   if (options.with_content)
     url.searchParams.append("with_content", options.with_content.toString());
+  if (options.render_html)
+    url.searchParams.append("render_html", options.render_html.toString());
   const response = await fetch(url.toString(), {
     ...getFetchConfig(),
   });
@@ -6658,12 +6660,17 @@ async function listWikiPages(
 /**
  * Get a specific wiki page
  */
-async function getWikiPage(projectId: string, slug: string): Promise<GitLabWikiPage> {
+async function getWikiPage(
+  projectId: string,
+  slug: string,
+  renderHtml?: boolean
+): Promise<GitLabWikiPage> {
   projectId = decodeURIComponent(projectId); // Decode project ID
-  const response = await fetch(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/wikis/${encodeURIComponent(slug)}`,
-    { ...getFetchConfig() }
+  const url = new URL(
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/wikis/${encodeURIComponent(slug)}`
   );
+  if (renderHtml) url.searchParams.append("render_html", renderHtml.toString());
+  const response = await fetch(url.toString(), { ...getFetchConfig() });
   await handleGitLabError(response);
   const data = await response.json();
   return GitLabWikiPageSchema.parse(data);
@@ -6757,6 +6764,8 @@ async function listGroupWikiPages(
   if (options.per_page) url.searchParams.append("per_page", options.per_page.toString());
   if (options.with_content)
     url.searchParams.append("with_content", options.with_content.toString());
+  if (options.render_html)
+    url.searchParams.append("render_html", options.render_html.toString());
   const response = await fetch(url.toString(), {
     ...getFetchConfig(),
   });
@@ -6768,12 +6777,17 @@ async function listGroupWikiPages(
 /**
  * Get a specific group wiki page
  */
-async function getGroupWikiPage(groupId: string, slug: string): Promise<GitLabWikiPage> {
+async function getGroupWikiPage(
+  groupId: string,
+  slug: string,
+  renderHtml?: boolean
+): Promise<GitLabWikiPage> {
   groupId = decodeURIComponent(groupId); // Decode group ID
-  const response = await fetch(
-    `${getEffectiveApiUrl()}/groups/${encodeURIComponent(groupId)}/wikis/${encodeURIComponent(slug)}`,
-    { ...getFetchConfig() }
+  const url = new URL(
+    `${getEffectiveApiUrl()}/groups/${encodeURIComponent(groupId)}/wikis/${encodeURIComponent(slug)}`
   );
+  if (renderHtml) url.searchParams.append("render_html", renderHtml.toString());
+  const response = await fetch(url.toString(), { ...getFetchConfig() });
   await handleGitLabError(response);
   const data = await response.json();
   return GitLabWikiPageSchema.parse(data);
@@ -10657,13 +10671,13 @@ async function handleToolCall(params: any) {
       }
 
       case "list_wiki_pages": {
-        const { project_id, page, per_page, with_content } = ListWikiPagesSchema.parse(
-          params.arguments
-        );
+        const { project_id, page, per_page, with_content, render_html } =
+          ListWikiPagesSchema.parse(params.arguments);
         const wikiPages = await listWikiPages(project_id, {
           page,
           per_page,
           with_content,
+          render_html,
         });
         return {
           content: [{ type: "text", text: JSON.stringify(wikiPages) }],
@@ -10671,8 +10685,8 @@ async function handleToolCall(params: any) {
       }
 
       case "get_wiki_page": {
-        const { project_id, slug } = GetWikiPageSchema.parse(params.arguments);
-        const wikiPage = await getWikiPage(project_id, slug);
+        const { project_id, slug, render_html } = GetWikiPageSchema.parse(params.arguments);
+        const wikiPage = await getWikiPage(project_id, slug, render_html);
         return {
           content: [{ type: "text", text: JSON.stringify(wikiPage) }],
         };
@@ -10717,13 +10731,13 @@ async function handleToolCall(params: any) {
       }
 
       case "list_group_wiki_pages": {
-        const { group_id, page, per_page, with_content } = ListGroupWikiPagesSchema.parse(
-          params.arguments
-        );
+        const { group_id, page, per_page, with_content, render_html } =
+          ListGroupWikiPagesSchema.parse(params.arguments);
         const wikiPages = await listGroupWikiPages(group_id, {
           page,
           per_page,
           with_content,
+          render_html,
         });
         return {
           content: [{ type: "text", text: JSON.stringify(wikiPages) }],
@@ -10731,8 +10745,8 @@ async function handleToolCall(params: any) {
       }
 
       case "get_group_wiki_page": {
-        const { group_id, slug } = GetGroupWikiPageSchema.parse(params.arguments);
-        const wikiPage = await getGroupWikiPage(group_id, slug);
+        const { group_id, slug, render_html } = GetGroupWikiPageSchema.parse(params.arguments);
+        const wikiPage = await getGroupWikiPage(group_id, slug, render_html);
         return {
           content: [{ type: "text", text: JSON.stringify(wikiPage) }],
         };

--- a/schemas.ts
+++ b/schemas.ts
@@ -2643,12 +2643,20 @@ export const ListWikiPagesSchema = z
   .object({
     project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
     with_content: z.coerce.boolean().optional().describe("Include content of the wiki pages"),
+    render_html: z.coerce
+      .boolean()
+      .optional()
+      .describe("Return rendered HTML content and include front_matter (e.g., the custom title)"),
   })
   .merge(PaginationOptionsSchema);
 
 export const GetWikiPageSchema = z.object({
   project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
   slug: z.string().describe("Slug of the wiki page (will be URL-encoded internally)"),
+  render_html: z.coerce
+    .boolean()
+    .optional()
+    .describe("Return rendered HTML content and include front_matter (e.g., the custom title)"),
 });
 export const CreateWikiPageSchema = z.object({
   project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
@@ -2675,6 +2683,7 @@ export const GitLabWikiPageSchema = z.object({
   slug: z.string(),
   format: z.string(),
   content: z.string().optional(),
+  front_matter: z.record(z.unknown()).optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 });
@@ -2684,12 +2693,20 @@ export const ListGroupWikiPagesSchema = z
   .object({
     group_id: z.coerce.string().describe("Group ID or URL-encoded path"),
     with_content: z.coerce.boolean().optional().describe("Include content of the wiki pages"),
+    render_html: z.coerce
+      .boolean()
+      .optional()
+      .describe("Return rendered HTML content and include front_matter (e.g., the custom title)"),
   })
   .merge(PaginationOptionsSchema);
 
 export const GetGroupWikiPageSchema = z.object({
   group_id: z.coerce.string().describe("Group ID or URL-encoded path"),
   slug: z.string().describe("Slug of the wiki page (will be URL-encoded internally)"),
+  render_html: z.coerce
+    .boolean()
+    .optional()
+    .describe("Return rendered HTML content and include front_matter (e.g., the custom title)"),
 });
 
 export const CreateGroupWikiPageSchema = z.object({


### PR DESCRIPTION
## Summary

Related to #564 (left open intentionally).

GitLab stores a wiki page's custom title (one that differs from the slug) in the page's **front matter**. The Wikis REST API only returns it in the `front_matter` field, and only when the request includes `render_html=true`. Previously:

- `getWikiPage` / `listWikiPages` (and group variants) sent no `render_html` query param
- `GitLabWikiPageSchema` had no `front_matter` field, so Zod `.parse()` dropped it even if present

So the custom title was unreachable through the MCP — `title` was always the humanized-slug value.

## Changes

- Add optional `render_html` parameter to `get_wiki_page`, `list_wiki_pages`, `get_group_wiki_page`, `list_group_wiki_pages`, passed through to the GitLab API
- Add `front_matter` (optional record) to `GitLabWikiPageSchema` so the parsed value survives
- Regenerate `docs/tools/wiki.md`

## Behavior

- Default behavior is unchanged (`render_html` omitted → same request/response as before)
- With `render_html: true`, the response includes `front_matter` (e.g. `{ "title": "Custom Title" }`) and `content` rendered as HTML, matching the GitLab REST API

## Test plan

- `tsc --noEmit` passes
- `test/utils/wiki-title.test.ts` and `test/nullish-tool-arguments-schema.test.ts` pass
- Manual: `get_wiki_page` with `render_html: true` against a page whose title differs from its slug returns the custom title in `front_matter.title`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in read-only query flag and optional schema field; default wiki tool behavior is unchanged.
> 
> **Overview**
> Adds optional **`render_html`** on project and group **`list_wiki_pages`** / **`get_wiki_page`** tools so callers can match GitLab’s Wikis API and receive **`front_matter`** (including custom titles that differ from the slug).
> 
> **`GitLabWikiPageSchema`** now keeps an optional **`front_matter`** field instead of stripping it during Zod parse. The HTTP helpers forward **`render_html`** as a query parameter; MCP tool handlers wire the new argument through. **`docs/tools/wiki.md`** documents the parameter.
> 
> When **`render_html`** is omitted, requests and responses behave as before. With **`render_html: true`**, responses can include **`front_matter`** and HTML **`content`** per the REST API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434b2bede4e35b9708c59325509cd912492a5ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
