### PR TITLE
fix: resolve remaining CodeQL open alerts

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -13,6 +13,9 @@ on:
           - minor
           - major
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/scripts/generate-tool-docs.ts
+++ b/scripts/generate-tool-docs.ts
@@ -259,7 +259,7 @@ function buildGroupPage(id: ToolsetId, toolNames: string[]): string {
   lines.push("## Tools in this group");
   lines.push("");
   for (const name of toolNames) {
-    lines.push(`- [\`${name}\`](#${name.replace(/_/g, "_")}) — ${rwBadge(name)}`);
+    lines.push(`- [\`${name}\`](#${name}) — ${rwBadge(name)}`);
   }
   lines.push("");
   lines.push("---");


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: write` to `manual-release.yml` (CodeQL #23)
- Remove no-op `replace(/_/g, "_")` in docs generator (CodeQL #46)
- Remaining open alerts (#25/#26/#36/#47/#48/#51) dismissed as false positive / won't fix / used in tests

## Test plan
- [ ] Confirm CodeQL #23 and #46 close after merge scan
- [ ] Spot-check generated tool docs anchors still link correctly