### PR TITLE
Make the MCP server name configurable via MCP_SERVER_NAME

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -300,6 +300,7 @@ Authorization: Bearer glpat-xxxxxxxxxxxxxxxxxxxx
 - **로컬 PAT**: `GITLAB_PERSONAL_ACCESS_TOKEN`, `GITLAB_API_URL`
 - **로컬 OAuth**: `GITLAB_USE_OAUTH=true`, `GITLAB_OAUTH_CLIENT_ID`, `GITLAB_OAUTH_REDIRECT_URI`, `GITLAB_API_URL`
 - **원격 멀티 유저 HTTP**: `STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true`(또는 `GITLAB_MCP_OAUTH=true`), `MCP_TRUST_PROXY=true`(리버스 프록시 뒤), `MAX_REQUESTS_PER_MINUTE=300`, `MCP_SERVER_URL` 또는 `MCP_ALLOWED_HOSTS`, `HOST`, `PORT`
+- **여러 배포를 동시에 운영**: 배포마다 `MCP_SERVER_NAME`을 다르게 설정(예: `gitlab-selfhosted-readonly`)하면 클라이언트, 로그, 텔레메트리에서 서로 구분할 수 있습니다
 - **멀티 Pod HPA (stateless)**: 위 설정 + `OAUTH_STATELESS_MODE=true`, `OAUTH_STATELESS_SECRET`(모든 Pod에서 동일). [Stateless Mode](./docs/configuration/stateless-mode.md) 참고.
 
 자주 참조하는 변수:

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Most users only need one of these starting sets:
 - **Local PAT**: `GITLAB_PERSONAL_ACCESS_TOKEN`, `GITLAB_API_URL`
 - **Local OAuth**: `GITLAB_USE_OAUTH=true`, `GITLAB_OAUTH_CLIENT_ID`, `GITLAB_OAUTH_REDIRECT_URI`, `GITLAB_API_URL`
 - **Remote multi-user HTTP**: `STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true` (or `GITLAB_MCP_OAUTH=true`), `MCP_TRUST_PROXY=true` (behind a reverse proxy), `MAX_REQUESTS_PER_MINUTE=300`, `MCP_SERVER_URL` or `MCP_ALLOWED_HOSTS`, `HOST`, `PORT`
+- **Multiple side-by-side deployments**: set a distinct `MCP_SERVER_NAME` per instance (e.g. `gitlab-selfhosted-readonly`) so clients, logs, and telemetry can tell them apart
 - **Multi-pod HPA (stateless)**: above + `OAUTH_STATELESS_MODE=true`, `OAUTH_STATELESS_SECRET` (same across all pods). See [Stateless Mode](./docs/configuration/stateless-mode.md).
 
 Commonly referenced variables:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -300,6 +300,7 @@ Authorization: Bearer glpat-xxxxxxxxxxxxxxxxxxxx
 - **本地 PAT**：`GITLAB_PERSONAL_ACCESS_TOKEN`, `GITLAB_API_URL`
 - **本地 OAuth**：`GITLAB_USE_OAUTH=true`, `GITLAB_OAUTH_CLIENT_ID`, `GITLAB_OAUTH_REDIRECT_URI`, `GITLAB_API_URL`
 - **远程多用户 HTTP**：`STREAMABLE_HTTP=true`, `REMOTE_AUTHORIZATION=true`（或 `GITLAB_MCP_OAUTH=true`）, `MCP_TRUST_PROXY=true`（反向代理后）, `MAX_REQUESTS_PER_MINUTE=300`, `MCP_SERVER_URL` 或 `MCP_ALLOWED_HOSTS`, `HOST`, `PORT`
+- **并行运行多个部署**：为每个实例设置不同的 `MCP_SERVER_NAME`（例如 `gitlab-selfhosted-readonly`），以便在客户端、日志和遥测数据中区分它们
 - **多 Pod HPA（stateless）**：上述配置 + `OAUTH_STATELESS_MODE=true`, `OAUTH_STATELESS_SECRET`（所有 Pod 相同）。参见 [Stateless Mode](./docs/configuration/stateless-mode.md)。
 
 常用变量：

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -509,6 +509,16 @@ Default:
 
 - `3002`
 
+### `MCP_SERVER_NAME`
+
+Name this server advertises to MCP clients during the `initialize` handshake
+(`serverInfo.name`). Set a distinct value to tell multiple GitLab MCP
+deployments apart in client UIs and logs.
+
+Default:
+
+- `better-gitlab-mcp-server`
+
 ### `MAX_REQUESTS_PER_MINUTE`
 
 Maximum requests allowed per rolling 60-second window. Applies to Streamable HTTP

--- a/index.ts
+++ b/index.ts
@@ -596,6 +596,8 @@ try {
   // Intentionally ignored: version read failure is non-critical
 }
 
+const SERVER_NAME = process.env.MCP_SERVER_NAME?.trim() || "better-gitlab-mcp-server";
+
 /**
  * Create a new MCP Server instance with request handlers registered.
  * Each transport connection gets its own Server instance to prevent
@@ -656,7 +658,7 @@ function createServer(): McpServer {
 
   const mcpServer = new McpServer(
     {
-      name: "better-gitlab-mcp-server",
+      name: SERVER_NAME,
       version: SERVER_VERSION,
     },
     {

--- a/test/README.md
+++ b/test/README.md
@@ -101,19 +101,6 @@ Tests for the Zod to JSON Schema conversion extension (`toJSONSchema`).
 npm run test:schema
 ```
 
-### mcp-server-name.test.ts
-Tests for the `MCP_SERVER_NAME` environment variable.
-
-**What it tests:**
-- Defaults to `better-gitlab-mcp-server` when unset
-- Reports the overridden name in the `initialize` handshake's `serverInfo.name` when set
-- Treats a whitespace-only value as unset
-
-**Running the tests:**
-```bash
-node --import tsx/esm --test --experimental-test-isolation=none test/mcp-server-name.test.ts
-```
-
 ## Running All Tests
 
 To run the complete test suite:

--- a/test/README.md
+++ b/test/README.md
@@ -101,6 +101,19 @@ Tests for the Zod to JSON Schema conversion extension (`toJSONSchema`).
 npm run test:schema
 ```
 
+### mcp-server-name.test.ts
+Tests for the `MCP_SERVER_NAME` environment variable.
+
+**What it tests:**
+- Defaults to `better-gitlab-mcp-server` when unset
+- Reports the overridden name in the `initialize` handshake's `serverInfo.name` when set
+- Treats a whitespace-only value as unset
+
+**Running the tests:**
+```bash
+node --import tsx/esm --test --experimental-test-isolation=none test/mcp-server-name.test.ts
+```
+
 ## Running All Tests
 
 To run the complete test suite:

--- a/test/mcp-server-name.test.ts
+++ b/test/mcp-server-name.test.ts
@@ -1,0 +1,115 @@
+import { after, describe, test } from "node:test";
+import assert from "node:assert";
+import {
+  cleanupServers,
+  findAvailablePort,
+  HOST,
+  launchServer,
+  ServerInstance,
+  TransportMode,
+} from "./utils/server-launcher.js";
+
+async function rawMcpRequest(
+  url: string,
+  body: object,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; data: any; text: string }> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream")) {
+    const dataLines = text
+      .split("\n")
+      .filter(line => line.startsWith("data: "))
+      .map(line => line.slice(6));
+    return {
+      status: response.status,
+      data: dataLines.length > 0 ? JSON.parse(dataLines.at(-1)!) : null,
+      text,
+    };
+  }
+
+  return {
+    status: response.status,
+    data: text ? JSON.parse(text) : null,
+    text,
+  };
+}
+
+const initializeBody = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: { name: "server-name-test", version: "1.0.0" },
+  },
+};
+
+let portOffset = 0;
+
+async function launchWithServerName(mcpServerName?: string) {
+  const port = await findAvailablePort(3700 + portOffset++ * 10);
+  const server = await launchServer({
+    mode: TransportMode.STREAMABLE_HTTP,
+    port,
+    timeout: 10_000,
+    env: {
+      STREAMABLE_HTTP: "true",
+      REMOTE_AUTHORIZATION: "true",
+      GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY: "true",
+      GITLAB_API_URL: "https://gitlab.example.com/api/v4",
+      ...(mcpServerName !== undefined ? { MCP_SERVER_NAME: mcpServerName } : {}),
+    },
+  });
+  return { server, mcpUrl: `http://${HOST}:${port}/mcp` };
+}
+
+describe("MCP_SERVER_NAME", { timeout: 20_000 }, () => {
+  let servers: ServerInstance[] = [];
+
+  after(() => {
+    cleanupServers(servers);
+    servers = [];
+  });
+
+  test("defaults to better-gitlab-mcp-server when unset", async () => {
+    const { server, mcpUrl } = await launchWithServerName();
+    servers.push(server);
+
+    const response = await rawMcpRequest(mcpUrl, initializeBody);
+
+    assert.strictEqual(response.status, 200, response.text);
+    assert.strictEqual(response.data?.result?.serverInfo?.name, "better-gitlab-mcp-server");
+  });
+
+  test("reports the overridden name when MCP_SERVER_NAME is set", async () => {
+    const { server, mcpUrl } = await launchWithServerName("gitlab-selfhosted-readonly");
+    servers.push(server);
+
+    const response = await rawMcpRequest(mcpUrl, initializeBody);
+
+    assert.strictEqual(response.status, 200, response.text);
+    assert.strictEqual(response.data?.result?.serverInfo?.name, "gitlab-selfhosted-readonly");
+  });
+
+  test("treats a whitespace-only MCP_SERVER_NAME as unset", async () => {
+    const { server, mcpUrl } = await launchWithServerName("   ");
+    servers.push(server);
+
+    const response = await rawMcpRequest(mcpUrl, initializeBody);
+
+    assert.strictEqual(response.status, 200, response.text);
+    assert.strictEqual(response.data?.result?.serverInfo?.name, "better-gitlab-mcp-server");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `MCP_SERVER_NAME` env var that overrides the `serverInfo.name` the server reports during the MCP `initialize` handshake, defaulting to the existing `better-gitlab-mcp-server` when unset or whitespace-only.
- Lets operators running multiple GitLab MCP instances side by side (e.g. gitlab.com vs. self-hosted, read-only vs. read-write) tell them apart in client UIs, logs, and telemetry.

## Changes
- `index.ts`: resolve `SERVER_NAME` once at startup (same pattern as `SERVER_VERSION`) and use it at the `McpServer` construction site.
- `docs/configuration/environment-variables.md`: document `MCP_SERVER_NAME` under Transport and Server Runtime, alongside `HOST`/`PORT`.
- `README.md`, `README.ko.md`, `README.zh-CN.md`: mention `MCP_SERVER_NAME` in the multi-deployment guidance.
- `test/mcp-server-name.test.ts`: new mock-server test covering the default, the override, and whitespace-only input being treated as unset.

## Test plan
- [x] `npm run build`
- [x] `node --import tsx/esm --test --experimental-test-isolation=none test/mcp-server-name.test.ts` — 3/3 passing
- [x] Manually confirmed `initialize` response `serverInfo.name` matches `better-gitlab-mcp-server` by default and the overridden value when `MCP_SERVER_NAME` is set

Closes #588