### PR TITLE
fix: document Homebrew tap URL for gitlab-mcp Formula

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -68,6 +68,7 @@ PAT, OAuth, 읽기 전용 모드, 동적 API URL, 원격 인증을 지원하며 
 서버를 한 번 설치하세요.
 
 ```shell
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For the simplest local setup, start with a Personal Access Token. For browser-ba
 Install the server once:
 
 ```shell
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,6 +68,7 @@
 安装服务器：
 
 ```shell
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/auth/custom-agent-multiple-pat.md
+++ b/docs/auth/custom-agent-multiple-pat.md
@@ -6,6 +6,7 @@ setups, multi-user deployments, and restricted tool surfaces.
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/auth/oauth-setup.md
+++ b/docs/auth/oauth-setup.md
@@ -18,6 +18,7 @@ OAuth2 provides several advantages over personal access tokens:
 - The GitLab MCP server installed:
 
   ```bash
+  brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
   brew install zereight/gitlab-mcp/zereight-mcp-gitlab
   ```
 

--- a/docs/clients/claude-code.md
+++ b/docs/clients/claude-code.md
@@ -26,6 +26,7 @@ Use an API URL, not the web root:
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/clients/codex.md
+++ b/docs/clients/codex.md
@@ -25,6 +25,7 @@ Use an API URL, not the web root:
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/clients/copilot.md
+++ b/docs/clients/copilot.md
@@ -14,6 +14,7 @@ That means you configure the server in:
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/clients/cursor.md
+++ b/docs/clients/cursor.md
@@ -15,6 +15,7 @@ If your team shares the setup, keep the config in version control when appropria
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/clients/json-clients.md
+++ b/docs/clients/json-clients.md
@@ -13,6 +13,7 @@ Because those client-specific schemas can vary, this guide does **not** assume a
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/clients/vscode.md
+++ b/docs/clients/vscode.md
@@ -14,6 +14,7 @@ Use workspace config when you want to share the MCP server with your team.
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/getting-started/cli-arguments.md
+++ b/docs/getting-started/cli-arguments.md
@@ -9,6 +9,7 @@ CLI arguments take precedence over environment variables.
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ client config.
 Install the server once:
 
 ```bash
+brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp
 brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 ```
 


### PR DESCRIPTION
## Summary
- `brew install zereight/gitlab-mcp/...` clones `zereight/homebrew-gitlab-mcp`, which does not exist (#600).
- Docs now tap the real repo URL first: `brew tap zereight/gitlab-mcp https://github.com/zereight/gitlab-mcp`.
- Synced across README (en/ko/zh-CN) and client/auth install guides.

## Test plan
- [ ] Fresh machine (no existing tap): run the two brew commands from README and confirm Formula installs
- [ ] Confirm `brew --repo zereight/gitlab-mcp` points at github.com/zereight/gitlab-mcp and contains `Formula/zereight-mcp-gitlab.rb`

Fixes #600

Made with [Cursor](https://cursor.com)