### PR TITLE
fix: encode job/pipeline IDs to block path traversal

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7036,7 +7036,7 @@ async function getPipeline(
 ): Promise<GitLabPipeline> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${pipelineId}`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${encodeGitLabPathSegment(pipelineId)}`
   );
 
   const response = await fetch(url.toString(), {
@@ -7187,7 +7187,7 @@ async function listPipelineJobs(
 ): Promise<GitLabPipelineJob[]> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${pipelineId}/jobs`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${encodeGitLabPathSegment(pipelineId)}/jobs`
   );
 
   // Add all query parameters
@@ -7229,7 +7229,7 @@ async function listPipelineTriggerJobs(
 ): Promise<GitLabPipelineTriggerJob[]> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${pipelineId}/bridges`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${encodeGitLabPathSegment(pipelineId)}/bridges`
   );
 
   // Add all query parameters
@@ -7262,7 +7262,7 @@ async function getPipelineJob(
 ): Promise<GitLabPipelineJob> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${jobId}`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${encodeGitLabPathSegment(jobId)}`
   );
 
   const response = await fetch(url.toString(), {
@@ -7297,7 +7297,7 @@ async function getPipelineJobOutput(
 ): Promise<string> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${jobId}/trace`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${encodeGitLabPathSegment(jobId)}/trace`
   );
 
   const response = await fetch(url.toString(), {
@@ -7405,7 +7405,7 @@ async function listJobArtifacts(
 ): Promise<GitLabArtifactEntry[]> {
   projectId = decodeURIComponent(projectId);
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${jobId}/artifacts/tree`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${encodeGitLabPathSegment(jobId)}/artifacts/tree`
   );
 
   Object.entries(options).forEach(([key, value]) => {
@@ -7450,7 +7450,7 @@ async function downloadJobArtifacts(
   const effectiveProjectId = getEffectiveProjectId(projectId);
 
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}/jobs/${jobId}/artifacts`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}/jobs/${encodeGitLabPathSegment(jobId)}/artifacts`
   );
 
   const response = await fetch(url.toString(), {
@@ -7498,7 +7498,7 @@ async function getJobArtifactFile(
     .join("/");
 
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}/jobs/${jobId}/artifacts/${encodedArtifactPath}`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}/jobs/${encodeGitLabPathSegment(jobId)}/artifacts/${encodedArtifactPath}`
   );
 
   const response = await fetch(url.toString(), {
@@ -7566,7 +7566,7 @@ async function retryPipeline(
 ): Promise<GitLabPipeline> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${pipelineId}/retry`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${encodeGitLabPathSegment(pipelineId)}/retry`
   );
 
   const response = await fetch(url.toString(), {
@@ -7592,7 +7592,7 @@ async function cancelPipeline(
 ): Promise<GitLabPipeline> {
   projectId = decodeURIComponent(projectId); // Decode project ID
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${pipelineId}/cancel`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/pipelines/${encodeGitLabPathSegment(pipelineId)}/cancel`
   );
 
   const response = await fetch(url.toString(), {
@@ -7620,7 +7620,7 @@ async function playPipelineJob(
 ): Promise<GitLabPipelineJob> {
   projectId = decodeURIComponent(projectId);
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${jobId}/play`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${encodeGitLabPathSegment(jobId)}/play`
   );
 
   const body: any = {};
@@ -7652,7 +7652,7 @@ async function retryPipelineJob(
 ): Promise<GitLabPipelineJob> {
   projectId = decodeURIComponent(projectId);
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${jobId}/retry`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${encodeGitLabPathSegment(jobId)}/retry`
   );
 
   const response = await fetch(url.toString(), {
@@ -7680,7 +7680,7 @@ async function cancelPipelineJob(
 ): Promise<GitLabPipelineJob> {
   projectId = decodeURIComponent(projectId);
   const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${jobId}/cancel`
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/jobs/${encodeGitLabPathSegment(jobId)}/cancel`
   );
 
   if (force !== undefined) {

--- a/test/path-segment-encoding.test.ts
+++ b/test/path-segment-encoding.test.ts
@@ -13,6 +13,8 @@ const rawPathSegmentPatterns = [
   "/draft_notes/${draftNoteId}",
   "/versions/${versionId}",
   "/groups/${groupId}",
+  "/jobs/${jobId}",
+  "/pipelines/${pipelineId}",
 ];
 
 test("GitLab URL path IDs are encoded before interpolation", () => {
@@ -31,6 +33,21 @@ test("encoding keeps path traversal payloads inside one URL segment", () => {
     url.pathname,
     "/api/v4/projects/42/issues/1%2F..%2F..%2F..%2F..%2Fadmin%2Fci%2Fvariables/notes"
   );
+});
+
+test("job_id path traversal stays under /jobs/", () => {
+  // GHSA-7c3w-fxgh-frc7 / #587: unencoded job_id with ../ escaped to /api/v4/user
+  const payload = "../../../user";
+  const url = new URL(
+    `https://gitlab.com/api/v4/projects/1/jobs/${encodeURIComponent(payload)}/trace`
+  );
+
+  assert.equal(
+    url.pathname,
+    "/api/v4/projects/1/jobs/..%2F..%2F..%2Fuser/trace"
+  );
+  assert.match(url.pathname, /\/jobs\/[^/]+\/trace$/);
+  assert.equal(url.pathname.includes("/api/v4/user"), false);
 });
 
 test("malformed percent-encoded segments can still be encoded", () => {


### PR DESCRIPTION
## Summary
- Encode `job_id` and `pipeline_id` with existing `encodeGitLabPathSegment` before interpolating into GitLab API URLs (same pattern as issue/MR IDs).
- Extend `test/path-segment-encoding.test.ts` so raw `/jobs/${jobId}` and `/pipelines/${pipelineId}` cannot regress, plus a PoC-shaped assert for `../../../user`.

Fixes #587 (GHSA-7c3w-fxgh-frc7).

## Why
`new URL()` collapses `../` in unencoded path segments. `get_pipeline_job_output({ job_id: "../../../user" })` hit `/api/v4/user` under the operator PAT. Download proxy already encoded `job_id`; `index.ts` job/pipeline builders did not.

## Test plan
- [x] `node --import tsx/esm --test test/path-segment-encoding.test.ts`
- [x] `npx tsc --noEmit`
- [ ] Confirm PoC no longer escapes: encoded path stays under `/jobs/..%2F../trace`


Made with [Cursor](https://cursor.com)