### PR TITLE
docs: document MCP rate limits and shared deployment tuning

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -269,7 +269,7 @@ MCP 클라이언트 설정:
 | `GITLAB_ALLOWED_HOSTS`                                           | 선택 | 허용할 `X-GitLab-API-URL` 호스트의 쉼표 구분 목록; `GITLAB_API_URL` 호스트는 항상 허용                                  |
 | `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY`                    | 선택 | 인증 없이 `initialize`, `notifications/initialized`, `tools/list`만 허용(도구 호출은 여전히 인증 필요)                  |
 | `MCP_SERVER_URL` / `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` | 선택 | DNS rebinding 방지를 위한 허용 `/mcp` 호스트/오리진 값                                                                  |
-| `MCP_TRUST_PROXY`                                                | 선택 | 리버스 프록시 뒤에서 `Forwarded` / `X-Forwarded-*` 헤더 신뢰(다운로드 URL, Express `req.ip`, OAuth rate limit) |
+| `MCP_TRUST_PROXY`                                                | 선택 | 리버스 프록시 뒤에서 `Forwarded` / `X-Forwarded-*` 헤더 신뢰(다운로드 URL, Express `req.ip`, `/mcp` IP rate limit, OAuth rate limit) |
 
 `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY=true`는 사용자가 GitLab 토큰을 제공하기 전에 도구 메타데이터를 조회해야 하는 MCP 게이트웨이나 관리 UI용입니다. 배포 환경에서 도구 목록 공개가 안전한 경우가 아니면 비활성화하세요.
 
@@ -299,7 +299,7 @@ Authorization: Bearer glpat-xxxxxxxxxxxxxxxxxxxx
 
 - **로컬 PAT**: `GITLAB_PERSONAL_ACCESS_TOKEN`, `GITLAB_API_URL`
 - **로컬 OAuth**: `GITLAB_USE_OAUTH=true`, `GITLAB_OAUTH_CLIENT_ID`, `GITLAB_OAUTH_REDIRECT_URI`, `GITLAB_API_URL`
-- **원격 멀티 유저 HTTP**: `STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true`, `HOST`, `PORT`
+- **원격 멀티 유저 HTTP**: `STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true`(또는 `GITLAB_MCP_OAUTH=true`), `MCP_TRUST_PROXY=true`(리버스 프록시 뒤), `MAX_REQUESTS_PER_MINUTE=300`, `MCP_SERVER_URL` 또는 `MCP_ALLOWED_HOSTS`, `HOST`, `PORT`
 - **멀티 Pod HPA (stateless)**: 위 설정 + `OAUTH_STATELESS_MODE=true`, `OAUTH_STATELESS_SECRET`(모든 Pod에서 동일). [Stateless Mode](./docs/configuration/stateless-mode.md) 참고.
 
 자주 참조하는 변수:
@@ -309,6 +309,8 @@ Authorization: Bearer glpat-xxxxxxxxxxxxxxxxxxxx
 - `GITLAB_USE_OAUTH`
 - `REMOTE_AUTHORIZATION`
 - `MCP_TRUST_PROXY`
+- `MAX_REQUESTS_PER_MINUTE`
+- `MAX_SESSIONS`
 - `MCP_ALLOWED_HOSTS`
 - `MCP_ALLOWED_ORIGINS`
 - `GITLAB_MCP_OAUTH`

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ the token to GitLab on behalf of the caller.
 | `GITLAB_ALLOWED_HOSTS`                        | optional | Comma-separated allowed `X-GitLab-API-URL` hosts; `GITLAB_API_URL` hosts are always allowed                             |
 | `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY` | optional | Allow unauthenticated `initialize`, `notifications/initialized`, and `tools/list` only (tool calls still require auth)  |
 | `MCP_SERVER_URL` / `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` | optional | Allowed public `/mcp` host/origin values for DNS rebinding protection                                   |
-| `MCP_TRUST_PROXY`                             | optional | Trust `Forwarded` / `X-Forwarded-*` headers behind a reverse proxy (download URLs, Express `req.ip`, OAuth rate limits) |
+| `MCP_TRUST_PROXY`                             | optional | Trust `Forwarded` / `X-Forwarded-*` headers behind a reverse proxy (download URLs, Express `req.ip`, `/mcp` IP rate limits, OAuth rate limits) |
 
 `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY=true` is intended for MCP gateways
 or admin UIs that need to inspect tool metadata before a user provides a GitLab
@@ -331,7 +331,7 @@ Most users only need one of these starting sets:
 
 - **Local PAT**: `GITLAB_PERSONAL_ACCESS_TOKEN`, `GITLAB_API_URL`
 - **Local OAuth**: `GITLAB_USE_OAUTH=true`, `GITLAB_OAUTH_CLIENT_ID`, `GITLAB_OAUTH_REDIRECT_URI`, `GITLAB_API_URL`
-- **Remote multi-user HTTP**: `STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true`, `HOST`, `PORT`
+- **Remote multi-user HTTP**: `STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true` (or `GITLAB_MCP_OAUTH=true`), `MCP_TRUST_PROXY=true` (behind a reverse proxy), `MAX_REQUESTS_PER_MINUTE=300`, `MCP_SERVER_URL` or `MCP_ALLOWED_HOSTS`, `HOST`, `PORT`
 - **Multi-pod HPA (stateless)**: above + `OAUTH_STATELESS_MODE=true`, `OAUTH_STATELESS_SECRET` (same across all pods). See [Stateless Mode](./docs/configuration/stateless-mode.md).
 
 Commonly referenced variables:
@@ -341,6 +341,8 @@ Commonly referenced variables:
 - `GITLAB_USE_OAUTH`
 - `REMOTE_AUTHORIZATION`
 - `MCP_TRUST_PROXY`
+- `MAX_REQUESTS_PER_MINUTE`
+- `MAX_SESSIONS`
 - `MCP_ALLOWED_HOSTS`
 - `MCP_ALLOWED_ORIGINS`
 - `GITLAB_MCP_OAUTH`
@@ -419,7 +421,7 @@ The token is stored per session (identified by `mcp-session-id` header) and reus
   Tokens are automatically cleaned up when sessions close
 - **Session timeout:** Auth tokens expire after `SESSION_TIMEOUT_SECONDS` (default 1 hour) of inactivity. After timeout, the client must send auth headers again. The transport session remains active.
 - Each request resets the timeout timer for that session
-- **Rate limiting:** Each session is limited to `MAX_REQUESTS_PER_MINUTE` requests per minute (default 60)
+- **Rate limiting:** `/mcp` requests are limited to `MAX_REQUESTS_PER_MINUTE` per client IP, and per MCP session when using OAuth or remote authorization (default 60). See [environment-variables.md](docs/configuration/environment-variables.md#max_requests_per_minute).
 - **Capacity limit:** Server accepts up to `MAX_SESSIONS` concurrent sessions (default 1000)
 
 ### MCP OAuth Setup (Claude.ai Native OAuth)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -269,7 +269,7 @@ MCP 客户端配置：
 | `GITLAB_ALLOWED_HOSTS`                                           | 可选 | 允许的 `X-GitLab-API-URL` 主机逗号分隔列表；`GITLAB_API_URL` 中的主机始终允许                                          |
 | `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY`                    | 可选 | 仅允许未认证的 `initialize`、`notifications/initialized`、`tools/list`（工具调用仍需认证）                                |
 | `MCP_SERVER_URL` / `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` | 可选 | 用于 DNS rebinding 防护的允许 `/mcp` 主机/来源值                                                                        |
-| `MCP_TRUST_PROXY`                                                | 可选 | 在反向代理后信任 `Forwarded` / `X-Forwarded-*` 请求头（下载 URL、Express `req.ip`、OAuth 速率限制）                      |
+| `MCP_TRUST_PROXY`                                                | 可选 | 在反向代理后信任 `Forwarded` / `X-Forwarded-*` 请求头（下载 URL、Express `req.ip`、`/mcp` IP 速率限制、OAuth 速率限制） |
 
 `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY=true` 适用于在用户提供 GitLab token 之前需要检查工具元数据的 MCP 网关或管理 UI。除非你的部署可以安全地暴露工具列表，否则请保持禁用。
 
@@ -299,7 +299,7 @@ Authorization: Bearer glpat-xxxxxxxxxxxxxxxxxxxx
 
 - **本地 PAT**：`GITLAB_PERSONAL_ACCESS_TOKEN`, `GITLAB_API_URL`
 - **本地 OAuth**：`GITLAB_USE_OAUTH=true`, `GITLAB_OAUTH_CLIENT_ID`, `GITLAB_OAUTH_REDIRECT_URI`, `GITLAB_API_URL`
-- **远程多用户 HTTP**：`STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true`, `HOST`, `PORT`
+- **远程多用户 HTTP**：`STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true`（或 `GITLAB_MCP_OAUTH=true`）, `MCP_TRUST_PROXY=true`（反向代理后）, `MAX_REQUESTS_PER_MINUTE=300`, `MCP_SERVER_URL` 或 `MCP_ALLOWED_HOSTS`, `HOST`, `PORT`
 - **多 Pod HPA（stateless）**：上述配置 + `OAUTH_STATELESS_MODE=true`, `OAUTH_STATELESS_SECRET`（所有 Pod 相同）。参见 [Stateless Mode](./docs/configuration/stateless-mode.md)。
 
 常用变量：
@@ -309,6 +309,8 @@ Authorization: Bearer glpat-xxxxxxxxxxxxxxxxxxxx
 - `GITLAB_USE_OAUTH`
 - `REMOTE_AUTHORIZATION`
 - `MCP_TRUST_PROXY`
+- `MAX_REQUESTS_PER_MINUTE`
+- `MAX_SESSIONS`
 - `MCP_ALLOWED_HOSTS`
 - `MCP_ALLOWED_ORIGINS`
 - `GITLAB_MCP_OAUTH`

--- a/docs/configuration/dynamic-api-url.md
+++ b/docs/configuration/dynamic-api-url.md
@@ -279,9 +279,12 @@ JSON response:
 
 ### Rate Limiting
 
-- Each session is subject to rate limiting (`MAX_REQUESTS_PER_MINUTE`)
+- `/mcp` requests are limited per client IP (`MAX_REQUESTS_PER_MINUTE`, default 60)
+- OAuth and remote-authorization sessions have an additional per-session limit (same env var)
+- Download proxy routes (`/downloads/*`) are limited per auth token (same env var)
+- Behind a reverse proxy, set `MCP_TRUST_PROXY=true` so the IP limit keys on real clients
 - The connection pool has a maximum size (`GITLAB_POOL_MAX_SIZE`)
-- Requests are rejected when limits are exceeded
+- Requests are rejected with HTTP 429 when limits are exceeded
 
 ### SSL/TLS
 
@@ -306,8 +309,9 @@ JSON response:
    - Wait for idle connections to be cleaned up or increase `GITLAB_POOL_MAX_SIZE`
 
 4. **"Rate limit exceeded"**
-   - You've exceeded `MAX_REQUESTS_PER_MINUTE` for your session
-   - Wait for the rate limit window to reset (1 minute)
+   - You've exceeded `MAX_REQUESTS_PER_MINUTE` for your client IP, MCP session, or download token
+   - Behind a shared proxy without `MCP_TRUST_PROXY=true`, all users share one IP bucket
+   - Wait for the rate limit window to reset (1 minute), or raise the limit and enable `MCP_TRUST_PROXY`
 
 ### Debug Logging
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -222,6 +222,10 @@ Effects when enabled:
   `X-Forwarded-For` values that include a source port (for example
   `1.2.3.4:5678` or `[2001:db8::1]:5678`) before `express-rate-limit` keys
   requests on `/authorize`, `/token`, `/register`, and `/revoke`.
+- **`/mcp` rate limiting** (Streamable HTTP): keys `POST` and `DELETE /mcp`
+  requests by the real client IP instead of the reverse-proxy IP. Required for
+  shared deployments behind a single egress IP so each user gets their own
+  `MAX_REQUESTS_PER_MINUTE` bucket.
 
 Use this only when the proxy is trusted **and** direct client access to the MCP
 server port is blocked. When unset, forwarded headers are ignored for URL
@@ -505,6 +509,46 @@ Default:
 
 - `3002`
 
+### `MAX_REQUESTS_PER_MINUTE`
+
+Maximum requests allowed per rolling 60-second window. Applies to Streamable HTTP
+and SSE remote deployments. Valid range: `1`–`1000`.
+
+Default:
+
+- `60`
+
+This single value is reused in three places (whichever limit is hit first wins):
+
+| Layer | Key | Routes |
+|-------|-----|--------|
+| Express middleware | Client IP | `POST` / `DELETE /mcp` |
+| Session handler | MCP session ID | Existing sessions when `REMOTE_AUTHORIZATION=true` or `GITLAB_MCP_OAUTH=true` |
+| Download proxy | Auth token | `GET /downloads/*` |
+
+When `MCP_TRUST_PROXY` is unset behind a reverse proxy, all clients share one IP
+bucket and the per-IP limit becomes the bottleneck for the whole deployment.
+
+**Shared deployment starting point:** `MCP_TRUST_PROXY=true` with
+`MAX_REQUESTS_PER_MINUTE=300` (raise if `/metrics` shows
+`rejectedByRateLimit` growth). This limits MCP server abuse; GitLab API rate
+limits are separate upstream constraints.
+
+Monitor rejections via `/metrics` → `rejectedByRateLimit` or
+`gitlab_mcp_requests_rejected_total{reason="rate_limit"}`.
+
+### `MAX_SESSIONS`
+
+Maximum concurrent MCP sessions on a single server instance (Streamable HTTP /
+remote authorization / MCP OAuth).
+
+Default:
+
+- `1000`
+
+When the limit is reached, new session creation is rejected until an existing
+session expires or is closed.
+
 ## Network and TLS
 
 ### `HTTP_PROXY`
@@ -548,7 +592,10 @@ Maximum GitLab client pool size.
 ## Remote shared deployment
 
 - `STREAMABLE_HTTP=true`
-- `REMOTE_AUTHORIZATION=true`
+- `REMOTE_AUTHORIZATION=true` or `GITLAB_MCP_OAUTH=true`
+- `MCP_TRUST_PROXY=true` (when behind a reverse proxy)
+- `MAX_REQUESTS_PER_MINUTE=300` (tune from metrics)
+- `MCP_SERVER_URL` or `MCP_ALLOWED_HOSTS` (non-loopback public host)
 - `HOST`
 - `PORT`
 


### PR DESCRIPTION
## Summary
- Document `MAX_REQUESTS_PER_MINUTE` and `MAX_SESSIONS` in the environment variables reference, including the three-layer limit model (client IP, MCP session, download token).
- Clarify that `MCP_TRUST_PROXY` is required behind a reverse proxy so `/mcp` IP rate limits key on real clients instead of a shared proxy IP.
- Align README (en/ko/zh), dynamic API URL docs, and the remote shared deployment checklist with shared-deployment starting values (`MCP_TRUST_PROXY=true`, `MAX_REQUESTS_PER_MINUTE=300`).

## Test plan
- [x] `make docs` (mkdocs build --strict)
- [x] `npm run check:skill-sync`
- [x] Verified README rate-limit bullets and env docs cross-link consistently across en/ko/zh


Made with [Cursor](https://cursor.com)