### PR TITLE
fix: slim get_merge_request and get_issue responses to cut token usage

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -122,7 +122,7 @@ MR lifecycle — create, update, merge, approve, plus diff/conflict inspection a
 | [`list_branches`](merge-requests.md#list_branches) | List branches in project with search filter | 📖 |
 | [`get_merge_request_conflicts`](merge-requests.md#get_merge_request_conflicts) | Get the conflicts of a merge request | 📖 |
 | [`list_merge_request_pipelines`](merge-requests.md#list_merge_request_pipelines) | List pipelines for a merge request with pagination | 📖 |
-| [`get_merge_request`](merge-requests.md#get_merge_request) | Get details of a merge request (mergeRequestIid or branchName required) | 📖 |
+| [`get_merge_request`](merge-requests.md#get_merge_request) | Get details of a merge request (mergeRequestIid or branchName required). Set include_summaries=true for deployment/commit/approval summaries | 📖 |
 | [`get_merge_request_diffs`](merge-requests.md#get_merge_request_diffs) | Get the changes/diffs of a merge request (mergeRequestIid or branchName required) | 📖 |
 | [`list_merge_request_changed_files`](merge-requests.md#list_merge_request_changed_files) | List changed file paths in a merge request without diff content (mergeRequestIid or branchName required) | 📖 |
 | [`list_merge_request_diffs`](merge-requests.md#list_merge_request_diffs) | List merge request diffs with pagination (mergeRequestIid or branchName required) | 📖 |
@@ -167,7 +167,7 @@ Issue CRUD, links, discussions and notes, todos, and emoji reactions. *(24 tools
 | [`create_issue`](issues.md#create_issue) | Create a new issue | ✏️ |
 | [`list_issues`](issues.md#list_issues) | List issues (default: created by current user; use scope='all' for all) | 📖 |
 | [`my_issues`](issues.md#my_issues) | List issues assigned to the authenticated user | 📖 |
-| [`get_issue`](issues.md#get_issue) | Get details of a specific issue | 📖 |
+| [`get_issue`](issues.md#get_issue) | Get details of a specific issue. Returns a slim milestone by default; set full_response=true for the complete milestone object | 📖 |
 | [`update_issue`](issues.md#update_issue) | Update an issue. Returns a slim confirmation by default; set full_response=true for the complete updated issue object | ✏️ |
 | [`update_issue_description_patch`](issues.md#update_issue_description_patch) | Apply a patch (search/replace or unified diff) to an issue description. Reduces token usage by allowing small changes without sending the full description. Supports dry_run to preview changes and create_note to summarize updates. | ✏️ |
 | [`delete_issue`](issues.md#delete_issue) | Delete an issue | ✏️ |

--- a/docs/tools/issues.md
+++ b/docs/tools/issues.md
@@ -108,7 +108,7 @@ List issues assigned to the authenticated user
 
 *📖 Read-only*
 
-Get details of a specific issue
+Get details of a specific issue. Returns a slim milestone by default; set full_response=true for the complete milestone object
 
 **Parameters**
 
@@ -116,6 +116,7 @@ Get details of a specific issue
 |---|---|:-:|---|
 | `project_id` | string | ✓ | Project ID or URL-encoded path |
 | `issue_iid` | string | ✓ | The internal ID of the project issue |
+| `full_response` | boolean |  | If true, return the complete issue object including the full milestone description. Default returns a slim milestone (id, iid, title, state, web_url) to reduce token usage. |
 
 ### `update_issue`
 

--- a/docs/tools/merge-requests.md
+++ b/docs/tools/merge-requests.md
@@ -170,7 +170,7 @@ List pipelines for a merge request with pagination
 
 *📖 Read-only*
 
-Get details of a merge request (mergeRequestIid or branchName required)
+Get details of a merge request (mergeRequestIid or branchName required). Set include_summaries=true for deployment/commit/approval summaries
 
 **Parameters**
 
@@ -179,6 +179,7 @@ Get details of a merge request (mergeRequestIid or branchName required)
 | `project_id` | string | ✓ | Project ID or complete URL-encoded path to project |
 | `merge_request_iid` | string |  | The IID of a merge request |
 | `source_branch` | string |  | Source branch name |
+| `include_summaries` | boolean |  | If true, include deployment_summary, commit_addition_summary and approval_summary (extra API calls, larger response). Default false to reduce token usage. |
 
 ### `get_merge_request_diffs`
 

--- a/index.ts
+++ b/index.ts
@@ -9896,6 +9896,11 @@ async function handleToolCall(params: any) {
           args.merge_request_iid,
           args.source_branch
         );
+        if (!args.include_summaries) {
+          return {
+            content: [{ type: "text", text: JSON.stringify(mergeRequest) }],
+          };
+        }
         const deploymentSummary = await buildMergeRequestDeploymentSummary(
           args.project_id,
           mergeRequest
@@ -10416,8 +10421,21 @@ async function handleToolCall(params: any) {
       case "get_issue": {
         const args = GetIssueSchema.parse(params.arguments);
         const issue = await getIssue(args.project_id, args.issue_iid);
+        const responseBody =
+          args.full_response || !issue.milestone
+            ? issue
+            : {
+                ...issue,
+                milestone: {
+                  id: issue.milestone.id,
+                  iid: issue.milestone.iid,
+                  title: issue.milestone.title,
+                  state: issue.milestone.state,
+                  web_url: issue.milestone.web_url,
+                },
+              };
         return {
-          content: [{ type: "text", text: JSON.stringify(issue) }],
+          content: [{ type: "text", text: JSON.stringify(responseBody) }],
         };
       }
 

--- a/schemas.ts
+++ b/schemas.ts
@@ -1904,7 +1904,15 @@ export const GetBranchDiffsSchema = ProjectParamsSchema.extend({
     ),
 });
 
-export const GetMergeRequestSchema = ProjectParamsSchema.extend({
+const flexibleBooleanOptional = z.preprocess(val => {
+  if (typeof val !== "string") return val;
+  const normalized = val.trim().toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return val;
+}, z.boolean().optional());
+
+const MergeRequestParamsSchema = ProjectParamsSchema.extend({
   project_id: z
     .preprocess(
       value => (value === undefined || value === null ? value : String(value)),
@@ -1921,7 +1929,13 @@ export const GetMergeRequestSchema = ProjectParamsSchema.extend({
   source_branch: z.string().optional().describe("Source branch name"),
 });
 
-export const UpdateMergeRequestSchema = GetMergeRequestSchema.extend({
+export const GetMergeRequestSchema = MergeRequestParamsSchema.extend({
+  include_summaries: flexibleBooleanOptional.describe(
+    "If true, include deployment_summary, commit_addition_summary and approval_summary (extra API calls, larger response). Default false to reduce token usage."
+  ),
+});
+
+export const UpdateMergeRequestSchema = MergeRequestParamsSchema.extend({
   title: z.string().optional().describe("The title of the merge request"),
   description: z.string().optional().describe("The description of the merge request"),
   target_branch: z.string().optional().describe("The target branch"),
@@ -2087,7 +2101,7 @@ export const ListMergeRequestPipelinesSchema = ProjectParamsSchema.extend({
     .describe("The internal ID of the merge request"),
 }).merge(PaginationOptionsSchema);
 
-export const GetMergeRequestDiffsSchema = GetMergeRequestSchema.extend({
+export const GetMergeRequestDiffsSchema = MergeRequestParamsSchema.extend({
   view: z.enum(["inline", "parallel"]).optional().describe("Diff view type"),
   excluded_file_patterns: z
     .array(z.string())
@@ -2097,7 +2111,7 @@ export const GetMergeRequestDiffsSchema = GetMergeRequestSchema.extend({
     ),
 });
 
-export const ListMergeRequestDiffsSchema = GetMergeRequestSchema.extend({
+export const ListMergeRequestDiffsSchema = MergeRequestParamsSchema.extend({
   page: z.coerce.number().optional().describe("Page number for pagination (default: 1)"),
   per_page: z.coerce
     .number()
@@ -2111,14 +2125,14 @@ export const ListMergeRequestDiffsSchema = GetMergeRequestSchema.extend({
     ),
 });
 
-export const ListMergeRequestChangedFilesSchema = GetMergeRequestSchema.extend({
+export const ListMergeRequestChangedFilesSchema = MergeRequestParamsSchema.extend({
   excluded_file_patterns: z
     .array(z.string())
     .optional()
     .describe('Array of regex patterns to exclude files. Examples: ["^vendor/", "\\.pb\\.go$"]'),
 });
 
-export const GetMergeRequestFileDiffSchema = GetMergeRequestSchema.extend({
+export const GetMergeRequestFileDiffSchema = MergeRequestParamsSchema.extend({
   file_paths: z
     .array(z.string())
     .describe(
@@ -2333,6 +2347,9 @@ export const ListMergeRequestsSchema = z
 export const GetIssueSchema = z.object({
   project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
   issue_iid: z.coerce.string().describe("The internal ID of the project issue"),
+  full_response: flexibleBooleanOptional.describe(
+    "If true, return the complete issue object including the full milestone description. Default returns a slim milestone (id, iid, title, state, web_url) to reduce token usage."
+  ),
 });
 
 export const UpdateIssueSchema = z.object({
@@ -2360,17 +2377,9 @@ export const UpdateIssueSchema = z.object({
       z.enum(["issue", "incident", "test_case", "task"]).optional()
     )
     .describe("The type of issue. One of issue, incident, test_case or task."),
-  full_response: z
-    .preprocess(val => {
-      if (typeof val !== "string") return val;
-      const normalized = val.trim().toLowerCase();
-      if (normalized === "true") return true;
-      if (normalized === "false") return false;
-      return val;
-    }, z.boolean().optional())
-    .describe(
-      "If true, return the complete updated issue object. Default returns a slim confirmation (iid, title, state, web_url, updated_at) to reduce token usage."
-    ),
+  full_response: flexibleBooleanOptional.describe(
+    "If true, return the complete updated issue object. Default returns a slim confirmation (iid, title, state, web_url, updated_at) to reduce token usage."
+  ),
 });
 
 export const DeleteIssueSchema = z.object({

--- a/test/test-deployment-tools.ts
+++ b/test/test-deployment-tools.ts
@@ -395,10 +395,42 @@ describe("deployment and environment tools", () => {
     assert.strictEqual(result.state, "available");
   });
 
-  test("get_merge_request returns compact deployment summary sorted by created_at desc", async () => {
+  test("get_merge_request omits summaries by default", async () => {
     const result = await callTool(
       "get_merge_request",
       { project_id: TEST_PROJECT_ID, merge_request_iid: TEST_MERGE_REQUEST_IID },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+      }
+    );
+
+    assert.strictEqual(result.iid, TEST_MERGE_REQUEST_IID);
+    assert.strictEqual(
+      result.deployment_summary,
+      undefined,
+      "deployment_summary should be omitted by default"
+    );
+    assert.strictEqual(
+      result.commit_addition_summary,
+      undefined,
+      "commit_addition_summary should be omitted by default"
+    );
+    assert.strictEqual(
+      result.approval_summary,
+      undefined,
+      "approval_summary should be omitted by default"
+    );
+  });
+
+  test("get_merge_request returns compact deployment summary sorted by created_at desc", async () => {
+    const result = await callTool(
+      "get_merge_request",
+      {
+        project_id: TEST_PROJECT_ID,
+        merge_request_iid: TEST_MERGE_REQUEST_IID,
+        include_summaries: true,
+      },
       {
         GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
         GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,

--- a/test/test-update-issue-slim.ts
+++ b/test/test-update-issue-slim.ts
@@ -130,4 +130,47 @@ describe("update_issue slim response", () => {
     assert.strictEqual(data.title, "Updated title");
     assert.strictEqual(data.full_response, undefined, "full_response must not leak into the issue");
   });
+
+  test("get_issue slims the milestone by default", async () => {
+    const result = await client.callTool("get_issue", {
+      project_id: "test/project",
+      issue_iid: "100",
+    });
+    const data = JSON.parse((result.content as any)[0]?.text || "{}");
+
+    assert.ok(data.milestone, "milestone should be present");
+    assert.strictEqual(data.milestone.title, "Sprint 42");
+    assert.ok(data.milestone.web_url, "milestone web_url should be present");
+    assert.strictEqual(
+      data.milestone.description,
+      undefined,
+      "milestone description must not be echoed by default"
+    );
+    assert.ok(data.description, "issue description should still be present");
+  });
+
+  test("get_issue full_response=true returns the full milestone", async () => {
+    const result = await client.callTool("get_issue", {
+      project_id: "test/project",
+      issue_iid: "100",
+      full_response: true,
+    });
+    const data = JSON.parse((result.content as any)[0]?.text || "{}");
+
+    assert.ok(data.milestone, "milestone should be present");
+    assert.ok(
+      typeof data.milestone.description === "string" && data.milestone.description.length > 0,
+      "milestone description should be included with full_response"
+    );
+  });
+
+  test("get_issue without milestone is unaffected", async () => {
+    const result = await client.callTool("get_issue", {
+      project_id: "test/project",
+      issue_iid: "6",
+    });
+    const data = JSON.parse((result.content as any)[0]?.text || "{}");
+    assert.strictEqual(data.milestone, null);
+    assert.strictEqual(data.iid, "6");
+  });
 });

--- a/test/utils/mock-gitlab-server.ts
+++ b/test/utils/mock-gitlab-server.ts
@@ -393,7 +393,17 @@ export class MockGitLabServer {
           },
           assignees: [],
           labels: [],
-          milestone: null,
+          milestone:
+            issueIid === 100
+              ? {
+                  id: 42,
+                  iid: 7,
+                  title: "Sprint 42",
+                  description: "A very long milestone description ".repeat(50),
+                  state: "active",
+                  web_url: `https://gitlab.mock/project/${projectId}/milestones/7`,
+                }
+              : null,
         });
       }
     );

--- a/tools/registry.ts
+++ b/tools/registry.ts
@@ -348,7 +348,8 @@ export const allTools = [
   },
   {
     name: "get_merge_request",
-    description: "Get details of a merge request (mergeRequestIid or branchName required)",
+    description:
+      "Get details of a merge request (mergeRequestIid or branchName required). Set include_summaries=true for deployment/commit/approval summaries",
     inputSchema: toJSONSchema(GetMergeRequestSchema),
   },
   {
@@ -570,7 +571,8 @@ export const allTools = [
   },
   {
     name: "get_issue",
-    description: "Get details of a specific issue",
+    description:
+      "Get details of a specific issue. Returns a slim milestone by default; set full_response=true for the complete milestone object",
     inputSchema: toJSONSchema(GetIssueSchema),
   },
   {


### PR DESCRIPTION
## Summary

Fixes #563 — "GitLab MCP includes large, unrequested payloads".

A user benchmark ([comment](https://github.com/zereight/gitlab-mcp/issues/563#issuecomment-4878890929)) measured ~98% token reduction when field-selected reads are used instead of the full payloads these tools return today. This PR makes the two remaining offenders slim by default, following the same opt-in pattern `update_issue` already uses (`full_response`).

## Changes

### `get_merge_request`
- `deployment_summary`, `commit_addition_summary` and `approval_summary` are now **opt-in** via `include_summaries: true`
- Default response returns the plain MR object — saving ~4,200 tokens per call **and** skipping the extra GitLab API calls (deployments, commits, approval state) entirely
- The new param lives only on `GetMergeRequestSchema`; `update_merge_request` and the diff/changed-files schemas now extend a shared base so the flag can't leak into API request bodies

### `get_issue`
- `milestone` is slimmed to `{id, iid, title, state, web_url}` by default (drops the milestone description echo, ~1,500 tokens per call)
- `full_response: true` returns the complete issue object unchanged
- Issues without a milestone are unaffected

## Tests
- `test/test-deployment-tools.ts`: new default-omission test; summary assertions now pass `include_summaries: true`
- `test/test-update-issue-slim.ts`: new `get_issue` tests for slim milestone, `full_response=true`, and null-milestone passthrough (mock server serves a milestone-bearing issue at iid 100)
- `npm run test:mock` (486 tests), `npm run test:schema`, oauth tests all green

## Breaking change note
Consumers relying on the embedded MR summaries must now pass `include_summaries: true`. Given the issue explicitly reports these as unrequested payloads (120–180k tokens/session), slim-by-default matches the MCP context-cost model; tool descriptions document the flag.