### PR TITLE
fix: allow milestone_id on update_merge_request

### DIFF
--- a/docs/tools/merge-requests.md
+++ b/docs/tools/merge-requests.md
@@ -296,6 +296,7 @@ Update a merge request (mergeRequestIid or branchName required)
 | `remove_source_branch` | boolean |  | Flag indicating if the source branch should be removed |
 | `squash` | boolean |  | Squash commits into a single commit when merging |
 | `draft` | boolean |  | Work in progress merge request |
+| `milestone_id` | string |  | Milestone ID to assign. Set to 0 to unassign. |
 
 ### `create_merge_request`
 

--- a/docs/tools/merge-requests.md
+++ b/docs/tools/merge-requests.md
@@ -296,7 +296,7 @@ Update a merge request (mergeRequestIid or branchName required)
 | `remove_source_branch` | boolean |  | Flag indicating if the source branch should be removed |
 | `squash` | boolean |  | Squash commits into a single commit when merging |
 | `draft` | boolean |  | Work in progress merge request |
-| `milestone_id` | string |  | Milestone ID to assign. Set to 0 to unassign. |
+| `milestone_id` | string |  | Milestone ID to assign. Set to 0 to unassign. Null is treated as omitted. |
 
 ### `create_merge_request`
 

--- a/schemas.ts
+++ b/schemas.ts
@@ -1971,10 +1971,9 @@ export const UpdateMergeRequestSchema = MergeRequestParamsSchema.extend({
     .optional()
     .describe("Squash commits into a single commit when merging"),
   draft: z.coerce.boolean().optional().describe("Work in progress merge request"),
-  milestone_id: z.coerce
-    .string()
-    .optional()
-    .describe("Milestone ID to assign. Set to 0 to unassign."),
+  milestone_id: z
+    .preprocess(val => (val === null ? undefined : val), z.coerce.string().optional())
+    .describe("Milestone ID to assign. Set to 0 to unassign. Null is treated as omitted."),
 });
 
 export const MergeMergeRequestSchema = ProjectParamsSchema.extend({

--- a/schemas.ts
+++ b/schemas.ts
@@ -1971,6 +1971,10 @@ export const UpdateMergeRequestSchema = MergeRequestParamsSchema.extend({
     .optional()
     .describe("Squash commits into a single commit when merging"),
   draft: z.coerce.boolean().optional().describe("Work in progress merge request"),
+  milestone_id: z.coerce
+    .string()
+    .optional()
+    .describe("Milestone ID to assign. Set to 0 to unassign."),
 });
 
 export const MergeMergeRequestSchema = ProjectParamsSchema.extend({

--- a/test/nullish-tool-arguments-schema.test.ts
+++ b/test/nullish-tool-arguments-schema.test.ts
@@ -6,6 +6,7 @@ import {
   ExecuteGraphQLSchema,
   GetBranchDiffsSchema,
   UpdateMergeRequestDiscussionNoteSchema,
+  UpdateMergeRequestSchema,
 } from "../schemas.js";
 import { sanitizeToolArguments } from "../utils/tool-args.js";
 
@@ -62,6 +63,27 @@ describe("When validating tool arguments after sanitization", () => {
       );
       assert.equal(parsed.position?.old_line, null);
       assert.equal(parsed.position?.new_line, 10);
+    });
+  });
+
+  describe("with update_merge_request", () => {
+    test("should omit null milestone_id instead of coercing to string null", () => {
+      const parsed = UpdateMergeRequestSchema.parse({
+        project_id: PROJECT_ID,
+        merge_request_iid: MERGE_REQUEST_IID,
+        title: "keep",
+        milestone_id: null,
+      });
+      assert.equal(parsed.milestone_id, undefined);
+    });
+
+    test("should keep 0 as unassign sentinel", () => {
+      const parsed = UpdateMergeRequestSchema.parse({
+        project_id: PROJECT_ID,
+        merge_request_iid: MERGE_REQUEST_IID,
+        milestone_id: 0,
+      });
+      assert.equal(parsed.milestone_id, "0");
     });
   });
 


### PR DESCRIPTION
## Summary
- Add optional `milestone_id` to `UpdateMergeRequestSchema` so `update_merge_request` can set/unset an MR milestone (GitLab accepts `0` to unassign).
- Document the new parameter in `docs/tools/merge-requests.md`.

Fixes #599

## Test plan
- [ ] Call `update_merge_request` with only `project_id`, `merge_request_iid`, and `milestone_id` — expect success (no 400 “at least one parameter must be provided”)
- [ ] Call with `milestone_id: 0` — expect milestone cleared
- [ ] Confirm create path unchanged


Made with [Cursor](https://cursor.com)