### PR TITLE
fix: align docs npx pin with npm-published versions

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -79,7 +79,7 @@ npm install -g @zereight/mcp-gitlab
 
 예시는 기존 `mcp-gitlab`보다 충돌 가능성이 낮은 `zereight-mcp-gitlab` 별칭을 사용합니다. MCP 클라이언트가 찾지 못하면 `which zereight-mcp-gitlab`의 절대 경로를 사용하세요.
 
-전역 설치를 쓰지 않으려면 `npx -y @zereight/mcp-gitlab@2.1.37`처럼 직전 안정 버전(문서가 권장하는 버전)으로 고정하세요. 항상 최신 버전을 원하면 `npx -y @zereight/mcp-gitlab@latest`를 사용하세요. 새 버전이 나오면 서버가 시작 시 stderr로 알려줍니다(`GITLAB_DISABLE_VERSION_CHECK=true`로 비활성화 가능).
+전역 설치를 쓰지 않으려면 `npx -y @zereight/mcp-gitlab@2.1.30`처럼 직전 안정 버전(문서가 권장하는 버전)으로 고정하세요. 항상 최신 버전을 원하면 `npx -y @zereight/mcp-gitlab@latest`를 사용하세요. 새 버전이 나오면 서버가 시작 시 stderr로 알려줍니다(`GITLAB_DISABLE_VERSION_CHECK=true`로 비활성화 가능).
 
 #### CLI 인자 사용하기(환경 변수 문제가 있는 클라이언트용)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ npm install -g @zereight/mcp-gitlab
 
 The examples use `zereight-mcp-gitlab`, a less collision-prone alias for the legacy `mcp-gitlab` binary. If your MCP client cannot find it, use the absolute path from `which zereight-mcp-gitlab`.
 
-No global install? Pin `npx` to the previous stable release (the version these docs recommend), for example `npx -y @zereight/mcp-gitlab@2.1.37`. If you always want the newest release, use `npx -y @zereight/mcp-gitlab@latest` instead. The server prints a notice to stderr on startup when a newer version is available (disable with `GITLAB_DISABLE_VERSION_CHECK=true`).
+No global install? Pin `npx` to the previous stable release (the version these docs recommend), for example `npx -y @zereight/mcp-gitlab@2.1.30`. If you always want the newest release, use `npx -y @zereight/mcp-gitlab@latest` instead. The server prints a notice to stderr on startup when a newer version is available (disable with `GITLAB_DISABLE_VERSION_CHECK=true`).
 
 #### Using CLI Arguments (for clients with env var issues)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,7 @@ npm install -g @zereight/mcp-gitlab
 
 示例使用 `zereight-mcp-gitlab`，这是比旧的 `mcp-gitlab` 更不容易冲突的别名。如果 MCP 客户端找不到它，请使用 `which zereight-mcp-gitlab` 输出的绝对路径。
 
-如果不想全局安装，请将 `npx` 固定到上一个稳定版本（即文档推荐的版本），例如 `npx -y @zereight/mcp-gitlab@2.1.37`。如果始终想使用最新版本，请改用 `npx -y @zereight/mcp-gitlab@latest`。有新版本发布时，服务器会在启动时通过 stderr 提示（可用 `GITLAB_DISABLE_VERSION_CHECK=true` 关闭）。
+如果不想全局安装，请将 `npx` 固定到上一个稳定版本（即文档推荐的版本），例如 `npx -y @zereight/mcp-gitlab@2.1.30`。如果始终想使用最新版本，请改用 `npx -y @zereight/mcp-gitlab@latest`。有新版本发布时，服务器会在启动时通过 stderr 提示（可用 `GITLAB_DISABLE_VERSION_CHECK=true` 关闭）。
 
 #### 使用 CLI 参数（适用于环境变量有问题的客户端）
 

--- a/docs/clients/json-clients.md
+++ b/docs/clients/json-clients.md
@@ -30,7 +30,7 @@ Use the local stdio server fields that your client expects and map in these valu
 
 The examples use `zereight-mcp-gitlab`, a less collision-prone alias for the legacy `mcp-gitlab` binary. If your client cannot find it, use the absolute path from `which zereight-mcp-gitlab`.
 
-No global install? Pin `npx` to the previous stable release, for example use `command: "npx"` with `args: ["-y", "@zereight/mcp-gitlab@2.1.37"]` before any server flags. Use `@zereight/mcp-gitlab@latest` if you always want the newest release.
+No global install? Pin `npx` to the previous stable release, for example use `command: "npx"` with `args: ["-y", "@zereight/mcp-gitlab@2.1.30"]` before any server flags. Use `@zereight/mcp-gitlab@latest` if you always want the newest release.
 
 ## Reusable PAT server block
 

--- a/docs/getting-started/cli-arguments.md
+++ b/docs/getting-started/cli-arguments.md
@@ -18,7 +18,7 @@ Or with npm:
 npm install -g @zereight/mcp-gitlab
 ```
 
-No global install? Pin `npx` to the previous stable release and keep the server flags after it, for example `npx -y @zereight/mcp-gitlab@2.1.37 --token=...`. Use `@zereight/mcp-gitlab@latest` if you always want the newest release.
+No global install? Pin `npx` to the previous stable release and keep the server flags after it, for example `npx -y @zereight/mcp-gitlab@2.1.30 --token=...`. Use `@zereight/mcp-gitlab@latest` if you always want the newest release.
 
 ## Example config
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ npm install -g @zereight/mcp-gitlab
 
 The examples use `zereight-mcp-gitlab`, a less collision-prone alias for the legacy `mcp-gitlab` binary. If your MCP client cannot find it, use the absolute path from `which zereight-mcp-gitlab`.
 
-No global install? Pin `npx` to the previous stable release (the version these docs recommend), for example `npx -y @zereight/mcp-gitlab@2.1.37`. If you always want the newest release, use `npx -y @zereight/mcp-gitlab@latest` instead.
+No global install? Pin `npx` to the previous stable release (the version these docs recommend), for example `npx -y @zereight/mcp-gitlab@2.1.30`. If you always want the newest release, use `npx -y @zereight/mcp-gitlab@latest` instead.
 
 === "Personal Access Token"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,6 +62,33 @@ sync_pinned_npx_docs_version() {
     return
   fi
 
+  # Git tags can outpace npm when publish fails; pin must exist on the registry.
+  if ! npm view "@zereight/mcp-gitlab@${version}" version >/dev/null 2>&1; then
+    local npm_pin
+    npm_pin=$(
+      npm view @zereight/mcp-gitlab versions --json 2>/dev/null | node -e '
+const wanted = process.argv[1];
+let raw = "";
+process.stdin.on("data", (c) => (raw += c));
+process.stdin.on("end", () => {
+  const versions = JSON.parse(raw);
+  const pin = [...versions].reverse().find(
+    (v) => v.localeCompare(wanted, undefined, { numeric: true }) < 0
+  );
+  if (!pin) process.exit(1);
+  process.stdout.write(pin);
+});
+' "$version"
+    ) || true
+    if [ -n "$npm_pin" ]; then
+      echo "⚠️  @$version is not on npm; pinning docs to @$npm_pin instead."
+      version="$npm_pin"
+    else
+      echo "⚠️  Could not resolve an npm-published pin for @$version; leaving docs unchanged."
+      return
+    fi
+  fi
+
   node - "$version" <<'NODE'
 const fs = require("fs");
 const path = require("path");


### PR DESCRIPTION
## Summary
- Docs were pinning `@zereight/mcp-gitlab@2.1.37`, but npm never published 2.1.31–2.1.37 (only up to 2.1.30, then 2.1.38).
- Retarget README/docs pins to `2.1.30` (last published before 2.1.38).
- Teach `scripts/release.sh` to fall back to the latest npm-published version when the previous git tag is missing from the registry.

## Current alignment
| Surface | Version |
|---|---|
| npm / package.json / server.json / Formula | 2.1.38 |
| Docker `zereight050/gitlab-mcp` | 2.1.38 (+ orphan 2.1.31–37 tags from failed npm publishes) |
| Docs npx pin (this PR) | 2.1.30 |

## Test plan
- [ ] Confirm `npm view @zereight/mcp-gitlab@2.1.30 version` succeeds
- [ ] Confirm `npm view @zereight/mcp-gitlab@2.1.37 version` fails
- [ ] Skim README / docs for `@zereight/mcp-gitlab@2.1.30`
- [ ] Optional: dry-run release pin path mentally for next patch


Made with [Cursor](https://cursor.com)