### PR TITLE
chore(ci): bump create-pull-request to v8

### DIFF
--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -27,7 +27,7 @@ jobs:
 
       # main is PR-protected; do not push with git-auto-commit-action.
       - name: Open Homebrew formula PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: automation/homebrew-formula
           title: "chore(homebrew): sync formula for release"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       # main is PR-protected; do not push with git-auto-commit-action.
       - name: Open Homebrew formula PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: automation/homebrew-formula
           title: "chore(homebrew): sync formula for release"


### PR DESCRIPTION
## Summary
- Bump `peter-evans/create-pull-request` from `@v7` (Node 20) to `@v8` (Node 24) in Homebrew sync workflows.
- Clears the GitHub Actions Node 20 deprecation warning on `sync-homebrew`.

## Test plan
- [ ] CI passes on this PR
- [ ] Next release `sync-homebrew` step no longer emits Node 20 deprecation warning