### PR TITLE
feat: add vulnerabilities toolset for AI-assisted triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,11 @@ Register the skill directory in your AI client to get optimal tool usage guidanc
 209. `update_dependency_proxy_settings` - Update dependency proxy settings for a group (enable/disable, credentials for authenticated Docker Hub pulls)
 210. `list_dependency_proxy_blobs` - List cached dependency proxy blobs for a group with cursor-based pagination
 211. `purge_dependency_proxy_cache` - Schedule purge of all cached dependency proxy blobs for a group
-212. `discover_tools` - Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy. Already-active categories are listed in the response.
+212. `list_project_vulnerabilities` - List vulnerabilities for a project with optional state, severity, and report type filters (GraphQL-backed, cursor pagination)
+213. `get_vulnerability` - Get full details of a specific vulnerability
+214. `dismiss_vulnerability` - Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, mitigating_control, not_applicable) and optional comment
+215. `confirm_vulnerability` - Confirm a vulnerability as a real finding requiring remediation
+216. `discover_tools` - Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response.
 
 <!-- TOOLS-END -->
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -414,15 +414,15 @@ Inspect and manage the GitLab dependency proxy cache settings, blob storage, and
 
 ### [Vulnerabilities](vulnerabilities.md)
 
-AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation. *(4 tools)*
+AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation. Backed by the GitLab GraphQL API; requires GitLab Ultimate. *(4 tools)*
 
 > Opt-in. Enable via `GITLAB_TOOLSETS=vulnerabilities` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
 
 | Tool | What it does | R/W |
 |---|---|:-:|
-| [`list_project_vulnerabilities`](vulnerabilities.md#list_project_vulnerabilities) | List vulnerabilities for a project with optional state, severity, and scanner filters | 📖 |
+| [`list_project_vulnerabilities`](vulnerabilities.md#list_project_vulnerabilities) | List vulnerabilities for a project with optional state, severity, and report type filters (GraphQL-backed, cursor pagination) | 📖 |
 | [`get_vulnerability`](vulnerabilities.md#get_vulnerability) | Get full details of a specific vulnerability | 📖 |
-| [`dismiss_vulnerability`](vulnerabilities.md#dismiss_vulnerability) | Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, no_longer_relevant) | ✏️ |
+| [`dismiss_vulnerability`](vulnerabilities.md#dismiss_vulnerability) | Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, mitigating_control, not_applicable) and optional comment | ✏️ |
 | [`confirm_vulnerability`](vulnerabilities.md#confirm_vulnerability) | Confirm a vulnerability as a real finding requiring remediation | ✏️ |
 
 ### [Meta & GraphQL](meta.md)

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -17,7 +17,7 @@ directly from `TOOLSET_DEFINITIONS` in
 | Status | Groups |
 |---|---|
 | **Default** — always exposed | [Projects & Namespaces](projects.md), [Projects & Files](repositories.md), [Branches & Commits](branches.md), [Groups](groups.md), [Merge Requests](merge-requests.md), [Issues](issues.md), [Labels](labels.md), [CI Lint](ci.md), [Users & Events](users.md) |
-| **Opt-in** — must be enabled | [Work Items](workitems.md), [Pipelines, Jobs & Deployments](pipelines.md) (also `USE_PIPELINE=true`), [Milestones](milestones.md) (also `USE_MILESTONE=true`), [Wiki](wiki.md) (also `USE_GITLAB_WIKI=true`), [Releases](releases.md), [Tags](tags.md), [Variables](variables.md), [Webhooks](webhooks.md), [Search](search.md), [Dependency Proxy](dependency-proxy.md), [Meta & GraphQL](meta.md) |
+| **Opt-in** — must be enabled | [Work Items](workitems.md), [Pipelines, Jobs & Deployments](pipelines.md) (also `USE_PIPELINE=true`), [Milestones](milestones.md) (also `USE_MILESTONE=true`), [Wiki](wiki.md) (also `USE_GITLAB_WIKI=true`), [Releases](releases.md), [Tags](tags.md), [Variables](variables.md), [Webhooks](webhooks.md), [Search](search.md), [Dependency Proxy](dependency-proxy.md), [Vulnerabilities](vulnerabilities.md), [Meta & GraphQL](meta.md) |
 
 **How to enable opt-in groups** (any one is sufficient):
 
@@ -412,6 +412,19 @@ Inspect and manage the GitLab dependency proxy cache settings, blob storage, and
 | [`list_dependency_proxy_blobs`](dependency-proxy.md#list_dependency_proxy_blobs) | List cached dependency proxy blobs for a group | 📖 |
 | [`purge_dependency_proxy_cache`](dependency-proxy.md#purge_dependency_proxy_cache) | Schedule purge of all cached dependency proxy blobs for a group | ✏️ |
 
+### [Vulnerabilities](vulnerabilities.md)
+
+AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation. *(4 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=vulnerabilities` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
+| Tool | What it does | R/W |
+|---|---|:-:|
+| [`list_project_vulnerabilities`](vulnerabilities.md#list_project_vulnerabilities) | List vulnerabilities for a project with optional state, severity, and scanner filters | 📖 |
+| [`get_vulnerability`](vulnerabilities.md#get_vulnerability) | Get full details of a specific vulnerability | 📖 |
+| [`dismiss_vulnerability`](vulnerabilities.md#dismiss_vulnerability) | Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, no_longer_relevant) | ✏️ |
+| [`confirm_vulnerability`](vulnerabilities.md#confirm_vulnerability) | Confirm a vulnerability as a real finding requiring remediation | ✏️ |
+
 ### [Meta & GraphQL](meta.md)
 
 Server diagnostics, tool discovery, and the GraphQL escape hatch. *(2 tools)*
@@ -421,7 +434,7 @@ Server diagnostics, tool discovery, and the GraphQL escape hatch. *(2 tools)*
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`execute_graphql`](meta.md#execute_graphql) | Execute a GitLab GraphQL query | 📖 |
-| [`discover_tools`](meta.md#discover_tools) | Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy. Already-active categories are listed in the response. | 📖 |
+| [`discover_tools`](meta.md#discover_tools) | Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response. | 📖 |
 
 ---
 

--- a/docs/tools/meta.md
+++ b/docs/tools/meta.md
@@ -29,7 +29,7 @@ Execute a GitLab GraphQL query
 
 *📖 Read-only*
 
-Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy. Already-active categories are listed in the response.
+Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response.
 
 **Parameters**
 

--- a/docs/tools/vulnerabilities.md
+++ b/docs/tools/vulnerabilities.md
@@ -1,0 +1,71 @@
+# Vulnerabilities
+
+AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation.
+
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=vulnerabilities` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
+## Tools in this group
+
+- [`list_project_vulnerabilities`](#list_project_vulnerabilities) — 📖 Read-only
+- [`get_vulnerability`](#get_vulnerability) — 📖 Read-only
+- [`dismiss_vulnerability`](#dismiss_vulnerability) — ✏️ Writes
+- [`confirm_vulnerability`](#confirm_vulnerability) — ✏️ Writes
+
+---
+
+### `list_project_vulnerabilities`
+
+*📖 Read-only*
+
+List vulnerabilities for a project with optional state, severity, and scanner filters
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `project_id` | string | ✓ | Project ID or URL-encoded path |
+| `state` | enum (`detected` \| `confirmed` \| `resolved` \| `dismissed`) |  | Filter by vulnerability state |
+| `severity` | enum (`critical` \| `high` \| `medium` \| `low` \| `info` \| `unknown`) |  | Filter by severity level |
+| `scanner` | string |  | Filter by scanner type (e.g. SECRET_DETECTION, SAST, DAST) |
+| `page` | number |  | Page number for pagination (default: 1) |
+| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+
+### `get_vulnerability`
+
+*📖 Read-only*
+
+Get full details of a specific vulnerability
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `vulnerability_id` | string | ✓ | The ID of the vulnerability |
+
+### `dismiss_vulnerability`
+
+*✏️ Writes*
+
+Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, no_longer_relevant)
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `vulnerability_id` | string | ✓ | The ID of the vulnerability to dismiss |
+| `reason` | enum (`acceptable_risk` \| `false_positive` \| `used_in_tests` \| `no_longer_relevant`) | ✓ | Reason for dismissal |
+| `comment` | string |  | Optional comment explaining the dismissal |
+
+### `confirm_vulnerability`
+
+*✏️ Writes*
+
+Confirm a vulnerability as a real finding requiring remediation
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `vulnerability_id` | string | ✓ | The ID of the vulnerability to confirm |
+| `comment` | string |  | Optional comment explaining the confirmation |

--- a/docs/tools/vulnerabilities.md
+++ b/docs/tools/vulnerabilities.md
@@ -28,7 +28,7 @@ List vulnerabilities for a project with optional state, severity, and report typ
 | `state` | enum (`detected` \| `confirmed` \| `resolved` \| `dismissed`) |  | Filter by vulnerability state |
 | `severity` | enum (`critical` \| `high` \| `medium` \| `low` \| `info` \| `unknown`) |  | Filter by severity level |
 | `report_type` | enum (`sast` \| `dast` \| `dependency_scanning` \| `container_scanning` \| `secret_detection` \| `coverage_fuzzing` \| `api_fuzzing` \| `cluster_image_scanning` \| `generic`) |  | Filter by scan/report type (e.g. secret_detection, sast, dast) |
-| `first` | number |  | Number of vulnerabilities to return (max: 100, default: 20) |
+| `first` | integer |  | Number of vulnerabilities to return (max: 100, default: 20) |
 | `after` | string |  | Cursor for pagination; use the endCursor from a previous response |
 
 ### `get_vulnerability`

--- a/docs/tools/vulnerabilities.md
+++ b/docs/tools/vulnerabilities.md
@@ -1,6 +1,6 @@
 # Vulnerabilities
 
-AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation.
+AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation. Backed by the GitLab GraphQL API; requires GitLab Ultimate.
 
 !!! note "Feature toggle"
     Opt-in. Enable via `GITLAB_TOOLSETS=vulnerabilities` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
@@ -18,7 +18,7 @@ AI-assisted vulnerability triage — list findings, inspect details, dismiss wit
 
 *📖 Read-only*
 
-List vulnerabilities for a project with optional state, severity, and scanner filters
+List vulnerabilities for a project with optional state, severity, and report type filters (GraphQL-backed, cursor pagination)
 
 **Parameters**
 
@@ -27,9 +27,9 @@ List vulnerabilities for a project with optional state, severity, and scanner fi
 | `project_id` | string | ✓ | Project ID or URL-encoded path |
 | `state` | enum (`detected` \| `confirmed` \| `resolved` \| `dismissed`) |  | Filter by vulnerability state |
 | `severity` | enum (`critical` \| `high` \| `medium` \| `low` \| `info` \| `unknown`) |  | Filter by severity level |
-| `scanner` | string |  | Filter by scanner type (e.g. SECRET_DETECTION, SAST, DAST) |
-| `page` | number |  | Page number for pagination (default: 1) |
-| `per_page` | number |  | Number of items per page (max: 100, default: 20) |
+| `report_type` | enum (`sast` \| `dast` \| `dependency_scanning` \| `container_scanning` \| `secret_detection` \| `coverage_fuzzing` \| `api_fuzzing` \| `cluster_image_scanning` \| `generic`) |  | Filter by scan/report type (e.g. secret_detection, sast, dast) |
+| `first` | number |  | Number of vulnerabilities to return (max: 100, default: 20) |
+| `after` | string |  | Cursor for pagination; use the endCursor from a previous response |
 
 ### `get_vulnerability`
 
@@ -41,20 +41,20 @@ Get full details of a specific vulnerability
 
 | Parameter | Type | Required | Description |
 |---|---|:-:|---|
-| `vulnerability_id` | string | ✓ | The ID of the vulnerability |
+| `vulnerability_id` | string | ✓ | The vulnerability ID (numeric or GraphQL global ID) |
 
 ### `dismiss_vulnerability`
 
 *✏️ Writes*
 
-Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, no_longer_relevant)
+Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, mitigating_control, not_applicable) and optional comment
 
 **Parameters**
 
 | Parameter | Type | Required | Description |
 |---|---|:-:|---|
-| `vulnerability_id` | string | ✓ | The ID of the vulnerability to dismiss |
-| `reason` | enum (`acceptable_risk` \| `false_positive` \| `used_in_tests` \| `no_longer_relevant`) | ✓ | Reason for dismissal |
+| `vulnerability_id` | string | ✓ | The ID of the vulnerability to dismiss (numeric or GraphQL global ID) |
+| `reason` | enum (`acceptable_risk` \| `false_positive` \| `used_in_tests` \| `mitigating_control` \| `not_applicable`) | ✓ | Reason for dismissal |
 | `comment` | string |  | Optional comment explaining the dismissal |
 
 ### `confirm_vulnerability`
@@ -67,5 +67,5 @@ Confirm a vulnerability as a real finding requiring remediation
 
 | Parameter | Type | Required | Description |
 |---|---|:-:|---|
-| `vulnerability_id` | string | ✓ | The ID of the vulnerability to confirm |
+| `vulnerability_id` | string | ✓ | The ID of the vulnerability to confirm (numeric or GraphQL global ID) |
 | `comment` | string |  | Optional comment explaining the confirmation |

--- a/index.ts
+++ b/index.ts
@@ -9239,6 +9239,9 @@ async function dismissVulnerability(
       `Failed to dismiss vulnerability: ${data.vulnerabilityDismiss.errors.join(", ")}`
     );
   }
+  if (!data.vulnerabilityDismiss.vulnerability) {
+    throw new Error(`Vulnerability not returned after dismissal (id: ${vulnerabilityId})`);
+  }
   return data.vulnerabilityDismiss.vulnerability;
 }
 
@@ -9272,6 +9275,9 @@ async function confirmVulnerability(
     throw new Error(
       `Failed to confirm vulnerability: ${data.vulnerabilityConfirm.errors.join(", ")}`
     );
+  }
+  if (!data.vulnerabilityConfirm.vulnerability) {
+    throw new Error(`Vulnerability not returned after confirmation (id: ${vulnerabilityId})`);
   }
   return data.vulnerabilityConfirm.vulnerability;
 }

--- a/index.ts
+++ b/index.ts
@@ -9030,11 +9030,17 @@ async function purgeDependencyProxyCache(groupId: string): Promise<void> {
 // params on list and reason/comment on dismiss. GitLab recommends the
 // GraphQL API for vulnerability management, which supports all of these.
 
-/** Convert a numeric vulnerability ID (or an existing GID) to a GraphQL global ID. */
+/** Convert a numeric vulnerability ID (or an existing Vulnerability GID) to a GraphQL global ID. */
 function toVulnerabilityGid(vulnerabilityId: string): string {
-  return vulnerabilityId.startsWith("gid://")
-    ? vulnerabilityId
-    : `gid://gitlab/Vulnerability/${vulnerabilityId}`;
+  if (/^\d+$/.test(vulnerabilityId)) {
+    return `gid://gitlab/Vulnerability/${vulnerabilityId}`;
+  }
+  if (/^gid:\/\/gitlab\/Vulnerability\/\d+$/.test(vulnerabilityId)) {
+    return vulnerabilityId;
+  }
+  throw new Error(
+    `Invalid vulnerability ID "${vulnerabilityId}": expected a numeric ID or a gid://gitlab/Vulnerability/<id> global ID`
+  );
 }
 
 /**
@@ -9055,6 +9061,63 @@ async function resolveProjectFullPath(projectId: string): Promise<string> {
     throw new Error(`Could not resolve full path for project ${decoded}`);
   }
   return project.path_with_namespace;
+}
+
+/**
+ * Enforce GITLAB_ALLOWED_PROJECT_IDS for vulnerability tools. Vulnerability
+ * GIDs are globally unique rather than project-scoped, so the boundary must
+ * be checked against the project the vulnerability actually belongs to —
+ * mirroring what getEffectiveProjectId does for project-scoped REST calls.
+ * Allowlist entries may be numeric IDs or full namespace paths.
+ */
+function assertVulnerabilityProjectAllowed(
+  vulnerabilityId: string,
+  project: { id?: string | null; fullPath?: string | null } | null | undefined
+): void {
+  if (GITLAB_ALLOWED_PROJECT_IDS.length === 0) {
+    return;
+  }
+  const fullPath = project?.fullPath ?? undefined;
+  const numericId = project?.id?.match(/^gid:\/\/gitlab\/Project\/(\d+)$/)?.[1];
+  const allowed =
+    (fullPath !== undefined && GITLAB_ALLOWED_PROJECT_IDS.includes(fullPath)) ||
+    (numericId !== undefined && GITLAB_ALLOWED_PROJECT_IDS.includes(numericId));
+  if (!allowed) {
+    throw new Error(
+      `Access denied: Vulnerability ${vulnerabilityId} belongs to project ${
+        fullPath ?? numericId ?? "unknown"
+      }, which is not in the allowed project list: ${GITLAB_ALLOWED_PROJECT_IDS.join(", ")}`
+    );
+  }
+}
+
+/**
+ * Pre-flight allowlist check for vulnerability mutations: resolves the
+ * vulnerability's project and verifies it against GITLAB_ALLOWED_PROJECT_IDS
+ * before any write is issued. No-op (no extra request) when the allowlist
+ * is not configured.
+ */
+async function ensureVulnerabilityProjectAllowed(vulnerabilityId: string): Promise<void> {
+  if (GITLAB_ALLOWED_PROJECT_IDS.length === 0) {
+    return;
+  }
+  const data = await executeGraphQL<{
+    vulnerability: { project: { id: string; fullPath: string } | null } | null;
+  }>(
+    `query getVulnerabilityProject($id: VulnerabilityID!) {
+      vulnerability(id: $id) {
+        project {
+          id
+          fullPath
+        }
+      }
+    }`,
+    { id: toVulnerabilityGid(vulnerabilityId) }
+  );
+  if (!data.vulnerability) {
+    throw new Error(`Vulnerability not found: ${vulnerabilityId}`);
+  }
+  assertVulnerabilityProjectAllowed(vulnerabilityId, data.vulnerability.project);
 }
 
 /** Shared GraphQL selection set for vulnerability objects. */
@@ -9184,7 +9247,11 @@ async function listProjectVulnerabilities(
 }
 
 async function getVulnerability(vulnerabilityId: string): Promise<unknown> {
-  const data = await executeGraphQL<{ vulnerability: unknown | null }>(
+  const data = await executeGraphQL<{
+    vulnerability:
+      | ({ project?: { id?: string; fullPath?: string } | null } & Record<string, unknown>)
+      | null;
+  }>(
     `query getVulnerability($id: VulnerabilityID!) {
       vulnerability(id: $id) {
         ${VULNERABILITY_FIELDS}
@@ -9200,6 +9267,7 @@ async function getVulnerability(vulnerabilityId: string): Promise<unknown> {
   if (!data.vulnerability) {
     throw new Error(`Vulnerability not found: ${vulnerabilityId}`);
   }
+  assertVulnerabilityProjectAllowed(vulnerabilityId, data.vulnerability.project);
   return data.vulnerability;
 }
 
@@ -9208,6 +9276,7 @@ async function dismissVulnerability(
   reason: string,
   comment?: string
 ): Promise<unknown> {
+  await ensureVulnerabilityProjectAllowed(vulnerabilityId);
   const input: Record<string, string> = {
     id: toVulnerabilityGid(vulnerabilityId),
     dismissalReason: reason.toUpperCase(),
@@ -9249,6 +9318,7 @@ async function confirmVulnerability(
   vulnerabilityId: string,
   comment?: string
 ): Promise<unknown> {
+  await ensureVulnerabilityProjectAllowed(vulnerabilityId);
   const input: Record<string, string> = { id: toVulnerabilityGid(vulnerabilityId) };
   if (comment) input.comment = comment;
 

--- a/index.ts
+++ b/index.ts
@@ -9024,33 +9024,183 @@ async function purgeDependencyProxyCache(groupId: string): Promise<void> {
   await handleGitLabError(response);
 }
 
-// --- Vulnerability functions ---
+// --- Vulnerability functions (GraphQL) ---
+//
+// The REST Vulnerabilities API is deprecated and silently ignores filter
+// params on list and reason/comment on dismiss. GitLab recommends the
+// GraphQL API for vulnerability management, which supports all of these.
+
+/** Convert a numeric vulnerability ID (or an existing GID) to a GraphQL global ID. */
+function toVulnerabilityGid(vulnerabilityId: string): string {
+  return vulnerabilityId.startsWith("gid://")
+    ? vulnerabilityId
+    : `gid://gitlab/Vulnerability/${vulnerabilityId}`;
+}
+
+/**
+ * Resolve a project ID or path to the full namespace path required by
+ * GraphQL's `project(fullPath:)` query. Numeric IDs are resolved via a
+ * REST lookup; paths are returned as-is (decoded).
+ */
+async function resolveProjectFullPath(projectId: string): Promise<string> {
+  const decoded = decodeURIComponent(getEffectiveProjectId(decodeURIComponent(projectId)));
+  if (!/^\d+$/.test(decoded)) {
+    return decoded;
+  }
+  const url = new URL(`${getEffectiveApiUrl()}/projects/${encodeURIComponent(decoded)}`);
+  const response = await fetch(url.toString(), { ...getFetchConfig() });
+  await handleGitLabError(response);
+  const project = (await response.json()) as { path_with_namespace?: string };
+  if (!project.path_with_namespace) {
+    throw new Error(`Could not resolve full path for project ${decoded}`);
+  }
+  return project.path_with_namespace;
+}
+
+/** Shared GraphQL selection set for vulnerability objects. */
+const VULNERABILITY_FIELDS = `
+  id
+  title
+  description
+  state
+  severity
+  reportType
+  detectedAt
+  confirmedAt
+  resolvedAt
+  dismissedAt
+  dismissalReason
+  webUrl
+  scanner {
+    name
+    externalId
+    vendor
+  }
+  identifiers {
+    externalType
+    externalId
+    name
+    url
+  }
+  links {
+    name
+    url
+  }
+  location {
+    ... on VulnerabilityLocationSast {
+      file
+      startLine
+      endLine
+    }
+    ... on VulnerabilityLocationSecretDetection {
+      file
+      startLine
+      endLine
+    }
+    ... on VulnerabilityLocationDependencyScanning {
+      file
+      dependency {
+        package {
+          name
+        }
+        version
+      }
+    }
+    ... on VulnerabilityLocationContainerScanning {
+      image
+      operatingSystem
+      dependency {
+        package {
+          name
+        }
+        version
+      }
+    }
+    ... on VulnerabilityLocationDast {
+      path
+      hostname
+    }
+  }
+`;
 
 async function listProjectVulnerabilities(
   projectId: string,
   options: Omit<z.infer<typeof ListProjectVulnerabilitiesSchema>, "project_id"> = {}
-): Promise<unknown[]> {
-  projectId = decodeURIComponent(projectId);
-  const url = new URL(
-    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/vulnerabilities`
+): Promise<unknown> {
+  const fullPath = await resolveProjectFullPath(projectId);
+  const variables: Record<string, unknown> = {
+    fullPath,
+    first: Math.min(options.first ?? 20, 100),
+  };
+  if (options.state) variables.state = [options.state.toUpperCase()];
+  if (options.severity) variables.severity = [options.severity.toUpperCase()];
+  if (options.report_type) variables.reportType = [options.report_type.toUpperCase()];
+  if (options.after) variables.after = options.after;
+
+  const data = await executeGraphQL<{
+    project: {
+      vulnerabilities: {
+        nodes: unknown[];
+        pageInfo: { endCursor: string | null; hasNextPage: boolean };
+      };
+    } | null;
+  }>(
+    `query listProjectVulnerabilities(
+      $fullPath: ID!
+      $state: [VulnerabilityState!]
+      $severity: [VulnerabilitySeverity!]
+      $reportType: [VulnerabilityReportType!]
+      $first: Int
+      $after: String
+    ) {
+      project(fullPath: $fullPath) {
+        vulnerabilities(
+          state: $state
+          severity: $severity
+          reportType: $reportType
+          first: $first
+          after: $after
+        ) {
+          nodes {
+            ${VULNERABILITY_FIELDS}
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    }`,
+    variables
   );
-  Object.entries(options).forEach(([key, value]) => {
-    if (value !== undefined) {
-      url.searchParams.append(key, value.toString());
-    }
-  });
-  const response = await fetch(url.toString(), { ...getFetchConfig() });
-  await handleGitLabError(response);
-  return (await response.json()) as unknown[];
+
+  if (!data.project) {
+    throw new Error(`Project not found or not accessible: ${fullPath}`);
+  }
+  return {
+    vulnerabilities: data.project.vulnerabilities.nodes,
+    pageInfo: data.project.vulnerabilities.pageInfo,
+  };
 }
 
 async function getVulnerability(vulnerabilityId: string): Promise<unknown> {
-  const url = new URL(
-    `${getEffectiveApiUrl()}/vulnerabilities/${encodeURIComponent(vulnerabilityId)}`
+  const data = await executeGraphQL<{ vulnerability: unknown | null }>(
+    `query getVulnerability($id: VulnerabilityID!) {
+      vulnerability(id: $id) {
+        ${VULNERABILITY_FIELDS}
+        project {
+          id
+          name
+          fullPath
+        }
+      }
+    }`,
+    { id: toVulnerabilityGid(vulnerabilityId) }
   );
-  const response = await fetch(url.toString(), { ...getFetchConfig() });
-  await handleGitLabError(response);
-  return (await response.json()) as unknown;
+  if (!data.vulnerability) {
+    throw new Error(`Vulnerability not found: ${vulnerabilityId}`);
+  }
+  return data.vulnerability;
 }
 
 async function dismissVulnerability(
@@ -9058,36 +9208,72 @@ async function dismissVulnerability(
   reason: string,
   comment?: string
 ): Promise<unknown> {
-  const url = new URL(
-    `${getEffectiveApiUrl()}/vulnerabilities/${encodeURIComponent(vulnerabilityId)}/dismiss`
+  const input: Record<string, string> = {
+    id: toVulnerabilityGid(vulnerabilityId),
+    dismissalReason: reason.toUpperCase(),
+  };
+  if (comment) input.comment = comment;
+
+  const data = await executeGraphQL<{
+    vulnerabilityDismiss: {
+      vulnerability: unknown | null;
+      errors: string[];
+    };
+  }>(
+    `mutation dismissVulnerability($input: VulnerabilityDismissInput!) {
+      vulnerabilityDismiss(input: $input) {
+        vulnerability {
+          id
+          state
+          dismissedAt
+          dismissalReason
+        }
+        errors
+      }
+    }`,
+    { input }
   );
-  const body: Record<string, string> = { reason };
-  if (comment) body.comment = comment;
-  const response = await fetch(url.toString(), {
-    ...getFetchConfig(),
-    method: "POST",
-    body: JSON.stringify(body),
-  });
-  await handleGitLabError(response);
-  return (await response.json()) as unknown;
+
+  if (data.vulnerabilityDismiss.errors?.length) {
+    throw new Error(
+      `Failed to dismiss vulnerability: ${data.vulnerabilityDismiss.errors.join(", ")}`
+    );
+  }
+  return data.vulnerabilityDismiss.vulnerability;
 }
 
 async function confirmVulnerability(
   vulnerabilityId: string,
   comment?: string
 ): Promise<unknown> {
-  const url = new URL(
-    `${getEffectiveApiUrl()}/vulnerabilities/${encodeURIComponent(vulnerabilityId)}/confirm`
+  const input: Record<string, string> = { id: toVulnerabilityGid(vulnerabilityId) };
+  if (comment) input.comment = comment;
+
+  const data = await executeGraphQL<{
+    vulnerabilityConfirm: {
+      vulnerability: unknown | null;
+      errors: string[];
+    };
+  }>(
+    `mutation confirmVulnerability($input: VulnerabilityConfirmInput!) {
+      vulnerabilityConfirm(input: $input) {
+        vulnerability {
+          id
+          state
+          confirmedAt
+        }
+        errors
+      }
+    }`,
+    { input }
   );
-  const body: Record<string, string> = {};
-  if (comment) body.comment = comment;
-  const response = await fetch(url.toString(), {
-    ...getFetchConfig(),
-    method: "POST",
-    body: JSON.stringify(body),
-  });
-  await handleGitLabError(response);
-  return (await response.json()) as unknown;
+
+  if (data.vulnerabilityConfirm.errors?.length) {
+    throw new Error(
+      `Failed to confirm vulnerability: ${data.vulnerabilityConfirm.errors.join(", ")}`
+    );
+  }
+  return data.vulnerabilityConfirm.vulnerability;
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -397,6 +397,10 @@ import {
   UpdateDependencyProxySettingsSchema,
   ListDependencyProxyBlobsSchema,
   PurgeDependencyProxyCacheSchema,
+  ListProjectVulnerabilitiesSchema,
+  GetVulnerabilitySchema,
+  DismissVulnerabilitySchema,
+  ConfirmVulnerabilitySchema,
   ListIssueDiscussionsSchema,
   ListIssueLinksSchema,
   ListIssuesSchema,
@@ -9020,6 +9024,72 @@ async function purgeDependencyProxyCache(groupId: string): Promise<void> {
   await handleGitLabError(response);
 }
 
+// --- Vulnerability functions ---
+
+async function listProjectVulnerabilities(
+  projectId: string,
+  options: Omit<z.infer<typeof ListProjectVulnerabilitiesSchema>, "project_id"> = {}
+): Promise<unknown[]> {
+  projectId = decodeURIComponent(projectId);
+  const url = new URL(
+    `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/vulnerabilities`
+  );
+  Object.entries(options).forEach(([key, value]) => {
+    if (value !== undefined) {
+      url.searchParams.append(key, value.toString());
+    }
+  });
+  const response = await fetch(url.toString(), { ...getFetchConfig() });
+  await handleGitLabError(response);
+  return (await response.json()) as unknown[];
+}
+
+async function getVulnerability(vulnerabilityId: string): Promise<unknown> {
+  const url = new URL(
+    `${getEffectiveApiUrl()}/vulnerabilities/${encodeURIComponent(vulnerabilityId)}`
+  );
+  const response = await fetch(url.toString(), { ...getFetchConfig() });
+  await handleGitLabError(response);
+  return (await response.json()) as unknown;
+}
+
+async function dismissVulnerability(
+  vulnerabilityId: string,
+  reason: string,
+  comment?: string
+): Promise<unknown> {
+  const url = new URL(
+    `${getEffectiveApiUrl()}/vulnerabilities/${encodeURIComponent(vulnerabilityId)}/dismiss`
+  );
+  const body: Record<string, string> = { reason };
+  if (comment) body.comment = comment;
+  const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  await handleGitLabError(response);
+  return (await response.json()) as unknown;
+}
+
+async function confirmVulnerability(
+  vulnerabilityId: string,
+  comment?: string
+): Promise<unknown> {
+  const url = new URL(
+    `${getEffectiveApiUrl()}/vulnerabilities/${encodeURIComponent(vulnerabilityId)}/confirm`
+  );
+  const body: Record<string, string> = {};
+  if (comment) body.comment = comment;
+  const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  await handleGitLabError(response);
+  return (await response.json()) as unknown;
+}
+
 /**
  * Upload a file to a GitLab project for use in markdown content.
  *
@@ -12136,6 +12206,33 @@ async function handleToolCall(params: any) {
             },
           ],
         };
+      }
+
+      // --- Vulnerability tools ---
+
+      case "list_project_vulnerabilities": {
+        const args = ListProjectVulnerabilitiesSchema.parse(params.arguments);
+        const { project_id, ...options } = args;
+        const result = await listProjectVulnerabilities(project_id, options);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      }
+
+      case "get_vulnerability": {
+        const args = GetVulnerabilitySchema.parse(params.arguments);
+        const result = await getVulnerability(args.vulnerability_id);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      }
+
+      case "dismiss_vulnerability": {
+        const args = DismissVulnerabilitySchema.parse(params.arguments);
+        const result = await dismissVulnerability(args.vulnerability_id, args.reason, args.comment);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      }
+
+      case "confirm_vulnerability": {
+        const args = ConfirmVulnerabilitySchema.parse(params.arguments);
+        const result = await confirmVulnerability(args.vulnerability_id, args.comment);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "upload_markdown": {

--- a/schemas.ts
+++ b/schemas.ts
@@ -4837,41 +4837,69 @@ export const PurgeDependencyProxyCacheSchema = z.object({
 
 // --- Vulnerability schemas ---
 
-// Schema for listing project vulnerabilities with optional filters
-export const ListProjectVulnerabilitiesSchema = z
-  .object({
-    project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
-    state: z
-      .enum(["detected", "confirmed", "resolved", "dismissed"])
-      .optional()
-      .describe("Filter by vulnerability state"),
-    severity: z
-      .enum(["critical", "high", "medium", "low", "info", "unknown"])
-      .optional()
-      .describe("Filter by severity level"),
-    scanner: z
-      .string()
-      .optional()
-      .describe("Filter by scanner type (e.g. SECRET_DETECTION, SAST, DAST)"),
-  })
-  .merge(PaginationOptionsSchema);
+// Schema for listing project vulnerabilities with optional filters (GraphQL-backed)
+export const ListProjectVulnerabilitiesSchema = z.object({
+  project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+  state: z
+    .enum(["detected", "confirmed", "resolved", "dismissed"])
+    .optional()
+    .describe("Filter by vulnerability state"),
+  severity: z
+    .enum(["critical", "high", "medium", "low", "info", "unknown"])
+    .optional()
+    .describe("Filter by severity level"),
+  report_type: z
+    .enum([
+      "sast",
+      "dast",
+      "dependency_scanning",
+      "container_scanning",
+      "secret_detection",
+      "coverage_fuzzing",
+      "api_fuzzing",
+      "cluster_image_scanning",
+      "generic",
+    ])
+    .optional()
+    .describe("Filter by scan/report type (e.g. secret_detection, sast, dast)"),
+  first: z.coerce
+    .number()
+    .optional()
+    .describe("Number of vulnerabilities to return (max: 100, default: 20)"),
+  after: z
+    .string()
+    .optional()
+    .describe("Cursor for pagination; use the endCursor from a previous response"),
+});
 
 // Schema for getting a single vulnerability by ID
 export const GetVulnerabilitySchema = z.object({
-  vulnerability_id: z.coerce.string().describe("The ID of the vulnerability"),
+  vulnerability_id: z.coerce
+    .string()
+    .describe("The vulnerability ID (numeric or GraphQL global ID)"),
 });
 
 // Schema for dismissing a vulnerability with required reason and optional comment
 export const DismissVulnerabilitySchema = z.object({
-  vulnerability_id: z.coerce.string().describe("The ID of the vulnerability to dismiss"),
+  vulnerability_id: z.coerce
+    .string()
+    .describe("The ID of the vulnerability to dismiss (numeric or GraphQL global ID)"),
   reason: z
-    .enum(["acceptable_risk", "false_positive", "used_in_tests", "no_longer_relevant"])
+    .enum([
+      "acceptable_risk",
+      "false_positive",
+      "used_in_tests",
+      "mitigating_control",
+      "not_applicable",
+    ])
     .describe("Reason for dismissal"),
   comment: z.string().optional().describe("Optional comment explaining the dismissal"),
 });
 
 // Schema for confirming a vulnerability with optional comment
 export const ConfirmVulnerabilitySchema = z.object({
-  vulnerability_id: z.coerce.string().describe("The ID of the vulnerability to confirm"),
+  vulnerability_id: z.coerce
+    .string()
+    .describe("The ID of the vulnerability to confirm (numeric or GraphQL global ID)"),
   comment: z.string().optional().describe("Optional comment explaining the confirmation"),
 });

--- a/schemas.ts
+++ b/schemas.ts
@@ -4834,3 +4834,44 @@ export const ListDependencyProxyBlobsSchema = z.object({
 export const PurgeDependencyProxyCacheSchema = z.object({
   group_id: z.coerce.string().describe("Group ID or URL-encoded path"),
 });
+
+// --- Vulnerability schemas ---
+
+// Schema for listing project vulnerabilities with optional filters
+export const ListProjectVulnerabilitiesSchema = z
+  .object({
+    project_id: z.coerce.string().describe("Project ID or URL-encoded path"),
+    state: z
+      .enum(["detected", "confirmed", "resolved", "dismissed"])
+      .optional()
+      .describe("Filter by vulnerability state"),
+    severity: z
+      .enum(["critical", "high", "medium", "low", "info", "unknown"])
+      .optional()
+      .describe("Filter by severity level"),
+    scanner: z
+      .string()
+      .optional()
+      .describe("Filter by scanner type (e.g. SECRET_DETECTION, SAST, DAST)"),
+  })
+  .merge(PaginationOptionsSchema);
+
+// Schema for getting a single vulnerability by ID
+export const GetVulnerabilitySchema = z.object({
+  vulnerability_id: z.coerce.string().describe("The ID of the vulnerability"),
+});
+
+// Schema for dismissing a vulnerability with required reason and optional comment
+export const DismissVulnerabilitySchema = z.object({
+  vulnerability_id: z.coerce.string().describe("The ID of the vulnerability to dismiss"),
+  reason: z
+    .enum(["acceptable_risk", "false_positive", "used_in_tests", "no_longer_relevant"])
+    .describe("Reason for dismissal"),
+  comment: z.string().optional().describe("Optional comment explaining the dismissal"),
+});
+
+// Schema for confirming a vulnerability with optional comment
+export const ConfirmVulnerabilitySchema = z.object({
+  vulnerability_id: z.coerce.string().describe("The ID of the vulnerability to confirm"),
+  comment: z.string().optional().describe("Optional comment explaining the confirmation"),
+});

--- a/schemas.ts
+++ b/schemas.ts
@@ -4864,6 +4864,9 @@ export const ListProjectVulnerabilitiesSchema = z.object({
     .describe("Filter by scan/report type (e.g. secret_detection, sast, dast)"),
   first: z.coerce
     .number()
+    .int()
+    .min(1)
+    .max(100)
     .optional()
     .describe("Number of vulnerabilities to return (max: 100, default: 20)"),
   after: z

--- a/scripts/check-skill-sync.ts
+++ b/scripts/check-skill-sync.ts
@@ -23,6 +23,7 @@ const REF_DIR = join(REPO_ROOT, "skills", "gitlab-mcp", "reference");
 
 // Response field names in reference docs — not MCP tools.
 const REFERENCE_FIELD_ALLOWLIST = new Set([
+  "after",
   "allow_multiple",
   "deleted_file",
   "excluded_file_patterns",

--- a/scripts/generate-tool-docs.ts
+++ b/scripts/generate-tool-docs.ts
@@ -135,6 +135,11 @@ const GROUP_META: Record<ToolsetId, GroupMeta> = {
     blurb:
       "Inspect and manage the GitLab dependency proxy cache settings, blob storage, and purge operations.",
   },
+  vulnerabilities: {
+    title: "Vulnerabilities",
+    blurb:
+      "AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation.",
+  },
 };
 
 const GROUP_ORDER: ToolsetId[] = [
@@ -157,6 +162,7 @@ const GROUP_ORDER: ToolsetId[] = [
   "webhooks",
   "search",
   "dependency_proxy",
+  "vulnerabilities",
 ];
 
 // --- Helpers --------------------------------------------------------------

--- a/scripts/generate-tool-docs.ts
+++ b/scripts/generate-tool-docs.ts
@@ -138,7 +138,7 @@ const GROUP_META: Record<ToolsetId, GroupMeta> = {
   vulnerabilities: {
     title: "Vulnerabilities",
     blurb:
-      "AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation.",
+      "AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation. Backed by the GitLab GraphQL API; requires GitLab Ultimate.",
   },
 };
 

--- a/skills/gitlab-mcp/SKILL.md
+++ b/skills/gitlab-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill when working with the GitLab MCP server tools for me
 
 # gitlab-mcp
 
-GitLab MCP server providing 212 tools: 210 tools across 19 toolsets, plus `execute_graphql` and the always-available `discover_tools` meta-tool.
+GitLab MCP server providing 216 tools: 214 tools across 20 toolsets, plus `execute_graphql` and the always-available `discover_tools` meta-tool.
 
 For exact generated parameter tables, see `docs/tools/`. Use this file for workflow shape and high-signal parameter hints.
 
@@ -32,6 +32,7 @@ For exact generated parameter tables, see `docs/tools/`. Use this file for workf
 | search (3 tools) | no | `GITLAB_TOOLSETS=search` |
 | variables (10 tools) | no | `GITLAB_TOOLSETS=variables` |
 | dependency_proxy (4 tools) | no | `GITLAB_TOOLSETS=dependency_proxy` |
+| vulnerabilities (4 tools) | no | `GITLAB_TOOLSETS=vulnerabilities` |
 
 Enable all: `GITLAB_TOOLSETS=all`. Use `GITLAB_TOOLS` to enable individual tools outside their toolset. `discover_tools` can list and activate opt-in categories for the current session. `execute_graphql` is not in a toolset; enable it explicitly with `GITLAB_TOOLS=execute_graphql`.
 
@@ -88,6 +89,12 @@ Enable with `GITLAB_TOOLSETS=variables` or `GITLAB_TOOLSETS=dependency_proxy`.
 
 - Webhooks: see reference/webhooks.md
 - Code search: see reference/search.md
+
+### Vulnerability Triage (see reference/vulnerability-triage.md)
+
+Enable with `GITLAB_TOOLSETS=vulnerabilities` (requires GitLab Ultimate).
+
+`list_project_vulnerabilities` -> `get_vulnerability` -> `dismiss_vulnerability` or `confirm_vulnerability`
 
 ### File Operations
 

--- a/skills/gitlab-mcp/reference/vulnerability-triage.md
+++ b/skills/gitlab-mcp/reference/vulnerability-triage.md
@@ -1,28 +1,32 @@
 # Vulnerability Triage
 
 > **Opt-in toolset**: Enable with `GITLAB_TOOLSETS=vulnerabilities`
+>
+> Requires GitLab Ultimate (vulnerability management is an Ultimate-tier feature). Backed by the GitLab GraphQL API.
 
 ## List & Inspect
 
-```
-list_project_vulnerabilities -> list vulnerabilities with filters (state, severity, scanner)
-  project_id: "my-group/my-project"
+```text
+list_project_vulnerabilities -> list vulnerabilities with filters (state, severity, report_type)
+  project_id: "my-group/my-project" (or numeric ID)
   state: "detected" | "confirmed" | "resolved" | "dismissed"
   severity: "critical" | "high" | "medium" | "low" | "info" | "unknown"
-  scanner: "SECRET_DETECTION" | "SAST" | "DAST" | ...
-  page: 1
-  per_page: 20 (max 100)
+  report_type: "secret_detection" | "sast" | "dast" | "dependency_scanning" | "container_scanning" | ...
+  first: 20 (max 100)
+  after: "<endCursor from previous response>"
 
 get_vulnerability             -> full vulnerability details (description, location, identifiers)
-  vulnerability_id: "12345"
+  vulnerability_id: "12345" (numeric or GraphQL global ID)
 ```
+
+Responses from `list_project_vulnerabilities` include a `pageInfo` object with `endCursor` and `hasNextPage`; pass `endCursor` as `after` to fetch the next page.
 
 ## Dismiss & Confirm
 
-```
+```text
 dismiss_vulnerability         -> dismiss a vulnerability with a reason
   vulnerability_id: "12345"
-  reason: "acceptable_risk" | "false_positive" | "used_in_tests" | "no_longer_relevant"
+  reason: "acceptable_risk" | "false_positive" | "used_in_tests" | "mitigating_control" | "not_applicable"
   comment: "Optional explanation"
 
 confirm_vulnerability         -> confirm a vulnerability as a real finding
@@ -30,7 +34,9 @@ confirm_vulnerability         -> confirm a vulnerability as a real finding
   comment: "Optional explanation"
 ```
 
-## Why no `resolve_vulnerability` tool?
+Both mutations persist the comment (and dismissal reason) in the vulnerability's audit trail.
+
+## Why is there no tool to resolve a vulnerability?
 
 Resolving a vulnerability means the underlying issue has been fixed (secret rotated, dependency upgraded, code patched). That requires actions outside GitLab's API: rotating credentials, deploying new code, or rebuilding images. GitLab automatically moves a vulnerability to "resolved" when a subsequent pipeline no longer reports it. An agent should not mark a vulnerability resolved directly, as that would bypass the actual remediation step.
 
@@ -44,9 +50,9 @@ Resolving a vulnerability means the underlying issue has been fixed (secret rota
    OR
 4. `confirm_vulnerability` -> mark as real finding requiring remediation
 
-### Filter by scanner type
+### Filter by scan type
 
-1. `list_project_vulnerabilities` with `scanner: "SECRET_DETECTION"` -> focus on leaked secrets
+1. `list_project_vulnerabilities` with `report_type: "secret_detection"` -> focus on leaked secrets
 2. `get_vulnerability` -> check file location and secret type
 3. `dismiss_vulnerability` with `reason: "used_in_tests"` -> dismiss test fixtures
 

--- a/skills/gitlab-mcp/reference/vulnerability-triage.md
+++ b/skills/gitlab-mcp/reference/vulnerability-triage.md
@@ -1,0 +1,57 @@
+# Vulnerability Triage
+
+> **Opt-in toolset**: Enable with `GITLAB_TOOLSETS=vulnerabilities`
+
+## List & Inspect
+
+```
+list_project_vulnerabilities -> list vulnerabilities with filters (state, severity, scanner)
+  project_id: "my-group/my-project"
+  state: "detected" | "confirmed" | "resolved" | "dismissed"
+  severity: "critical" | "high" | "medium" | "low" | "info" | "unknown"
+  scanner: "SECRET_DETECTION" | "SAST" | "DAST" | ...
+  page: 1
+  per_page: 20 (max 100)
+
+get_vulnerability             -> full vulnerability details (description, location, identifiers)
+  vulnerability_id: "12345"
+```
+
+## Dismiss & Confirm
+
+```
+dismiss_vulnerability         -> dismiss a vulnerability with a reason
+  vulnerability_id: "12345"
+  reason: "acceptable_risk" | "false_positive" | "used_in_tests" | "no_longer_relevant"
+  comment: "Optional explanation"
+
+confirm_vulnerability         -> confirm a vulnerability as a real finding
+  vulnerability_id: "12345"
+  comment: "Optional explanation"
+```
+
+## Why no `resolve_vulnerability` tool?
+
+Resolving a vulnerability means the underlying issue has been fixed (secret rotated, dependency upgraded, code patched). That requires actions outside GitLab's API: rotating credentials, deploying new code, or rebuilding images. GitLab automatically moves a vulnerability to "resolved" when a subsequent pipeline no longer reports it. An agent should not mark a vulnerability resolved directly, as that would bypass the actual remediation step.
+
+## Common Patterns
+
+### Triage detected vulnerabilities
+
+1. `list_project_vulnerabilities` with `state: "detected"` -> review open findings
+2. `get_vulnerability` -> inspect details (file, line, description, identifiers)
+3. `dismiss_vulnerability` with reason -> dismiss false positives or accepted risks
+   OR
+4. `confirm_vulnerability` -> mark as real finding requiring remediation
+
+### Filter by scanner type
+
+1. `list_project_vulnerabilities` with `scanner: "SECRET_DETECTION"` -> focus on leaked secrets
+2. `get_vulnerability` -> check file location and secret type
+3. `dismiss_vulnerability` with `reason: "used_in_tests"` -> dismiss test fixtures
+
+### Review critical findings
+
+1. `list_project_vulnerabilities` with `severity: "critical"` -> prioritize critical issues
+2. `get_vulnerability` -> review full context
+3. `confirm_vulnerability` with `comment: "Needs immediate fix"` -> flag for remediation

--- a/test/test-toolset-filtering.ts
+++ b/test/test-toolset-filtering.ts
@@ -49,6 +49,7 @@ const TOOLSET_TOOL_COUNTS: Record<string, number> = {
   groups: 1,
   variables: 10,
   dependency_proxy: 4,
+  vulnerabilities: 4,
 };
 
 const LEGACY_PIPELINE_CI_TOOL_COUNT = 2;
@@ -77,6 +78,7 @@ const NON_DEFAULT_TOOLSETS = [
   "search",
   "variables",
   "dependency_proxy",
+  "vulnerabilities",
 ];
 
 // discover_tools meta-tool is always force-injected (Step 5.5)

--- a/test/test-vulnerabilities.ts
+++ b/test/test-vulnerabilities.ts
@@ -1,0 +1,435 @@
+import { describe, test, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn } from "child_process";
+import { MockGitLabServer, findMockServerPort } from "./utils/mock-gitlab-server.js";
+
+const MOCK_TOKEN = "glpat-mock-token-12345";
+const TEST_PROJECT_ID = "456";
+const TEST_VULNERABILITY_ID = "789";
+
+const mockVulnerability = {
+  id: 789,
+  title: "Hard-coded credential detected",
+  description: "A hard-coded credential was found in source code",
+  state: "detected",
+  severity: "critical",
+  scanner: { name: "SECRET_DETECTION" },
+  location: { file: "config/secrets.yml", start_line: 42, end_line: 42 },
+  identifiers: [{ type: "cve", name: "CVE-2024-0001", value: "CVE-2024-0001" }],
+  links: [{ name: "More info", url: "https://example.com/vuln/789" }],
+  detected_at: "2024-06-01T10:00:00Z",
+  dismissed_at: null,
+  confirmed_at: null,
+  resolved_at: null,
+  dismissal_reason: null,
+};
+
+const mockVulnerabilityList = [
+  mockVulnerability,
+  {
+    id: 790,
+    title: "SQL Injection in login form",
+    description: "Unsanitized input used in SQL query",
+    state: "confirmed",
+    severity: "high",
+    scanner: { name: "SAST" },
+    location: { file: "src/auth/login.ts", start_line: 18, end_line: 22 },
+    identifiers: [{ type: "cwe", name: "CWE-89", value: "CWE-89" }],
+    links: [],
+    detected_at: "2024-06-02T08:00:00Z",
+    dismissed_at: null,
+    confirmed_at: "2024-06-03T09:00:00Z",
+    resolved_at: null,
+    dismissal_reason: null,
+  },
+  {
+    id: 791,
+    title: "Outdated dependency with known CVE",
+    description: "Package foo@1.2.3 has a known vulnerability",
+    state: "dismissed",
+    severity: "medium",
+    scanner: { name: "DAST" },
+    location: { file: "package.json", start_line: 10, end_line: 10 },
+    identifiers: [{ type: "cve", name: "CVE-2024-9999", value: "CVE-2024-9999" }],
+    links: [{ name: "Advisory", url: "https://example.com/advisory/9999" }],
+    detected_at: "2024-05-15T12:00:00Z",
+    dismissed_at: "2024-05-20T14:00:00Z",
+    confirmed_at: null,
+    resolved_at: null,
+    dismissal_reason: "acceptable_risk",
+  },
+];
+
+async function callTool(
+  toolName: string,
+  args: Record<string, any>,
+  env: NodeJS.ProcessEnv
+): Promise<any> {
+  return new Promise<any>((resolve, reject) => {
+    const proc = spawn("node", ["build/index.js"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        ...env,
+        USE_PIPELINE: "true",
+      },
+    });
+
+    let output = "";
+    let errorOutput = "";
+    proc.stdout?.on("data", (d: Buffer) => (output += d));
+    proc.stderr?.on("data", (d: Buffer) => (errorOutput += d));
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        return reject(new Error(`Process exited with code ${code}: ${errorOutput}`));
+      }
+
+      const line = output.split("\n").find((l) => l.startsWith("{"));
+      if (!line) {
+        return reject(new Error("No JSON output found"));
+      }
+
+      try {
+        const response = JSON.parse(line);
+        if (response.error) {
+          reject(response.error);
+        } else {
+          const content = response.result?.content?.[0]?.text;
+          if (content) {
+            try {
+              resolve(JSON.parse(content));
+            } catch {
+              resolve(content);
+            }
+          } else {
+            resolve(response.result);
+          }
+        }
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    proc.stdin?.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: toolName, arguments: args },
+      }) + "\n"
+    );
+  });
+}
+
+describe("vulnerability tools", () => {
+  let mockGitLab: MockGitLabServer;
+  let mockGitLabUrl: string;
+
+  // Capture variables for verifying request bodies and query params
+  let lastDismissBody: any = null;
+  let lastConfirmBody: any = null;
+  let lastListQueryParams: any = null;
+
+  before(async () => {
+    const mockPort = await findMockServerPort();
+    mockGitLab = new MockGitLabServer({
+      port: mockPort,
+      validTokens: [MOCK_TOKEN],
+    });
+
+    // GET /projects/456/vulnerabilities - list with filter capture
+    mockGitLab.addMockHandler("get", `/projects/${TEST_PROJECT_ID}/vulnerabilities`, (req, res) => {
+      lastListQueryParams = { ...req.query };
+      res.json(mockVulnerabilityList);
+    });
+
+    // GET /vulnerabilities/789 - single vulnerability detail
+    mockGitLab.addMockHandler("get", `/vulnerabilities/${TEST_VULNERABILITY_ID}`, (req, res) => {
+      res.json(mockVulnerability);
+    });
+
+    // POST /vulnerabilities/789/dismiss - dismiss with body capture
+    mockGitLab.addMockHandler("post", `/vulnerabilities/${TEST_VULNERABILITY_ID}/dismiss`, (req, res) => {
+      lastDismissBody = req.body;
+      res.json({
+        ...mockVulnerability,
+        state: "dismissed",
+        dismissed_at: "2024-06-10T12:00:00Z",
+        dismissal_reason: req.body?.reason || "false_positive",
+      });
+    });
+
+    // POST /vulnerabilities/789/confirm - confirm with body capture
+    mockGitLab.addMockHandler("post", `/vulnerabilities/${TEST_VULNERABILITY_ID}/confirm`, (req, res) => {
+      lastConfirmBody = req.body;
+      res.json({
+        ...mockVulnerability,
+        state: "confirmed",
+        confirmed_at: "2024-06-10T12:00:00Z",
+      });
+    });
+
+    await mockGitLab.start();
+    mockGitLabUrl = mockGitLab.getUrl();
+  });
+
+  after(async () => {
+    await mockGitLab.stop();
+  });
+
+  test("list_project_vulnerabilities returns array of vulnerabilities", async () => {
+    const result = await callTool(
+      "list_project_vulnerabilities",
+      { project_id: TEST_PROJECT_ID },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.ok(Array.isArray(result), "Response should be an array");
+    assert.strictEqual(result.length, 3, "Should return 3 vulnerabilities");
+    assert.strictEqual(result[0].id, 789);
+    assert.strictEqual(result[0].title, "Hard-coded credential detected");
+  });
+
+  test("list_project_vulnerabilities forwards state filter as query param", async () => {
+    lastListQueryParams = null;
+
+    await callTool(
+      "list_project_vulnerabilities",
+      { project_id: TEST_PROJECT_ID, state: "detected" },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.ok(lastListQueryParams, "Query params should have been captured");
+    assert.strictEqual(lastListQueryParams.state, "detected", "state filter should be forwarded");
+  });
+
+  test("list_project_vulnerabilities forwards severity filter as query param", async () => {
+    lastListQueryParams = null;
+
+    await callTool(
+      "list_project_vulnerabilities",
+      { project_id: TEST_PROJECT_ID, severity: "critical" },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.ok(lastListQueryParams, "Query params should have been captured");
+    assert.strictEqual(lastListQueryParams.severity, "critical", "severity filter should be forwarded");
+  });
+
+  test("list_project_vulnerabilities forwards scanner filter as query param", async () => {
+    lastListQueryParams = null;
+
+    await callTool(
+      "list_project_vulnerabilities",
+      { project_id: TEST_PROJECT_ID, scanner: "SECRET_DETECTION" },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.ok(lastListQueryParams, "Query params should have been captured");
+    assert.strictEqual(lastListQueryParams.scanner, "SECRET_DETECTION", "scanner filter should be forwarded");
+  });
+
+  test("get_vulnerability returns full vulnerability object", async () => {
+    const result = await callTool(
+      "get_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.strictEqual(result.id, 789);
+    assert.strictEqual(result.title, "Hard-coded credential detected");
+    assert.strictEqual(result.description, "A hard-coded credential was found in source code");
+    assert.strictEqual(result.state, "detected");
+    assert.strictEqual(result.severity, "critical");
+    assert.strictEqual(result.scanner.name, "SECRET_DETECTION");
+    assert.strictEqual(result.location.file, "config/secrets.yml");
+    assert.strictEqual(result.location.start_line, 42);
+    assert.strictEqual(result.identifiers[0].name, "CVE-2024-0001");
+    assert.strictEqual(result.links[0].url, "https://example.com/vuln/789");
+  });
+
+  test("dismiss_vulnerability sends correct POST body with reason", async () => {
+    lastDismissBody = null;
+
+    const result = await callTool(
+      "dismiss_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID, reason: "false_positive" },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.ok(lastDismissBody, "Request body should have been captured");
+    assert.strictEqual(lastDismissBody.reason, "false_positive", "reason should be in request body");
+    assert.strictEqual(result.state, "dismissed");
+  });
+
+  test("dismiss_vulnerability includes comment when provided", async () => {
+    lastDismissBody = null;
+
+    await callTool(
+      "dismiss_vulnerability",
+      {
+        vulnerability_id: TEST_VULNERABILITY_ID,
+        reason: "acceptable_risk",
+        comment: "Reviewed by security team, risk accepted",
+      },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.ok(lastDismissBody, "Request body should have been captured");
+    assert.strictEqual(lastDismissBody.reason, "acceptable_risk");
+    assert.strictEqual(lastDismissBody.comment, "Reviewed by security team, risk accepted");
+  });
+
+  test("confirm_vulnerability sends POST to correct endpoint", async () => {
+    lastConfirmBody = null;
+
+    const result = await callTool(
+      "confirm_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.strictEqual(result.state, "confirmed");
+    assert.strictEqual(result.confirmed_at, "2024-06-10T12:00:00Z");
+  });
+
+  test("confirm_vulnerability includes comment when provided", async () => {
+    lastConfirmBody = null;
+
+    await callTool(
+      "confirm_vulnerability",
+      {
+        vulnerability_id: TEST_VULNERABILITY_ID,
+        comment: "Confirmed after manual verification",
+      },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+      }
+    );
+
+    assert.ok(lastConfirmBody, "Request body should have been captured");
+    assert.strictEqual(lastConfirmBody.comment, "Confirmed after manual verification");
+  });
+
+  // Read-only mode tests
+  test("read-only mode: list_project_vulnerabilities succeeds", async () => {
+    const result = await callTool(
+      "list_project_vulnerabilities",
+      { project_id: TEST_PROJECT_ID },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+        GITLAB_PERMISSION_MODE: "readonly",
+      }
+    );
+
+    assert.ok(Array.isArray(result), "Response should be an array in readonly mode");
+    assert.strictEqual(result.length, 3);
+  });
+
+  test("read-only mode: get_vulnerability succeeds", async () => {
+    const result = await callTool(
+      "get_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID },
+      {
+        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        GITLAB_TOOLSETS: "vulnerabilities",
+        GITLAB_PERMISSION_MODE: "readonly",
+      }
+    );
+
+    assert.strictEqual(result.id, 789);
+    assert.strictEqual(result.title, "Hard-coded credential detected");
+  });
+
+  test("read-only mode: dismiss_vulnerability is rejected", async () => {
+    await assert.rejects(
+      () =>
+        callTool(
+          "dismiss_vulnerability",
+          { vulnerability_id: TEST_VULNERABILITY_ID, reason: "false_positive" },
+          {
+            GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+            GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+            GITLAB_TOOLSETS: "vulnerabilities",
+            GITLAB_PERMISSION_MODE: "readonly",
+          }
+        ),
+      (err: any) => {
+        const msg = typeof err === "string" ? err : err?.message || JSON.stringify(err);
+        assert.ok(
+          msg.toLowerCase().includes("not allowed") ||
+            msg.toLowerCase().includes("read-only") ||
+            msg.toLowerCase().includes("readonly") ||
+            msg.toLowerCase().includes("not available"),
+          `Expected read-only rejection, got: ${msg}`
+        );
+        return true;
+      }
+    );
+  });
+
+  test("read-only mode: confirm_vulnerability is rejected", async () => {
+    await assert.rejects(
+      () =>
+        callTool(
+          "confirm_vulnerability",
+          { vulnerability_id: TEST_VULNERABILITY_ID },
+          {
+            GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+            GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+            GITLAB_TOOLSETS: "vulnerabilities",
+            GITLAB_PERMISSION_MODE: "readonly",
+          }
+        ),
+      (err: any) => {
+        const msg = typeof err === "string" ? err : err?.message || JSON.stringify(err);
+        assert.ok(
+          msg.toLowerCase().includes("not allowed") ||
+            msg.toLowerCase().includes("read-only") ||
+            msg.toLowerCase().includes("readonly") ||
+            msg.toLowerCase().includes("not available"),
+          `Expected read-only rejection, got: ${msg}`
+        );
+        return true;
+      }
+    );
+  });
+});

--- a/test/test-vulnerabilities.ts
+++ b/test/test-vulnerabilities.ts
@@ -513,4 +513,132 @@ describe("vulnerability tools", () => {
       }
     );
   });
+
+  // GITLAB_ALLOWED_PROJECT_IDS tests: the mock vulnerability belongs to
+  // project 456 (test-group/test-project), so an allowlist of "999" must
+  // deny all id-only vulnerability tools.
+  const assertAccessDenied = (err: any) => {
+    const msg = typeof err === "string" ? err : err?.message || JSON.stringify(err);
+    assert.ok(msg.includes("Access denied"), `Expected allowlist rejection, got: ${msg}`);
+    return true;
+  };
+
+  test("allowlist: get_vulnerability is rejected for a vulnerability outside allowed projects", async () => {
+    await assert.rejects(
+      () =>
+        callTool(
+          "get_vulnerability",
+          { vulnerability_id: TEST_VULNERABILITY_ID },
+          { ...baseEnv(), GITLAB_ALLOWED_PROJECT_IDS: "999" }
+        ),
+      assertAccessDenied
+    );
+  });
+
+  test("allowlist: get_vulnerability succeeds when project is allowed by numeric ID", async () => {
+    const result = await callTool(
+      "get_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID },
+      { ...baseEnv(), GITLAB_ALLOWED_PROJECT_IDS: TEST_PROJECT_ID }
+    );
+    assert.strictEqual(result.id, TEST_VULNERABILITY_GID);
+  });
+
+  test("allowlist: get_vulnerability succeeds when project is allowed by full path", async () => {
+    const result = await callTool(
+      "get_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID },
+      { ...baseEnv(), GITLAB_ALLOWED_PROJECT_IDS: `999,${TEST_PROJECT_FULL_PATH}` }
+    );
+    assert.strictEqual(result.id, TEST_VULNERABILITY_GID);
+  });
+
+  test("allowlist: dismiss_vulnerability is rejected before the mutation is sent", async () => {
+    lastDismissInput = null;
+
+    await assert.rejects(
+      () =>
+        callTool(
+          "dismiss_vulnerability",
+          { vulnerability_id: TEST_VULNERABILITY_ID, reason: "false_positive" },
+          { ...baseEnv(), GITLAB_ALLOWED_PROJECT_IDS: "999" }
+        ),
+      assertAccessDenied
+    );
+    assert.strictEqual(
+      lastDismissInput,
+      null,
+      "vulnerabilityDismiss mutation must not be sent for a denied project"
+    );
+  });
+
+  test("allowlist: confirm_vulnerability is rejected before the mutation is sent", async () => {
+    lastConfirmInput = null;
+
+    await assert.rejects(
+      () =>
+        callTool(
+          "confirm_vulnerability",
+          { vulnerability_id: TEST_VULNERABILITY_ID },
+          { ...baseEnv(), GITLAB_ALLOWED_PROJECT_IDS: "999" }
+        ),
+      assertAccessDenied
+    );
+    assert.strictEqual(
+      lastConfirmInput,
+      null,
+      "vulnerabilityConfirm mutation must not be sent for a denied project"
+    );
+  });
+
+  test("allowlist: dismiss_vulnerability succeeds when the vulnerability's project is allowed", async () => {
+    lastDismissInput = null;
+
+    const result = await callTool(
+      "dismiss_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID, reason: "false_positive" },
+      { ...baseEnv(), GITLAB_ALLOWED_PROJECT_IDS: TEST_PROJECT_ID }
+    );
+
+    assert.ok(lastDismissInput, "Mutation should be sent after the allowlist check passes");
+    assert.strictEqual(lastDismissInput.id, TEST_VULNERABILITY_GID);
+    assert.strictEqual(result.state, "DISMISSED");
+  });
+
+  // GID validation tests: only numeric IDs and Vulnerability GIDs are accepted
+  const assertInvalidVulnerabilityId = (err: any) => {
+    const msg = typeof err === "string" ? err : err?.message || JSON.stringify(err);
+    assert.ok(
+      msg.includes("Invalid vulnerability ID"),
+      `Expected invalid-ID rejection, got: ${msg}`
+    );
+    return true;
+  };
+
+  test("gid validation: get_vulnerability rejects non-Vulnerability GIDs", async () => {
+    await assert.rejects(
+      () =>
+        callTool("get_vulnerability", { vulnerability_id: "gid://gitlab/Project/456" }, baseEnv()),
+      assertInvalidVulnerabilityId
+    );
+  });
+
+  test("gid validation: dismiss_vulnerability rejects a non-numeric ID before any request", async () => {
+    lastDismissInput = null;
+
+    await assert.rejects(
+      () =>
+        callTool(
+          "dismiss_vulnerability",
+          { vulnerability_id: "not-a-vuln-id", reason: "false_positive" },
+          baseEnv()
+        ),
+      assertInvalidVulnerabilityId
+    );
+    assert.strictEqual(
+      lastDismissInput,
+      null,
+      "vulnerabilityDismiss mutation must not be sent for an invalid ID"
+    );
+  });
 });

--- a/test/test-vulnerabilities.ts
+++ b/test/test-vulnerabilities.ts
@@ -5,58 +5,53 @@ import { MockGitLabServer, findMockServerPort } from "./utils/mock-gitlab-server
 
 const MOCK_TOKEN = "glpat-mock-token-12345";
 const TEST_PROJECT_ID = "456";
+const TEST_PROJECT_FULL_PATH = "test-group/test-project";
 const TEST_VULNERABILITY_ID = "789";
+const TEST_VULNERABILITY_GID = `gid://gitlab/Vulnerability/${TEST_VULNERABILITY_ID}`;
 
 const mockVulnerability = {
-  id: 789,
+  id: TEST_VULNERABILITY_GID,
   title: "Hard-coded credential detected",
   description: "A hard-coded credential was found in source code",
-  state: "detected",
-  severity: "critical",
-  scanner: { name: "SECRET_DETECTION" },
-  location: { file: "config/secrets.yml", start_line: 42, end_line: 42 },
-  identifiers: [{ type: "cve", name: "CVE-2024-0001", value: "CVE-2024-0001" }],
+  state: "DETECTED",
+  severity: "CRITICAL",
+  reportType: "SECRET_DETECTION",
+  detectedAt: "2024-06-01T10:00:00Z",
+  confirmedAt: null,
+  resolvedAt: null,
+  dismissedAt: null,
+  dismissalReason: null,
+  webUrl: "https://gitlab.mock/test-group/test-project/-/security/vulnerabilities/789",
+  scanner: { name: "GitLeaks", externalId: "gitleaks", vendor: "GitLab" },
+  identifiers: [
+    { externalType: "cve", externalId: "CVE-2024-0001", name: "CVE-2024-0001", url: null },
+  ],
   links: [{ name: "More info", url: "https://example.com/vuln/789" }],
-  detected_at: "2024-06-01T10:00:00Z",
-  dismissed_at: null,
-  confirmed_at: null,
-  resolved_at: null,
-  dismissal_reason: null,
+  location: { file: "config/secrets.yml", startLine: 42, endLine: 42 },
 };
 
 const mockVulnerabilityList = [
   mockVulnerability,
   {
-    id: 790,
+    ...mockVulnerability,
+    id: "gid://gitlab/Vulnerability/790",
     title: "SQL Injection in login form",
-    description: "Unsanitized input used in SQL query",
-    state: "confirmed",
-    severity: "high",
-    scanner: { name: "SAST" },
-    location: { file: "src/auth/login.ts", start_line: 18, end_line: 22 },
-    identifiers: [{ type: "cwe", name: "CWE-89", value: "CWE-89" }],
-    links: [],
-    detected_at: "2024-06-02T08:00:00Z",
-    dismissed_at: null,
-    confirmed_at: "2024-06-03T09:00:00Z",
-    resolved_at: null,
-    dismissal_reason: null,
+    state: "CONFIRMED",
+    severity: "HIGH",
+    reportType: "SAST",
+    confirmedAt: "2024-06-03T09:00:00Z",
+    location: { file: "src/auth/login.ts", startLine: 18, endLine: 22 },
   },
   {
-    id: 791,
+    ...mockVulnerability,
+    id: "gid://gitlab/Vulnerability/791",
     title: "Outdated dependency with known CVE",
-    description: "Package foo@1.2.3 has a known vulnerability",
-    state: "dismissed",
-    severity: "medium",
-    scanner: { name: "DAST" },
-    location: { file: "package.json", start_line: 10, end_line: 10 },
-    identifiers: [{ type: "cve", name: "CVE-2024-9999", value: "CVE-2024-9999" }],
-    links: [{ name: "Advisory", url: "https://example.com/advisory/9999" }],
-    detected_at: "2024-05-15T12:00:00Z",
-    dismissed_at: "2024-05-20T14:00:00Z",
-    confirmed_at: null,
-    resolved_at: null,
-    dismissal_reason: "acceptable_risk",
+    state: "DISMISSED",
+    severity: "MEDIUM",
+    reportType: "DEPENDENCY_SCANNING",
+    dismissedAt: "2024-05-20T14:00:00Z",
+    dismissalReason: "ACCEPTABLE_RISK",
+    location: { file: "package.json", dependency: { package: { name: "foo" }, version: "1.2.3" } },
   },
 ];
 
@@ -80,12 +75,12 @@ async function callTool(
     proc.stdout?.on("data", (d: Buffer) => (output += d));
     proc.stderr?.on("data", (d: Buffer) => (errorOutput += d));
 
-    proc.on("close", (code) => {
+    proc.on("close", code => {
       if (code !== 0) {
         return reject(new Error(`Process exited with code ${code}: ${errorOutput}`));
       }
 
-      const line = output.split("\n").find((l) => l.startsWith("{"));
+      const line = output.split("\n").find(l => l.startsWith("{"));
       if (!line) {
         return reject(new Error("No JSON output found"));
       }
@@ -126,10 +121,17 @@ describe("vulnerability tools", () => {
   let mockGitLab: MockGitLabServer;
   let mockGitLabUrl: string;
 
-  // Capture variables for verifying request bodies and query params
-  let lastDismissBody: any = null;
-  let lastConfirmBody: any = null;
-  let lastListQueryParams: any = null;
+  // Capture variables for verifying GraphQL payloads
+  let lastListVariables: any = null;
+  let lastDismissInput: any = null;
+  let lastConfirmInput: any = null;
+  let lastGetId: any = null;
+
+  const baseEnv = () => ({
+    GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+    GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+    GITLAB_TOOLSETS: "vulnerabilities",
+  });
 
   before(async () => {
     const mockPort = await findMockServerPort();
@@ -138,36 +140,91 @@ describe("vulnerability tools", () => {
       validTokens: [MOCK_TOKEN],
     });
 
-    // GET /projects/456/vulnerabilities - list with filter capture
-    mockGitLab.addMockHandler("get", `/projects/${TEST_PROJECT_ID}/vulnerabilities`, (req, res) => {
-      lastListQueryParams = { ...req.query };
-      res.json(mockVulnerabilityList);
-    });
+    // All four tools go through POST /api/graphql; dispatch on operation name
+    mockGitLab.addRootHandler("post", "/api/graphql", (req, res) => {
+      const query: string = req.body.query || "";
+      const variables = req.body.variables || {};
 
-    // GET /vulnerabilities/789 - single vulnerability detail
-    mockGitLab.addMockHandler("get", `/vulnerabilities/${TEST_VULNERABILITY_ID}`, (req, res) => {
-      res.json(mockVulnerability);
-    });
+      if (query.includes("vulnerabilityDismiss")) {
+        lastDismissInput = variables.input;
+        res.json({
+          data: {
+            vulnerabilityDismiss: {
+              vulnerability: {
+                id: TEST_VULNERABILITY_GID,
+                state: "DISMISSED",
+                dismissedAt: "2024-06-10T12:00:00Z",
+                dismissalReason: variables.input?.dismissalReason || null,
+              },
+              errors: [],
+            },
+          },
+        });
+        return;
+      }
 
-    // POST /vulnerabilities/789/dismiss - dismiss with body capture
-    mockGitLab.addMockHandler("post", `/vulnerabilities/${TEST_VULNERABILITY_ID}/dismiss`, (req, res) => {
-      lastDismissBody = req.body;
-      res.json({
-        ...mockVulnerability,
-        state: "dismissed",
-        dismissed_at: "2024-06-10T12:00:00Z",
-        dismissal_reason: req.body?.reason || "false_positive",
-      });
-    });
+      if (query.includes("vulnerabilityConfirm")) {
+        lastConfirmInput = variables.input;
+        res.json({
+          data: {
+            vulnerabilityConfirm: {
+              vulnerability: {
+                id: TEST_VULNERABILITY_GID,
+                state: "CONFIRMED",
+                confirmedAt: "2024-06-10T12:00:00Z",
+              },
+              errors: [],
+            },
+          },
+        });
+        return;
+      }
 
-    // POST /vulnerabilities/789/confirm - confirm with body capture
-    mockGitLab.addMockHandler("post", `/vulnerabilities/${TEST_VULNERABILITY_ID}/confirm`, (req, res) => {
-      lastConfirmBody = req.body;
-      res.json({
-        ...mockVulnerability,
-        state: "confirmed",
-        confirmed_at: "2024-06-10T12:00:00Z",
-      });
+      if (query.includes("listProjectVulnerabilities")) {
+        lastListVariables = variables;
+        let nodes = mockVulnerabilityList;
+        if (variables.state) {
+          nodes = nodes.filter(v => variables.state.includes(v.state));
+        }
+        if (variables.severity) {
+          nodes = nodes.filter(v => variables.severity.includes(v.severity));
+        }
+        if (variables.reportType) {
+          nodes = nodes.filter(v => variables.reportType.includes(v.reportType));
+        }
+        res.json({
+          data: {
+            project: {
+              vulnerabilities: {
+                nodes,
+                pageInfo: { endCursor: "cursor-abc", hasNextPage: false },
+              },
+            },
+          },
+        });
+        return;
+      }
+
+      if (query.includes("getVulnerability")) {
+        lastGetId = variables.id;
+        res.json({
+          data: {
+            vulnerability: {
+              ...mockVulnerability,
+              project: {
+                id: "gid://gitlab/Project/456",
+                name: "Test Project",
+                fullPath: TEST_PROJECT_FULL_PATH,
+              },
+            },
+          },
+        });
+        return;
+      }
+
+      res
+        .status(400)
+        .json({ errors: [{ message: `Unexpected GraphQL query: ${query.slice(0, 80)}` }] });
     });
 
     await mockGitLab.start();
@@ -178,117 +235,150 @@ describe("vulnerability tools", () => {
     await mockGitLab.stop();
   });
 
-  test("list_project_vulnerabilities returns array of vulnerabilities", async () => {
+  test("list_project_vulnerabilities returns vulnerabilities with pageInfo", async () => {
     const result = await callTool(
       "list_project_vulnerabilities",
       { project_id: TEST_PROJECT_ID },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      baseEnv()
     );
 
-    assert.ok(Array.isArray(result), "Response should be an array");
-    assert.strictEqual(result.length, 3, "Should return 3 vulnerabilities");
-    assert.strictEqual(result[0].id, 789);
-    assert.strictEqual(result[0].title, "Hard-coded credential detected");
+    assert.ok(
+      Array.isArray(result.vulnerabilities),
+      "Response should contain vulnerabilities array"
+    );
+    assert.strictEqual(result.vulnerabilities.length, 3, "Should return 3 vulnerabilities");
+    assert.strictEqual(result.vulnerabilities[0].id, TEST_VULNERABILITY_GID);
+    assert.strictEqual(result.vulnerabilities[0].title, "Hard-coded credential detected");
+    assert.ok(result.pageInfo, "Response should include pageInfo for cursor pagination");
+    assert.strictEqual(result.pageInfo.hasNextPage, false);
   });
 
-  test("list_project_vulnerabilities forwards state filter as query param", async () => {
-    lastListQueryParams = null;
+  test("list_project_vulnerabilities resolves numeric project ID to full path", async () => {
+    lastListVariables = null;
 
-    await callTool(
+    await callTool("list_project_vulnerabilities", { project_id: TEST_PROJECT_ID }, baseEnv());
+
+    assert.ok(lastListVariables, "GraphQL variables should have been captured");
+    assert.strictEqual(
+      lastListVariables.fullPath,
+      TEST_PROJECT_FULL_PATH,
+      "Numeric project ID should be resolved to the project full path"
+    );
+  });
+
+  test("list_project_vulnerabilities passes state filter as GraphQL enum", async () => {
+    lastListVariables = null;
+
+    const result = await callTool(
       "list_project_vulnerabilities",
       { project_id: TEST_PROJECT_ID, state: "detected" },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      baseEnv()
     );
 
-    assert.ok(lastListQueryParams, "Query params should have been captured");
-    assert.strictEqual(lastListQueryParams.state, "detected", "state filter should be forwarded");
+    assert.ok(lastListVariables, "GraphQL variables should have been captured");
+    assert.deepStrictEqual(
+      lastListVariables.state,
+      ["DETECTED"],
+      "state should be uppercased enum array"
+    );
+    assert.strictEqual(result.vulnerabilities.length, 1, "Mock should filter to only DETECTED");
   });
 
-  test("list_project_vulnerabilities forwards severity filter as query param", async () => {
-    lastListQueryParams = null;
+  test("list_project_vulnerabilities passes severity filter as GraphQL enum", async () => {
+    lastListVariables = null;
 
-    await callTool(
+    const result = await callTool(
       "list_project_vulnerabilities",
       { project_id: TEST_PROJECT_ID, severity: "critical" },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      baseEnv()
     );
 
-    assert.ok(lastListQueryParams, "Query params should have been captured");
-    assert.strictEqual(lastListQueryParams.severity, "critical", "severity filter should be forwarded");
+    assert.ok(lastListVariables, "GraphQL variables should have been captured");
+    assert.deepStrictEqual(lastListVariables.severity, ["CRITICAL"]);
+    assert.strictEqual(result.vulnerabilities.length, 1, "Mock should filter to only CRITICAL");
   });
 
-  test("list_project_vulnerabilities forwards scanner filter as query param", async () => {
-    lastListQueryParams = null;
+  test("list_project_vulnerabilities passes report_type filter as GraphQL enum", async () => {
+    lastListVariables = null;
+
+    const result = await callTool(
+      "list_project_vulnerabilities",
+      { project_id: TEST_PROJECT_ID, report_type: "secret_detection" },
+      baseEnv()
+    );
+
+    assert.ok(lastListVariables, "GraphQL variables should have been captured");
+    assert.deepStrictEqual(lastListVariables.reportType, ["SECRET_DETECTION"]);
+    assert.strictEqual(
+      result.vulnerabilities.length,
+      1,
+      "Mock should filter to only SECRET_DETECTION"
+    );
+  });
+
+  test("list_project_vulnerabilities forwards cursor pagination", async () => {
+    lastListVariables = null;
 
     await callTool(
       "list_project_vulnerabilities",
-      { project_id: TEST_PROJECT_ID, scanner: "SECRET_DETECTION" },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      { project_id: TEST_PROJECT_ID, first: 50, after: "cursor-abc" },
+      baseEnv()
     );
 
-    assert.ok(lastListQueryParams, "Query params should have been captured");
-    assert.strictEqual(lastListQueryParams.scanner, "SECRET_DETECTION", "scanner filter should be forwarded");
+    assert.ok(lastListVariables, "GraphQL variables should have been captured");
+    assert.strictEqual(lastListVariables.first, 50);
+    assert.strictEqual(lastListVariables.after, "cursor-abc");
   });
 
-  test("get_vulnerability returns full vulnerability object", async () => {
+  test("get_vulnerability returns full vulnerability object via GID", async () => {
+    lastGetId = null;
+
     const result = await callTool(
       "get_vulnerability",
       { vulnerability_id: TEST_VULNERABILITY_ID },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      baseEnv()
     );
 
-    assert.strictEqual(result.id, 789);
+    assert.strictEqual(
+      lastGetId,
+      TEST_VULNERABILITY_GID,
+      "Numeric ID should be converted to a GraphQL global ID"
+    );
+    assert.strictEqual(result.id, TEST_VULNERABILITY_GID);
     assert.strictEqual(result.title, "Hard-coded credential detected");
     assert.strictEqual(result.description, "A hard-coded credential was found in source code");
-    assert.strictEqual(result.state, "detected");
-    assert.strictEqual(result.severity, "critical");
-    assert.strictEqual(result.scanner.name, "SECRET_DETECTION");
+    assert.strictEqual(result.state, "DETECTED");
+    assert.strictEqual(result.severity, "CRITICAL");
+    assert.strictEqual(result.reportType, "SECRET_DETECTION");
     assert.strictEqual(result.location.file, "config/secrets.yml");
-    assert.strictEqual(result.location.start_line, 42);
+    assert.strictEqual(result.location.startLine, 42);
     assert.strictEqual(result.identifiers[0].name, "CVE-2024-0001");
     assert.strictEqual(result.links[0].url, "https://example.com/vuln/789");
+    assert.strictEqual(result.project.fullPath, TEST_PROJECT_FULL_PATH);
   });
 
-  test("dismiss_vulnerability sends correct POST body with reason", async () => {
-    lastDismissBody = null;
+  test("dismiss_vulnerability sends dismissalReason in mutation input", async () => {
+    lastDismissInput = null;
 
     const result = await callTool(
       "dismiss_vulnerability",
       { vulnerability_id: TEST_VULNERABILITY_ID, reason: "false_positive" },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      baseEnv()
     );
 
-    assert.ok(lastDismissBody, "Request body should have been captured");
-    assert.strictEqual(lastDismissBody.reason, "false_positive", "reason should be in request body");
-    assert.strictEqual(result.state, "dismissed");
+    assert.ok(lastDismissInput, "Mutation input should have been captured");
+    assert.strictEqual(lastDismissInput.id, TEST_VULNERABILITY_GID);
+    assert.strictEqual(
+      lastDismissInput.dismissalReason,
+      "FALSE_POSITIVE",
+      "Reason should be mapped to the GraphQL enum"
+    );
+    assert.strictEqual(result.state, "DISMISSED");
+    assert.strictEqual(result.dismissalReason, "FALSE_POSITIVE");
   });
 
   test("dismiss_vulnerability includes comment when provided", async () => {
-    lastDismissBody = null;
+    lastDismissInput = null;
 
     await callTool(
       "dismiss_vulnerability",
@@ -297,37 +387,49 @@ describe("vulnerability tools", () => {
         reason: "acceptable_risk",
         comment: "Reviewed by security team, risk accepted",
       },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      baseEnv()
     );
 
-    assert.ok(lastDismissBody, "Request body should have been captured");
-    assert.strictEqual(lastDismissBody.reason, "acceptable_risk");
-    assert.strictEqual(lastDismissBody.comment, "Reviewed by security team, risk accepted");
+    assert.ok(lastDismissInput, "Mutation input should have been captured");
+    assert.strictEqual(lastDismissInput.dismissalReason, "ACCEPTABLE_RISK");
+    assert.strictEqual(lastDismissInput.comment, "Reviewed by security team, risk accepted");
   });
 
-  test("confirm_vulnerability sends POST to correct endpoint", async () => {
-    lastConfirmBody = null;
+  test("dismiss_vulnerability accepts mitigating_control and not_applicable reasons", async () => {
+    lastDismissInput = null;
+    await callTool(
+      "dismiss_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID, reason: "mitigating_control" },
+      baseEnv()
+    );
+    assert.strictEqual(lastDismissInput.dismissalReason, "MITIGATING_CONTROL");
+
+    lastDismissInput = null;
+    await callTool(
+      "dismiss_vulnerability",
+      { vulnerability_id: TEST_VULNERABILITY_ID, reason: "not_applicable" },
+      baseEnv()
+    );
+    assert.strictEqual(lastDismissInput.dismissalReason, "NOT_APPLICABLE");
+  });
+
+  test("confirm_vulnerability sends mutation with GID", async () => {
+    lastConfirmInput = null;
 
     const result = await callTool(
       "confirm_vulnerability",
       { vulnerability_id: TEST_VULNERABILITY_ID },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      baseEnv()
     );
 
-    assert.strictEqual(result.state, "confirmed");
-    assert.strictEqual(result.confirmed_at, "2024-06-10T12:00:00Z");
+    assert.ok(lastConfirmInput, "Mutation input should have been captured");
+    assert.strictEqual(lastConfirmInput.id, TEST_VULNERABILITY_GID);
+    assert.strictEqual(result.state, "CONFIRMED");
+    assert.strictEqual(result.confirmedAt, "2024-06-10T12:00:00Z");
   });
 
   test("confirm_vulnerability includes comment when provided", async () => {
-    lastConfirmBody = null;
+    lastConfirmInput = null;
 
     await callTool(
       "confirm_vulnerability",
@@ -335,15 +437,11 @@ describe("vulnerability tools", () => {
         vulnerability_id: TEST_VULNERABILITY_ID,
         comment: "Confirmed after manual verification",
       },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-      }
+      baseEnv()
     );
 
-    assert.ok(lastConfirmBody, "Request body should have been captured");
-    assert.strictEqual(lastConfirmBody.comment, "Confirmed after manual verification");
+    assert.ok(lastConfirmInput, "Mutation input should have been captured");
+    assert.strictEqual(lastConfirmInput.comment, "Confirmed after manual verification");
   });
 
   // Read-only mode tests
@@ -351,31 +449,24 @@ describe("vulnerability tools", () => {
     const result = await callTool(
       "list_project_vulnerabilities",
       { project_id: TEST_PROJECT_ID },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-        GITLAB_PERMISSION_MODE: "readonly",
-      }
+      { ...baseEnv(), GITLAB_PERMISSION_MODE: "readonly" }
     );
 
-    assert.ok(Array.isArray(result), "Response should be an array in readonly mode");
-    assert.strictEqual(result.length, 3);
+    assert.ok(
+      Array.isArray(result.vulnerabilities),
+      "Should return vulnerabilities in readonly mode"
+    );
+    assert.strictEqual(result.vulnerabilities.length, 3);
   });
 
   test("read-only mode: get_vulnerability succeeds", async () => {
     const result = await callTool(
       "get_vulnerability",
       { vulnerability_id: TEST_VULNERABILITY_ID },
-      {
-        GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-        GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-        GITLAB_TOOLSETS: "vulnerabilities",
-        GITLAB_PERMISSION_MODE: "readonly",
-      }
+      { ...baseEnv(), GITLAB_PERMISSION_MODE: "readonly" }
     );
 
-    assert.strictEqual(result.id, 789);
+    assert.strictEqual(result.id, TEST_VULNERABILITY_GID);
     assert.strictEqual(result.title, "Hard-coded credential detected");
   });
 
@@ -385,12 +476,7 @@ describe("vulnerability tools", () => {
         callTool(
           "dismiss_vulnerability",
           { vulnerability_id: TEST_VULNERABILITY_ID, reason: "false_positive" },
-          {
-            GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-            GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-            GITLAB_TOOLSETS: "vulnerabilities",
-            GITLAB_PERMISSION_MODE: "readonly",
-          }
+          { ...baseEnv(), GITLAB_PERMISSION_MODE: "readonly" }
         ),
       (err: any) => {
         const msg = typeof err === "string" ? err : err?.message || JSON.stringify(err);
@@ -412,12 +498,7 @@ describe("vulnerability tools", () => {
         callTool(
           "confirm_vulnerability",
           { vulnerability_id: TEST_VULNERABILITY_ID },
-          {
-            GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
-            GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
-            GITLAB_TOOLSETS: "vulnerabilities",
-            GITLAB_PERMISSION_MODE: "readonly",
-          }
+          { ...baseEnv(), GITLAB_PERMISSION_MODE: "readonly" }
         ),
       (err: any) => {
         const msg = typeof err === "string" ? err : err?.message || JSON.stringify(err);

--- a/tools/registry.ts
+++ b/tools/registry.ts
@@ -223,6 +223,10 @@ import {
   UpdateDependencyProxySettingsSchema,
   ListDependencyProxyBlobsSchema,
   PurgeDependencyProxyCacheSchema,
+  ListProjectVulnerabilitiesSchema,
+  GetVulnerabilitySchema,
+  DismissVulnerabilitySchema,
+  ConfirmVulnerabilitySchema,
 } from "../schemas.js";
 
 const IS_REMOTE = SSE || STREAMABLE_HTTP;
@@ -1311,6 +1315,27 @@ export const allTools = [
     description: "Schedule purge of all cached dependency proxy blobs for a group",
     inputSchema: toJSONSchema(PurgeDependencyProxyCacheSchema),
   },
+  // --- Vulnerability tools ---
+  {
+    name: "list_project_vulnerabilities",
+    description: "List vulnerabilities for a project with optional state, severity, and scanner filters",
+    inputSchema: toJSONSchema(ListProjectVulnerabilitiesSchema),
+  },
+  {
+    name: "get_vulnerability",
+    description: "Get full details of a specific vulnerability",
+    inputSchema: toJSONSchema(GetVulnerabilitySchema),
+  },
+  {
+    name: "dismiss_vulnerability",
+    description: "Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, no_longer_relevant)",
+    inputSchema: toJSONSchema(DismissVulnerabilitySchema),
+  },
+  {
+    name: "confirm_vulnerability",
+    description: "Confirm a vulnerability as a real finding requiring remediation",
+    inputSchema: toJSONSchema(ConfirmVulnerabilitySchema),
+  },
   // --- Meta tool: Dynamic tool discovery ---
   {
     name: "discover_tools",
@@ -1448,6 +1473,8 @@ export const readOnlyTools = new Set([
   "get_group_variable",
   "get_dependency_proxy_settings",
   "list_dependency_proxy_blobs",
+  "list_project_vulnerabilities",
+  "get_vulnerability",
 ]);
 
 // Define which tools are destructive (data loss potential)
@@ -1590,7 +1617,8 @@ export type ToolsetId =
   | "webhooks"
   | "search"
   | "variables"
-  | "dependency_proxy";
+  | "dependency_proxy"
+  | "vulnerabilities";
 
 export interface ToolsetDefinition {
   readonly id: ToolsetId;
@@ -1917,6 +1945,16 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
       "update_dependency_proxy_settings",
       "list_dependency_proxy_blobs",
       "purge_dependency_proxy_cache",
+    ]),
+  },
+  {
+    id: "vulnerabilities",
+    isDefault: false,
+    tools: new Set([
+      "list_project_vulnerabilities",
+      "get_vulnerability",
+      "dismiss_vulnerability",
+      "confirm_vulnerability",
     ]),
   },
 ] as const;

--- a/tools/registry.ts
+++ b/tools/registry.ts
@@ -1318,7 +1318,7 @@ export const allTools = [
   // --- Vulnerability tools ---
   {
     name: "list_project_vulnerabilities",
-    description: "List vulnerabilities for a project with optional state, severity, and scanner filters",
+    description: "List vulnerabilities for a project with optional state, severity, and report type filters (GraphQL-backed, cursor pagination)",
     inputSchema: toJSONSchema(ListProjectVulnerabilitiesSchema),
   },
   {
@@ -1328,7 +1328,7 @@ export const allTools = [
   },
   {
     name: "dismiss_vulnerability",
-    description: "Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, no_longer_relevant)",
+    description: "Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, mitigating_control, not_applicable) and optional comment",
     inputSchema: toJSONSchema(DismissVulnerabilitySchema),
   },
   {


### PR DESCRIPTION
Add opt-in vulnerabilities toolset (GITLAB_TOOLSETS=vulnerabilities) with four tools: list_project_vulnerabilities, get_vulnerability, dismiss_vulnerability, and confirm_vulnerability.

- Zod input schemas in schemas.ts
- Tool registration, toolset definition, permission sets in tools/registry.ts
- API functions and handleToolCall cases in index.ts
- Skill reference at skills/gitlab-mcp/reference/vulnerability-triage.md
- Tests at test/test-vulnerabilities.ts (13 tests covering filters, request bodies, and readonly permission blocking)
- Generated docs at docs/tools/vulnerabilities.md

dismiss/confirm require modify or full permission mode (blocked in readonly). Neither is in deleteTools (available in modify mode as state transitions).