### PR TITLE
fix: add permissions to docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,9 @@ on:
         required: true
         default: 'latest'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to `docker-publish.yml` (CodeQL #2)
- Dismissed remaining open alerts: #11 (won't fix — intentional TLS opt-in), #15 (used in tests)

## Test plan
- [ ] Confirm CodeQL #2 closes after merge scan
- [ ] Confirm security/code-scanning open count is 0