### PR TITLE
fix: add protected resource metadata for path-suffixed discovery

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12939,6 +12939,23 @@ async function startStreamableHTTPServer(): Promise<void> {
       );
     }
 
+    // RFC 9728 path-suffixed discovery: clients connecting to /mcp will
+    // request /.well-known/oauth-protected-resource/mcp to discover the
+    // resource identifier. Register this route so the resource field matches
+    // the actual transport URL the client connects to - regardless of
+    // whether the server is deployed behind a path-stripping reverse proxy.
+    if (!issuerPath) {
+      const mcpResourceUrl = `${issuerUrl.origin}/mcp`;
+      app.get("/.well-known/oauth-protected-resource/mcp", (_req: Request, res: Response) => {
+        res.json({
+          resource: mcpResourceUrl,
+          authorization_servers: [issuerUrl.href],
+          scopes_supported: scopesSupported,
+          resource_name: "GitLab MCP Server",
+        });
+      });
+    }
+
     // Mounts /.well-known/oauth-authorization-server (shadowed above when basePath set),
     //        /.well-known/oauth-protected-resource, /authorize, /token, /register, /revoke
     // Some proxies include the port in X-Forwarded-For (e.g. "1.2.3.4:5678" or

--- a/test/mcp-oauth-tests.ts
+++ b/test/mcp-oauth-tests.ts
@@ -172,6 +172,29 @@ describe("MCP OAuth — Discovery Endpoints", () => {
     console.log("  ✓ Protected resource metadata returned");
   });
 
+  test("unprefixed MCP_SERVER_URL serves /mcp resource discovery at /.well-known/oauth-protected-resource/mcp", async () => {
+    // When MCP_SERVER_URL has no path, the server registers a dedicated route
+    // at /.well-known/oauth-protected-resource/mcp (RFC 9728 path-suffixed
+    // discovery) so clients connecting to /mcp can discover the resource.
+    const issuerUrl = new URL(mcpBaseUrl);
+
+    const res = await fetch(`${mcpBaseUrl}/.well-known/oauth-protected-resource/mcp`);
+    assert.strictEqual(res.status, 200, "Should return 200");
+
+    const body = (await res.json()) as Record<string, unknown>;
+    assert.strictEqual(
+      body.resource,
+      `${issuerUrl.origin}/mcp`,
+      "resource should be ${origin}/mcp"
+    );
+    assert.deepStrictEqual(
+      body.authorization_servers,
+      [issuerUrl.href],
+      "authorization_servers should contain the issuer URL"
+    );
+    console.log("  ✓ Unprefixed MCP_SERVER_URL: /mcp resource discovery returned correct metadata");
+  });
+
   test("path-prefixed MCP_SERVER_URL serves path-aware discovery metadata", async () => {
     const mockPort = await findMockServerPort();
     const prefixedMockGitLab = new MockGitLabServer({


### PR DESCRIPTION
# Summary

This registers /.well-known/oauth-protected-resource/mcp with resource set to the actual transport URL when MCP_SERVER_URL has no path. No config changes needed, backwards compatible.

## Why this is needed

With the new version of kiro-cli (2.11), we noticed that kiro-cli will not authenticate against the mcp anymore with the following error:

```text
Metadata error: Protected resource metadata resource mismatch:
expected 'https://gitlab-mcp.example.com/mcp', got 'https://gitlab-mcp.example.com/'
```

kiro-cli 2.11 seems to perform RFC 9728 path-suffixed discovery: when connecting to /mcp, it requests /.well-known/oauth-protected-resource/mcp. The server returns 404 for this path when MCP_SERVER_URL has no path component, causing the client to fall back to the root endpoint which returns resource: "https://host/" instead of "https://host/mcp".