### PR TITLE
Add Homebrew tap for zereight-mcp-gitlab

### DIFF
--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -1,23 +1,19 @@
 name: Sync Homebrew Formula
 
 on:
-  workflow_run:
-    workflows: ["NPM Publish"]
-    types: [completed]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -1,0 +1,32 @@
+name: Sync Homebrew Formula
+
+on:
+  workflow_run:
+    workflows: ["NPM Publish"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.21.1"
+
+      - name: Sync formula from npm tarball
+        run: bash scripts/sync-homebrew-formula.sh
+
+      - name: Commit formula update
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: chore(homebrew): sync formula for release
+          file_pattern: Formula/zereight-mcp-gitlab.rb

--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Commit formula update
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: chore(homebrew): sync formula for release
+          commit_message: "chore(homebrew): sync formula for release"
           file_pattern: Formula/zereight-mcp-gitlab.rb

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,3 +30,26 @@ jobs:
         run: npm run build
       - name: Publish to npm
         run: npm publish --access public --provenance
+
+  sync-homebrew:
+    needs: npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.21.1"
+
+      - name: Sync formula from npm tarball
+        run: bash scripts/sync-homebrew-formula.sh
+
+      - name: Commit formula update
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: chore(homebrew): sync formula for release
+          file_pattern: Formula/zereight-mcp-gitlab.rb

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,5 +51,5 @@ jobs:
       - name: Commit formula update
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: chore(homebrew): sync formula for release
+          commit_message: "chore(homebrew): sync formula for release"
           file_pattern: Formula/zereight-mcp-gitlab.rb

--- a/Formula/zereight-mcp-gitlab.rb
+++ b/Formula/zereight-mcp-gitlab.rb
@@ -1,0 +1,26 @@
+class ZereightMcpGitlab < Formula
+  desc "GitLab Model Context Protocol server for AI clients"
+  homepage "https://github.com/zereight/gitlab-mcp"
+  url "https://registry.npmjs.org/@zereight/mcp-gitlab/-/mcp-gitlab-2.1.29.tgz"
+  sha256 "41fcb51ee2312871f5a78670a08257361e8c7273506389f0f9a434efbc580fd0"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    ENV["GITLAB_PERSONAL_ACCESS_TOKEN"] = "homebrew-test-token"
+
+    json = <<~JSON
+      {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"homebrew","version":"#{version}"}}}
+      {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+    JSON
+
+    output = pipe_output(bin/"zereight-mcp-gitlab", json, 0)
+    assert_match "better-gitlab-mcp-server", output
+  end
+end

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,16 +69,16 @@ PAT, OAuth, 읽기 전용 모드, 동적 API URL, 원격 인증을 지원하며 
 
 가장 단순한 로컬 설정은 Personal Access Token으로 시작하세요. 브라우저 기반 로컬 인증은 OAuth2를 사용하세요. 원격 또는 멀티 유저 배포는 아래 MCP OAuth 및 원격 인증 섹션을 참고하세요.
 
-서버를 한 번 전역 설치하세요.
-
-```shell
-npm install -g @zereight/mcp-gitlab
-```
-
-Homebrew로 설치할 수도 있습니다:
+서버를 한 번 설치하세요.
 
 ```shell
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+npm으로 설치할 수도 있습니다:
+
+```shell
+npm install -g @zereight/mcp-gitlab
 ```
 
 예시는 기존 `mcp-gitlab`보다 충돌 가능성이 낮은 `zereight-mcp-gitlab` 별칭을 사용합니다. MCP 클라이언트가 찾지 못하면 `which zereight-mcp-gitlab`의 절대 경로를 사용하세요.

--- a/README.ko.md
+++ b/README.ko.md
@@ -75,6 +75,12 @@ PAT, OAuth, 읽기 전용 모드, 동적 API URL, 원격 인증을 지원하며 
 npm install -g @zereight/mcp-gitlab
 ```
 
+Homebrew로 설치할 수도 있습니다:
+
+```shell
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
 예시는 기존 `mcp-gitlab`보다 충돌 가능성이 낮은 `zereight-mcp-gitlab` 별칭을 사용합니다. MCP 클라이언트가 찾지 못하면 `which zereight-mcp-gitlab`의 절대 경로를 사용하세요.
 
 전역 설치를 쓰지 않으려면 `npx -y @zereight/mcp-gitlab@2.1.28`처럼 직전 안정 버전(문서가 권장하는 버전)으로 고정하세요. 항상 최신 버전을 원하면 `npx -y @zereight/mcp-gitlab@latest`를 사용하세요. 새 버전이 나오면 서버가 시작 시 stderr로 알려줍니다(`GITLAB_DISABLE_VERSION_CHECK=true`로 비활성화 가능).

--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ The server supports four authentication methods:
 
 For the simplest local setup, start with a Personal Access Token. For browser-based local auth, use OAuth2. For remote or multi-user deployments, continue to the MCP OAuth and Remote Authorization sections later in this README.
 
-Install the server globally once:
-
-```shell
-npm install -g @zereight/mcp-gitlab
-```
-
-Or with Homebrew:
+Install the server once:
 
 ```shell
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
+
+```shell
+npm install -g @zereight/mcp-gitlab
 ```
 
 The examples use `zereight-mcp-gitlab`, a less collision-prone alias for the legacy `mcp-gitlab` binary. If your MCP client cannot find it, use the absolute path from `which zereight-mcp-gitlab`.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Install the server globally once:
 npm install -g @zereight/mcp-gitlab
 ```
 
+Or with Homebrew:
+
+```shell
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
 The examples use `zereight-mcp-gitlab`, a less collision-prone alias for the legacy `mcp-gitlab` binary. If your MCP client cannot find it, use the absolute path from `which zereight-mcp-gitlab`.
 
 No global install? Pin `npx` to the previous stable release (the version these docs recommend), for example `npx -y @zereight/mcp-gitlab@2.1.28`. If you always want the newest release, use `npx -y @zereight/mcp-gitlab@latest` instead. The server prints a notice to stderr on startup when a newer version is available (disable with `GITLAB_DISABLE_VERSION_CHECK=true`).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,16 +69,16 @@
 
 最简单的本地设置可以从 Personal Access Token 开始。基于浏览器的本地认证使用 OAuth2。远程或多用户部署请继续查看下面的 MCP OAuth 和远程授权部分。
 
-先全局安装一次服务器：
-
-```shell
-npm install -g @zereight/mcp-gitlab
-```
-
-也可以使用 Homebrew 安装：
+安装服务器：
 
 ```shell
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+也可以使用 npm 安装：
+
+```shell
+npm install -g @zereight/mcp-gitlab
 ```
 
 示例使用 `zereight-mcp-gitlab`，这是比旧的 `mcp-gitlab` 更不容易冲突的别名。如果 MCP 客户端找不到它，请使用 `which zereight-mcp-gitlab` 输出的绝对路径。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,6 +75,12 @@
 npm install -g @zereight/mcp-gitlab
 ```
 
+也可以使用 Homebrew 安装：
+
+```shell
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
 示例使用 `zereight-mcp-gitlab`，这是比旧的 `mcp-gitlab` 更不容易冲突的别名。如果 MCP 客户端找不到它，请使用 `which zereight-mcp-gitlab` 输出的绝对路径。
 
 如果不想全局安装，请将 `npx` 固定到上一个稳定版本（即文档推荐的版本），例如 `npx -y @zereight/mcp-gitlab@2.1.28`。如果始终想使用最新版本，请改用 `npx -y @zereight/mcp-gitlab@latest`。有新版本发布时，服务器会在启动时通过 stderr 提示（可用 `GITLAB_DISABLE_VERSION_CHECK=true` 关闭）。

--- a/docs/auth/custom-agent-multiple-pat.md
+++ b/docs/auth/custom-agent-multiple-pat.md
@@ -3,7 +3,13 @@
 This guide explains how to run `gitlab-mcp` for custom agents, single-user PAT
 setups, multi-user deployments, and restricted tool surfaces.
 
-Install the server globally once:
+Install the server once:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
 
 ```bash
 npm install -g @zereight/mcp-gitlab

--- a/docs/auth/oauth-setup.md
+++ b/docs/auth/oauth-setup.md
@@ -15,7 +15,13 @@ OAuth2 provides several advantages over personal access tokens:
 
 - A GitLab account (GitLab.com or self-hosted GitLab instance)
 - Node.js installed on your machine
-- The GitLab MCP server installed globally:
+- The GitLab MCP server installed:
+
+  ```bash
+  brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+  ```
+
+  Or with npm:
 
   ```bash
   npm install -g @zereight/mcp-gitlab

--- a/docs/clients/claude-code.md
+++ b/docs/clients/claude-code.md
@@ -23,7 +23,13 @@ Use an API URL, not the web root:
 - `https://gitlab.com/api/v4`
 - `https://your-gitlab.example.com/api/v4`
 
-Install the server globally once:
+Install the server once:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
 
 ```bash
 npm install -g @zereight/mcp-gitlab

--- a/docs/clients/codex.md
+++ b/docs/clients/codex.md
@@ -22,7 +22,13 @@ Use an API URL, not the web root:
 - `https://gitlab.com/api/v4`
 - `https://your-gitlab.example.com/api/v4`
 
-Install the server globally once:
+Install the server once:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
 
 ```bash
 npm install -g @zereight/mcp-gitlab

--- a/docs/clients/copilot.md
+++ b/docs/clients/copilot.md
@@ -11,7 +11,13 @@ That means you configure the server in:
 - `.vscode/mcp.json` for workspace scope, or
 - your user-profile `mcp.json` for global scope
 
-Install the server globally once:
+Install the server once:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
 
 ```bash
 npm install -g @zereight/mcp-gitlab

--- a/docs/clients/cursor.md
+++ b/docs/clients/cursor.md
@@ -12,7 +12,13 @@ Use a common Cursor MCP config file pattern such as:
 
 If your team shares the setup, keep the config in version control when appropriate.
 
-Install the server globally once:
+Install the server once:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
 
 ```bash
 npm install -g @zereight/mcp-gitlab

--- a/docs/clients/json-clients.md
+++ b/docs/clients/json-clients.md
@@ -10,7 +10,13 @@ Different clients use different top-level schemas and file locations.
 
 Because those client-specific schemas can vary, this guide does **not** assume a single exact file path or wrapper format. Instead, it gives you reusable server blocks for `@zereight/mcp-gitlab` that you can place inside the client's MCP configuration structure.
 
-Install the server globally once:
+Install the server once:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
 
 ```bash
 npm install -g @zereight/mcp-gitlab

--- a/docs/clients/vscode.md
+++ b/docs/clients/vscode.md
@@ -11,7 +11,13 @@ VS Code supports two MCP configuration locations:
 
 Use workspace config when you want to share the MCP server with your team.
 
-Install the server globally once:
+Install the server once:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
 
 ```bash
 npm install -g @zereight/mcp-gitlab

--- a/docs/getting-started/cli-arguments.md
+++ b/docs/getting-started/cli-arguments.md
@@ -6,7 +6,13 @@ instead.
 
 CLI arguments take precedence over environment variables.
 
-Install the server globally once:
+Install the server once:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
 
 ```bash
 npm install -g @zereight/mcp-gitlab

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,12 @@ Install the server globally once:
 npm install -g @zereight/mcp-gitlab
 ```
 
+Or with Homebrew:
+
+```bash
+brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
 The examples use `zereight-mcp-gitlab`, a less collision-prone alias for the legacy `mcp-gitlab` binary. If your MCP client cannot find it, use the absolute path from `which zereight-mcp-gitlab`.
 
 No global install? Pin `npx` to the previous stable release (the version these docs recommend), for example `npx -y @zereight/mcp-gitlab@2.1.28`. If you always want the newest release, use `npx -y @zereight/mcp-gitlab@latest` instead.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,16 +29,16 @@ from any MCP-compatible AI client.
 Pick the auth method that fits your environment and drop it into your MCP
 client config.
 
-Install the server globally once:
-
-```bash
-npm install -g @zereight/mcp-gitlab
-```
-
-Or with Homebrew:
+Install the server once:
 
 ```bash
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
+```
+
+Or with npm:
+
+```bash
+npm install -g @zereight/mcp-gitlab
 ```
 
 The examples use `zereight-mcp-gitlab`, a less collision-prone alias for the legacy `mcp-gitlab` binary. If your MCP client cannot find it, use the absolute path from `which zereight-mcp-gitlab`.

--- a/index.ts
+++ b/index.ts
@@ -13609,7 +13609,7 @@ async function runServer() {
         if (latestVersion) {
           logger.warn(
             `A newer version of @zereight/mcp-gitlab is available: v${latestVersion} (current: v${SERVER_VERSION}). ` +
-              `Upgrade with \`npx -y @zereight/mcp-gitlab@latest\` or \`npm install -g @zereight/mcp-gitlab\`. ` +
+              `Upgrade with \`brew upgrade zereight-mcp-gitlab\`, \`npx -y @zereight/mcp-gitlab@latest\`, or \`npm install -g @zereight/mcp-gitlab\`. ` +
               `Set GITLAB_DISABLE_VERSION_CHECK=true to disable this check.`
           );
         }

--- a/scripts/sync-homebrew-formula.sh
+++ b/scripts/sync-homebrew-formula.sh
@@ -3,13 +3,32 @@ set -euo pipefail
 
 FORMULA_PATH="Formula/zereight-mcp-gitlab.rb"
 VERSION=$(node -p "require('./package.json').version")
-TARBALL_URL="https://registry.npmjs.org/@zereight/mcp-gitlab/-/mcp-gitlab-${VERSION}.tgz"
+METADATA_URL="https://registry.npmjs.org/@zereight/mcp-gitlab/${VERSION}"
 
-if ! SHA256=$(curl -fsSL "$TARBALL_URL" | shasum -a 256 | awk '{print $1}'); then
-  echo "Error: failed to download npm tarball for @zereight/mcp-gitlab@${VERSION}."
+if ! METADATA=$(curl -fsSL "$METADATA_URL"); then
+  echo "Error: failed to fetch npm metadata for @zereight/mcp-gitlab@${VERSION}."
   echo "Publish to npm first, then rerun this script."
   exit 1
 fi
+
+TARBALL_URL=$(node -e "const dist=JSON.parse(process.argv[1]).dist; if (!dist?.tarball || !dist?.shasum) process.exit(1); console.log(dist.tarball)" "$METADATA")
+EXPECTED_SHASUM=$(node -e "console.log(JSON.parse(process.argv[1]).dist.shasum)" "$METADATA")
+
+tmp_tarball=$(mktemp)
+trap 'rm -f "$tmp_tarball"' EXIT
+
+if ! curl -fsSL "$TARBALL_URL" -o "$tmp_tarball"; then
+  echo "Error: failed to download npm tarball for @zereight/mcp-gitlab@${VERSION}."
+  exit 1
+fi
+
+ACTUAL_SHASUM=$(shasum -a 1 "$tmp_tarball" | awk '{print $1}')
+if [ "$ACTUAL_SHASUM" != "$EXPECTED_SHASUM" ]; then
+  echo "Error: npm tarball shasum mismatch for @zereight/mcp-gitlab@${VERSION}."
+  exit 1
+fi
+
+SHA256=$(shasum -a 256 "$tmp_tarball" | awk '{print $1}')
 
 mkdir -p "$(dirname "$FORMULA_PATH")"
 

--- a/scripts/sync-homebrew-formula.sh
+++ b/scripts/sync-homebrew-formula.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FORMULA_PATH="Formula/zereight-mcp-gitlab.rb"
+VERSION=$(node -p "require('./package.json').version")
+TARBALL_URL="https://registry.npmjs.org/@zereight/mcp-gitlab/-/mcp-gitlab-${VERSION}.tgz"
+
+if ! SHA256=$(curl -fsSL "$TARBALL_URL" | shasum -a 256 | awk '{print $1}'); then
+  echo "Error: failed to download npm tarball for @zereight/mcp-gitlab@${VERSION}."
+  echo "Publish to npm first, then rerun this script."
+  exit 1
+fi
+
+mkdir -p "$(dirname "$FORMULA_PATH")"
+
+cat >"$FORMULA_PATH" <<EOF
+class ZereightMcpGitlab < Formula
+  desc "GitLab Model Context Protocol server for AI clients"
+  homepage "https://github.com/zereight/gitlab-mcp"
+  url "$TARBALL_URL"
+  sha256 "$SHA256"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    ENV["GITLAB_PERSONAL_ACCESS_TOKEN"] = "homebrew-test-token"
+
+    json = <<~JSON
+      {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"homebrew","version":"#{version}"}}}
+      {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+    JSON
+
+    output = pipe_output(bin/"zereight-mcp-gitlab", json, 0)
+    assert_match "better-gitlab-mcp-server", output
+  end
+end
+EOF
+
+echo "Updated $FORMULA_PATH for @zereight/mcp-gitlab@${VERSION}"


### PR DESCRIPTION
## Summary
- Add a repo-local Homebrew formula (`Formula/zereight-mcp-gitlab.rb`) that installs the published npm tarball with `depends_on "node"`.
- Add `scripts/sync-homebrew-formula.sh` to refresh formula `url`/`sha256` from the npm registry after each release.
- Run formula sync in CI after the existing NPM Publish workflow succeeds, then auto-commit the updated formula.
- Document `brew install zereight/gitlab-mcp/zereight-mcp-gitlab` in READMEs and docs.

## How it works
1. `brew tap zereight/gitlab-mcp` clones this repo as a tap (`homebrew-gitlab-mcp`).
2. The formula downloads `@zereight/mcp-gitlab` from the npm registry (same artifact as `npm install -g`).
3. Homebrew runs `npm install` into `libexec` and symlinks `zereight-mcp-gitlab` / `mcp-gitlab` into `bin`.
4. On release, npm publish runs first; when it succeeds, the Homebrew workflow downloads the new tarball, updates `sha256`, and commits.

## Test plan
- [ ] `brew tap zereight/gitlab-mcp`
- [ ] `brew install zereight/gitlab-mcp/zereight-mcp-gitlab`
- [ ] `brew test zereight/gitlab-mcp/zereight-mcp-gitlab`
- [ ] `zereight-mcp-gitlab` is on PATH and MCP clients can launch it


Made with [Cursor](https://cursor.com)