### PR TITLE
docs(wiki): warn that the title param changes the slug/URL and document the front-matter path

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -456,6 +456,22 @@ AI 클라이언트에 skill 디렉터리를 등록하면 전체 ListTools 응답
 
 전체 도구 목록은 영어 README의 [Tools 섹션](./README.md#tools-%EF%B8%8F)을 참고하세요. 현재 서버는 머지 리퀘스트, 이슈, 파이프라인, 배포, 환경, 아티팩트, 마일스톤, 위키, 저장소, 릴리스, 사용자, 이벤트, work item, 웹훅, 코드 검색, GraphQL 실행 도구를 제공합니다.
 
+### Wiki 페이지 제목과 slug
+
+GitLab은 wiki 페이지 제목에서 **slug**(URL, `/-/wikis/<slug>`)를 도출합니다. 따라서 `update_wiki_page` / `update_group_wiki_page`에 `title`을 전달하면 **페이지 이름이 바뀌고 URL이 변경**되어(중첩 페이지의 경우 마지막 세그먼트만 변경됨) 기존 링크가 깨집니다.
+
+URL을 유지한 채 **표시 제목**만 변경하려면 `title`을 전달하지 **말고**, 표시 제목을 페이지 내용의 YAML front matter에 저장한 뒤 내용을 업데이트하세요:
+
+```markdown
+---
+title: 사용자 지정 표시 제목
+---
+
+페이지 본문…
+```
+
+GitLab은 slug/URL을 그대로 유지하고 UI에 front matter의 제목을 표시합니다. 다시 읽을 때는 `get_wiki_page`에 `render_html: true`를 전달하면 `front_matter` 필드가 채워집니다 — 일반 `title` 필드는 항상 slug에서 도출된 값을 반영합니다.
+
 ## 테스트 🧪
 
 프로젝트에는 원격 인증을 포함한 포괄적인 테스트가 포함되어 있습니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -458,7 +458,7 @@ AI 클라이언트에 skill 디렉터리를 등록하면 전체 ListTools 응답
 
 ### Wiki 페이지 제목과 slug
 
-GitLab은 wiki 페이지 제목에서 **slug**(URL, `/-/wikis/<slug>`)를 도출합니다. 따라서 `update_wiki_page` / `update_group_wiki_page`에 `title`을 전달하면 **페이지 이름이 바뀌고 URL이 변경**되어(중첩 페이지의 경우 마지막 세그먼트만 변경됨) 기존 링크가 깨집니다.
+GitLab은 wiki 페이지 제목에서 **slug**(URL, `/-/wikis/<slug>`)를 도출합니다. 따라서 `update_wiki_page` / `update_group_wiki_page`에 `title`을 전달하면 **페이지 이름이 바뀌고 URL이 변경**되어(중첩 페이지의 경우 페이지가 다른 경로로 이동할 수도 있음) 기존 링크가 깨집니다.
 
 URL을 유지한 채 **표시 제목**만 변경하려면 `title`을 전달하지 **말고**, 표시 제목을 페이지 내용의 YAML front matter에 저장한 뒤 내용을 업데이트하세요:
 

--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ Register the skill directory in your AI client to get optimal tool usage guidanc
 
 ### Wiki page titles vs. slugs
 
-GitLab derives a wiki page's **slug** (its URL, `/-/wikis/<slug>`) from the page title. Passing `title` to `update_wiki_page` / `update_group_wiki_page` therefore **renames the page and changes its URL** — for nested pages, only the leaf segment changes — which breaks existing links.
+GitLab derives a wiki page's **slug** (its URL, `/-/wikis/<slug>`) from the page title. Passing `title` to `update_wiki_page` / `update_group_wiki_page` therefore **renames the page and changes its URL** — for nested pages it can also move the page to a different path — which breaks existing links.
 
 To change only the **displayed title** while keeping the URL stable, do **not** pass `title`. Instead, store the display title in the page content's YAML front matter and update the content:
 

--- a/README.md
+++ b/README.md
@@ -700,6 +700,22 @@ Register the skill directory in your AI client to get optimal tool usage guidanc
 
 </details>
 
+### Wiki page titles vs. slugs
+
+GitLab derives a wiki page's **slug** (its URL, `/-/wikis/<slug>`) from the page title. Passing `title` to `update_wiki_page` / `update_group_wiki_page` therefore **renames the page and changes its URL** — for nested pages, only the leaf segment changes — which breaks existing links.
+
+To change only the **displayed title** while keeping the URL stable, do **not** pass `title`. Instead, store the display title in the page content's YAML front matter and update the content:
+
+```markdown
+---
+title: My Custom Display Title
+---
+
+Page body…
+```
+
+GitLab keeps the slug/URL untouched and shows the front-matter title in the UI. Read it back with `get_wiki_page` using `render_html: true`, which populates the `front_matter` field — the plain `title` field always reflects the slug-derived value.
+
 ## Testing 🧪
 
 The project includes comprehensive test coverage including remote authorization:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -456,6 +456,22 @@ npx skills add zereight/gitlab-mcp --skill gitlab-mcp-skill
 
 完整工具列表请参考英文 README 的 [Tools 部分](./README.md#tools-%EF%B8%8F)。当前服务器提供合并请求、议题、流水线、部署、环境、制品、里程碑、Wiki、仓库、发布、用户、事件、work item、webhook、代码搜索和 GraphQL 执行相关工具。
 
+### Wiki 页面标题与 slug
+
+GitLab 会根据 wiki 页面标题推导其 **slug**（即 URL，`/-/wikis/<slug>`）。因此向 `update_wiki_page` / `update_group_wiki_page` 传入 `title` 会**重命名页面并改变其 URL**——对于嵌套页面，仅叶子段会变——从而导致已有链接失效。
+
+若只想修改**显示标题**而保持 URL 不变，请**不要**传入 `title`，而是把显示标题写入页面内容的 YAML front matter 并更新内容：
+
+```markdown
+---
+title: 我的自定义显示标题
+---
+
+页面正文…
+```
+
+GitLab 会保持 slug/URL 不变，并在界面中显示 front matter 中的标题。读取时对 `get_wiki_page` 传入 `render_html: true`，即可填充 `front_matter` 字段——而普通的 `title` 字段始终反映由 slug 推导的值。
+
 ## 测试 🧪
 
 项目包含完整测试覆盖，包括远程授权：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -458,7 +458,7 @@ npx skills add zereight/gitlab-mcp --skill gitlab-mcp-skill
 
 ### Wiki 页面标题与 slug
 
-GitLab 会根据 wiki 页面标题推导其 **slug**（即 URL，`/-/wikis/<slug>`）。因此向 `update_wiki_page` / `update_group_wiki_page` 传入 `title` 会**重命名页面并改变其 URL**——对于嵌套页面，仅叶子段会变——从而导致已有链接失效。
+GitLab 会根据 wiki 页面标题推导其 **slug**（即 URL，`/-/wikis/<slug>`）。因此向 `update_wiki_page` / `update_group_wiki_page` 传入 `title` 会**重命名页面并改变其 URL**——对于嵌套页面，还可能把页面移动到不同的路径——从而导致已有链接失效。
 
 若只想修改**显示标题**而保持 URL 不变，请**不要**传入 `title`，而是把显示标题写入页面内容的 YAML front matter 并更新内容：
 

--- a/docs/tools/wiki.md
+++ b/docs/tools/wiki.md
@@ -77,7 +77,7 @@ Update a wiki page in a project
 |---|---|:-:|---|
 | `project_id` | string | ✓ | Project ID or URL-encoded path |
 | `slug` | string | ✓ | Slug of the wiki page (will be URL-encoded internally) |
-| `title` | string |  | New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages, only the leaf segment changes), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter. |
+| `title` | string |  | New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages it can also move the page to a different path), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter. |
 | `content` | string |  | New content of the wiki page |
 | `format` | string |  | Content format, e.g., markdown, rdoc |
 
@@ -151,7 +151,7 @@ Update a wiki page in a group
 |---|---|:-:|---|
 | `group_id` | string | ✓ | Group ID or URL-encoded path |
 | `slug` | string | ✓ | Slug of the wiki page (will be URL-encoded internally) |
-| `title` | string |  | New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages, only the leaf segment changes), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter. |
+| `title` | string |  | New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages it can also move the page to a different path), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter. |
 | `content` | string |  | New content of the wiki page |
 | `format` | string |  | Content format, e.g., markdown, rdoc |
 

--- a/docs/tools/wiki.md
+++ b/docs/tools/wiki.md
@@ -77,7 +77,7 @@ Update a wiki page in a project
 |---|---|:-:|---|
 | `project_id` | string | ✓ | Project ID or URL-encoded path |
 | `slug` | string | ✓ | Slug of the wiki page (will be URL-encoded internally) |
-| `title` | string |  | New title of the wiki page |
+| `title` | string |  | New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages, only the leaf segment changes), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter. |
 | `content` | string |  | New content of the wiki page |
 | `format` | string |  | Content format, e.g., markdown, rdoc |
 
@@ -151,7 +151,7 @@ Update a wiki page in a group
 |---|---|:-:|---|
 | `group_id` | string | ✓ | Group ID or URL-encoded path |
 | `slug` | string | ✓ | Slug of the wiki page (will be URL-encoded internally) |
-| `title` | string |  | New title of the wiki page |
+| `title` | string |  | New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages, only the leaf segment changes), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter. |
 | `content` | string |  | New content of the wiki page |
 | `format` | string |  | Content format, e.g., markdown, rdoc |
 

--- a/schemas.ts
+++ b/schemas.ts
@@ -2667,7 +2667,12 @@ export const CreateWikiPageSchema = z.object({
 export const UpdateWikiPageSchema = z.object({
   project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
   slug: z.string().describe("Slug of the wiki page (will be URL-encoded internally)"),
-  title: z.string().optional().describe("New title of the wiki page"),
+  title: z
+    .string()
+    .optional()
+    .describe(
+      "New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages, only the leaf segment changes), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter."
+    ),
   content: z.string().optional().describe("New content of the wiki page"),
   format: z.string().optional().describe("Content format, e.g., markdown, rdoc"),
 });
@@ -2719,7 +2724,12 @@ export const CreateGroupWikiPageSchema = z.object({
 export const UpdateGroupWikiPageSchema = z.object({
   group_id: z.coerce.string().describe("Group ID or URL-encoded path"),
   slug: z.string().describe("Slug of the wiki page (will be URL-encoded internally)"),
-  title: z.string().optional().describe("New title of the wiki page"),
+  title: z
+    .string()
+    .optional()
+    .describe(
+      "New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages, only the leaf segment changes), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter."
+    ),
   content: z.string().optional().describe("New content of the wiki page"),
   format: z.string().optional().describe("Content format, e.g., markdown, rdoc"),
 });

--- a/schemas.ts
+++ b/schemas.ts
@@ -2671,7 +2671,7 @@ export const UpdateWikiPageSchema = z.object({
     .string()
     .optional()
     .describe(
-      "New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages, only the leaf segment changes), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter."
+      "New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages it can also move the page to a different path), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter."
     ),
   content: z.string().optional().describe("New content of the wiki page"),
   format: z.string().optional().describe("Content format, e.g., markdown, rdoc"),
@@ -2728,7 +2728,7 @@ export const UpdateGroupWikiPageSchema = z.object({
     .string()
     .optional()
     .describe(
-      "New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages, only the leaf segment changes), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter."
+      "New title of the wiki page. WARNING: setting this renames the page and changes its slug/URL (for nested pages it can also move the page to a different path), which breaks existing links. To change only the displayed title while keeping the URL, omit this parameter and instead set a `title:` field in the content's YAML front matter."
     ),
   content: z.string().optional().describe("New content of the wiki page"),
   format: z.string().optional().describe("Content format, e.g., markdown, rdoc"),


### PR DESCRIPTION
## Summary

Follow-up to #570. As agreed in that thread, this implements **options 1 and 2** (parameter-description warnings + a README front-matter display-title path). It deliberately does **not** change `updateWikiPage` behavior or add a `front_matter_title` parameter — that larger option (3) is left for a separate discussion.

GitLab derives a wiki page's **slug** (its URL) from the page title. Passing `title` to `update_wiki_page` / `update_group_wiki_page` therefore renames the page and changes its URL — for nested pages, only the leaf segment — which **silently breaks existing links**. Until now there was no warning on the parameter and no documented way to change only the *displayed* title while keeping the URL stable.

## Changes

- **`schemas.ts`** — expand the `title` description on `UpdateWikiPageSchema` and `UpdateGroupWikiPageSchema` with a warning that setting it renames the page and changes its slug/URL, plus a pointer to the front-matter method for URL-preserving title changes.
- **`docs/tools/wiki.md`** — regenerated from the updated schemas via `scripts/generate-tool-docs.ts`; no manual edits, so it stays in sync with the CI drift check.
- **`README.md`, `README.zh-CN.md`, `README.ko.md`** — add a "Wiki page titles vs. slugs" section documenting how to change only the displayed title by editing the content's YAML front matter instead of passing `title`.

## The documented URL-preserving method

To change only the displayed title while keeping the URL, do **not** pass `title`. Instead set a `title:` field in the content's YAML front matter and update the content. Read it back with `get_wiki_page` using `render_html: true`, which populates `front_matter` (the plain `title` field always reflects the slug-derived value).

## Verification

- `npx tsc --noEmit` passes.
- `npx tsx scripts/generate-tool-docs.ts` yields no drift beyond the intended `docs/tools/wiki.md` change (matches the CI drift check).
- Verified end-to-end against a live GitLab wiki:
  - `get_wiki_page(render_html: true)` returns the custom title in `front_matter.title` while `title` stays slug-derived.
  - Editing only the front-matter `title` updates the displayed title with the slug/URL unchanged and the page body preserved byte-for-byte.
  - Passing `title` to `update_wiki_page` moves the page to a new slug (the old URL 404s) — exactly the behavior this PR now warns about.

Addresses #570 (options 1 and 2).
