### PR TITLE
fix: keep Draft Notes API fields in GitLabDraftNoteSchema

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -2931,26 +2931,31 @@ const optionalMergeRequestThreadPosition = z.preprocess(
 );
 
 // Draft Notes API schemas
+// Response shape follows Draft Notes API (not Notes API): note, author_id,
+// line_code, merge_request_id, commit_id — no created_at/updated_at.
 export const GitLabDraftNoteSchema = z
   .object({
     id: z.coerce.string(),
+    author_id: z.coerce.number().nullable().optional(),
     author: GitLabUserSchema.optional(),
     body: z.string().optional(),
-    note: z.string().optional(), // Some APIs might use 'note' instead of 'body'
-    created_at: z.string().optional(),
-    updated_at: z.string().optional(),
+    note: z.string().optional(), // Draft Notes API uses 'note'; keep 'body' for callers
+    line_code: z.string().nullable().optional(),
+    merge_request_id: z.coerce.number().nullable().optional(),
+    commit_id: z.string().nullable().optional(),
     discussion_id: z.string().nullable().optional(),
     position: z.record(z.unknown()).nullable().optional(),
     resolve_discussion: z.coerce.boolean().optional(),
   })
   .transform(data => ({
-    // Normalize the response to always have consistent field names
     id: data.id,
+    author_id: data.author_id ?? null,
     author: data.author,
     body: data.body || data.note || "",
-    created_at: data.created_at || "",
-    updated_at: data.updated_at || "",
-    discussion_id: data.discussion_id || null,
+    line_code: data.line_code ?? null,
+    merge_request_id: data.merge_request_id ?? null,
+    commit_id: data.commit_id ?? null,
+    discussion_id: data.discussion_id ?? null,
     position: data.position,
     resolve_discussion: data.resolve_discussion,
   }));

--- a/test/draft-note-schema.test.ts
+++ b/test/draft-note-schema.test.ts
@@ -13,6 +13,9 @@ test("draft note schema keeps Draft Notes API fields and drops fake timestamps",
     discussion_id: null,
     position: { new_path: "src/app.ts", new_line: 17 },
     resolve_discussion: false,
+    // Notes-API leftovers that Draft Notes API never returns — must be stripped
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
   });
 
   assert.equal(parsed.id, "42");

--- a/test/draft-note-schema.test.ts
+++ b/test/draft-note-schema.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GitLabDraftNoteSchema } from "../schemas.js";
+
+test("draft note schema keeps Draft Notes API fields and drops fake timestamps", () => {
+  const parsed = GitLabDraftNoteSchema.parse({
+    id: 42,
+    author_id: 7,
+    note: "looks wrong on this line",
+    line_code: "a1b2c3d4e5f6_12_17",
+    merge_request_id: 99,
+    commit_id: "abc123",
+    discussion_id: null,
+    position: { new_path: "src/app.ts", new_line: 17 },
+    resolve_discussion: false,
+  });
+
+  assert.equal(parsed.id, "42");
+  assert.equal(parsed.author_id, 7);
+  assert.equal(parsed.body, "looks wrong on this line");
+  assert.equal(parsed.line_code, "a1b2c3d4e5f6_12_17");
+  assert.equal(parsed.merge_request_id, 99);
+  assert.equal(parsed.commit_id, "abc123");
+  assert.equal(parsed.discussion_id, null);
+  assert.equal(parsed.resolve_discussion, false);
+  assert.equal("created_at" in parsed, false);
+  assert.equal("updated_at" in parsed, false);
+});
+
+test("draft note schema preserves null line_code for unresolved positions", () => {
+  const parsed = GitLabDraftNoteSchema.parse({
+    id: "43",
+    author_id: 7,
+    note: "orphan draft",
+    line_code: null,
+    merge_request_id: 99,
+    commit_id: null,
+    discussion_id: null,
+    position: null,
+    resolve_discussion: false,
+  });
+
+  assert.equal(parsed.line_code, null);
+  assert.equal(parsed.commit_id, null);
+});


### PR DESCRIPTION
## Summary
- Align `GitLabDraftNoteSchema` with the Draft Notes API: keep `line_code`, `author_id`, `merge_request_id`, and `commit_id`.
- Drop fabricated `created_at` / `updated_at` (not returned by this endpoint).
- Keep `note` → `body` normalization for callers.
- Add schema regression tests.

Fixes #609

## Test plan
- [x] `node --import tsx/esm --test test/draft-note-schema.test.ts`
- [x] `npm run build`
- [ ] Spot-check `list_draft_notes` / `get_draft_note` against a real MR with a positioned draft (optional)


Made with [Cursor](https://cursor.com)