### PR TITLE
fix: accept null GitLab fields in protected-branch and compare schemas

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -1117,6 +1117,7 @@ export const CreateBranchOptionsSchema = z.object({
 });
 
 export const GitLabCompareResultSchema = z.object({
+  // GitLab may return null commit for empty/no-op compare ranges
   commit: z
     .object({
       id: z.string().optional(),
@@ -1126,6 +1127,7 @@ export const GitLabCompareResultSchema = z.object({
       author_email: z.string().optional(),
       created_at: z.string().optional(),
     })
+    .nullable()
     .optional(),
   commits: z.array(GitLabCommitSchema),
   diffs: z.array(GitLabDiffSchema),
@@ -1852,8 +1854,9 @@ export const UpdateDefaultBranchSchema = ProjectParamsSchema.extend({
 export const GitLabProtectedBranchAccessLevelSchema = z.object({
   access_level: z.number().nullable().optional(),
   access_level_description: z.string().optional(),
-  user_id: z.number().optional(),
-  group_id: z.number().optional(),
+  // GitLab returns null for role-based access levels (not user-/group-specific)
+  user_id: z.number().nullable().optional(),
+  group_id: z.number().nullable().optional(),
 });
 
 export const GitLabProtectedBranchSchema = z.object({

--- a/test/nullable-gitlab-response-fields.test.ts
+++ b/test/nullable-gitlab-response-fields.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  GitLabCompareResultSchema,
+  GitLabProtectedBranchAccessLevelSchema,
+} from "../schemas.js";
+
+test("role-based protected-branch access levels accept null user_id/group_id", () => {
+  // #575: GitLab returns null for role-based levels, not omitted fields
+  const parsed = GitLabProtectedBranchAccessLevelSchema.parse({
+    access_level: 40,
+    access_level_description: "Maintainers",
+    user_id: null,
+    group_id: null,
+  });
+  assert.equal(parsed.user_id, null);
+  assert.equal(parsed.group_id, null);
+});
+
+test("branch compare accepts null commit", () => {
+  const parsed = GitLabCompareResultSchema.parse({
+    commit: null,
+    commits: [],
+    diffs: [],
+  });
+  assert.equal(parsed.commit, null);
+});

--- a/test/test-protected-branches.ts
+++ b/test/test-protected-branches.ts
@@ -12,10 +12,29 @@ function buildProtectedBranch(overrides: Record<string, unknown> = {}) {
     id: 1,
     name: TEST_BRANCH,
     push_access_levels: [
-      { access_level: 30, access_level_description: "Developers + Maintainers" },
+      {
+        access_level: 30,
+        access_level_description: "Developers + Maintainers",
+        user_id: null,
+        group_id: null,
+      },
     ],
-    merge_access_levels: [{ access_level: 40, access_level_description: "Maintainers" }],
-    unprotect_access_levels: [{ access_level: 60, access_level_description: "Administrators" }],
+    merge_access_levels: [
+      {
+        access_level: 40,
+        access_level_description: "Maintainers",
+        user_id: null,
+        group_id: null,
+      },
+    ],
+    unprotect_access_levels: [
+      {
+        access_level: 60,
+        access_level_description: "Administrators",
+        user_id: null,
+        group_id: null,
+      },
+    ],
     allow_force_push: false,
     code_owner_approval_required: false,
     ...overrides,


### PR DESCRIPTION
## Summary
- Make `user_id` / `group_id` on protected-branch access levels `nullable` (role-based levels return `null`).
- Make compare `commit` `nullable` (empty/no-op ranges).
- Cover with a unit parse test and nulls in the protected-branch mock.

Fixes #575.

## Why
Zod `.optional()` allows omit, not `null`. GitLab returns `null` for role-based access levels and sometimes for compare `commit`, so reads fail and `protect_branch` looks failed after the write already applied.

## Test plan
- [x] `node --import tsx/esm --test test/nullable-gitlab-response-fields.test.ts`
- [x] `node --import tsx/esm --test test/test-protected-branches.ts`
- [x] `npm run build`


Made with [Cursor](https://cursor.com)