### PR TITLE
fix: align logging and allow json logging via LOG_FORMAT=json

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -432,6 +432,36 @@ Legacy additive flag for pipeline-related tools. Prefer `GITLAB_TOOLSETS=pipelin
 > just three toolsets. Use `GITLAB_TOOLSETS` (groups) and `GITLAB_TOOLS` (individual tools)
 > instead.
 
+## Logging
+
+### `LOG_LEVEL`
+
+Pino log level.
+
+Values: `fatal`, `error`, `warn`, `info`, `debug`, `trace`, `silent`
+
+Default:
+
+- `info`
+
+### `LOG_FORMAT`
+
+Controls log output format. When set to `json`, disables `pino-pretty` and
+writes newline-delimited JSON to stderr. Useful for production deployments
+where logs are ingested by a collector (Datadog, Loki, CloudWatch, etc.).
+
+Values: `json` | _(any other value or unset uses `pino-pretty`)_
+
+Default:
+
+- _(unset — human-readable colored output via `pino-pretty`)_
+
+Example:
+
+```bash
+LOG_FORMAT=json LOG_LEVEL=warn npm start
+```
+
 ## Transport and Server Runtime
 
 ### `STREAMABLE_HTTP`

--- a/index.ts
+++ b/index.ts
@@ -550,50 +550,9 @@ import {
   createHash,
   timingSafeEqual,
 } from "node:crypto";
-import { pino } from "pino";
+import { createLogger } from "./utils/logger.js";
 
-const logger = pino(
-  {
-    level: process.env.LOG_LEVEL || "info",
-    // Redact sensitive values that must never appear in logs. Covers both
-    // typical auth-context property names and common HTTP header-bag shapes
-    // that tool/fetch wrappers may include when logging errors.
-    redact: {
-      paths: [
-        "token",
-        "*.token",
-        "ctx.token",
-        "context.token",
-        "authData.token",
-        "auth.token",
-        "headers.authorization",
-        "headers.Authorization",
-        'headers["private-token"]',
-        'headers["Private-Token"]',
-        'headers["job-token"]',
-        'headers["JOB-TOKEN"]',
-        'headers["mcp-session-id"]',
-        'headers["Mcp-Session-Id"]',
-        "sessionId",
-        "*.sessionId",
-        "ctx.sessionId",
-        "context.sessionId",
-      ],
-      censor: "[REDACTED]",
-    },
-    ...(process.env.LOG_FORMAT !== "json" && {
-      transport: {
-        target: "pino-pretty",
-        options: {
-          colorize: true,
-          levelFirst: true,
-          destination: 2,
-        },
-      },
-    }),
-  },
-  ...(process.env.LOG_FORMAT === "json" ? [pino.destination(2)] : []),
-);
+const logger = createLogger();
 
 /**
  * Read version from package.json

--- a/index.ts
+++ b/index.ts
@@ -552,43 +552,48 @@ import {
 } from "node:crypto";
 import { pino } from "pino";
 
-const logger = pino({
-  level: process.env.LOG_LEVEL || "info",
-  // Redact sensitive values that must never appear in logs. Covers both
-  // typical auth-context property names and common HTTP header-bag shapes
-  // that tool/fetch wrappers may include when logging errors.
-  redact: {
-    paths: [
-      "token",
-      "*.token",
-      "ctx.token",
-      "context.token",
-      "authData.token",
-      "auth.token",
-      "headers.authorization",
-      "headers.Authorization",
-      'headers["private-token"]',
-      'headers["Private-Token"]',
-      'headers["job-token"]',
-      'headers["JOB-TOKEN"]',
-      'headers["mcp-session-id"]',
-      'headers["Mcp-Session-Id"]',
-      "sessionId",
-      "*.sessionId",
-      "ctx.sessionId",
-      "context.sessionId",
-    ],
-    censor: "[REDACTED]",
-  },
-  transport: {
-    target: "pino-pretty",
-    options: {
-      colorize: true,
-      levelFirst: true,
-      destination: 2,
+const logger = pino(
+  {
+    level: process.env.LOG_LEVEL || "info",
+    // Redact sensitive values that must never appear in logs. Covers both
+    // typical auth-context property names and common HTTP header-bag shapes
+    // that tool/fetch wrappers may include when logging errors.
+    redact: {
+      paths: [
+        "token",
+        "*.token",
+        "ctx.token",
+        "context.token",
+        "authData.token",
+        "auth.token",
+        "headers.authorization",
+        "headers.Authorization",
+        'headers["private-token"]',
+        'headers["Private-Token"]',
+        'headers["job-token"]',
+        'headers["JOB-TOKEN"]',
+        'headers["mcp-session-id"]',
+        'headers["Mcp-Session-Id"]',
+        "sessionId",
+        "*.sessionId",
+        "ctx.sessionId",
+        "context.sessionId",
+      ],
+      censor: "[REDACTED]",
     },
+    ...(process.env.LOG_FORMAT !== "json" && {
+      transport: {
+        target: "pino-pretty",
+        options: {
+          colorize: true,
+          levelFirst: true,
+          destination: 2,
+        },
+      },
+    }),
   },
-});
+  ...(process.env.LOG_FORMAT === "json" ? [pino.destination(2)] : []),
+);
 
 /**
  * Read version from package.json

--- a/oauth-proxy.ts
+++ b/oauth-proxy.ts
@@ -57,7 +57,6 @@ import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/serv
 import type { AuthorizationParams, OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js";
 import type { Response } from "express";
 import { randomUUID, randomBytes, createHash } from "node:crypto";
-import { pino } from "pino";
 import type { Request } from "express";
 
 import {
@@ -76,24 +75,9 @@ import {
   openStoredTokensCode,
 } from "./stateless/stored-tokens.js";
 import type { StatelessKeyMaterial } from "./stateless/index.js";
+import { createLogger } from "./utils/logger.js";
 
-const logger = pino(
-  {
-    name: "gitlab-mcp-oauth-proxy",
-    level: process.env.LOG_LEVEL || "info",
-    ...(process.env.LOG_FORMAT !== "json" && {
-      transport: {
-        target: "pino-pretty",
-        options: {
-          colorize: true,
-          levelFirst: true,
-          destination: 2,
-        },
-      },
-    }),
-  },
-  ...(process.env.LOG_FORMAT === "json" ? [pino.destination(2)] : []),
-);
+const logger = createLogger("gitlab-mcp-oauth-proxy");
 
 /**
  * Shape of the response from GitLab's /oauth/token/info endpoint.

--- a/oauth-proxy.ts
+++ b/oauth-proxy.ts
@@ -77,7 +77,23 @@ import {
 } from "./stateless/stored-tokens.js";
 import type { StatelessKeyMaterial } from "./stateless/index.js";
 
-const logger = pino({ name: "gitlab-mcp-oauth-proxy" });
+const logger = pino(
+  {
+    name: "gitlab-mcp-oauth-proxy",
+    level: process.env.LOG_LEVEL || "info",
+    ...(process.env.LOG_FORMAT !== "json" && {
+      transport: {
+        target: "pino-pretty",
+        options: {
+          colorize: true,
+          levelFirst: true,
+          destination: 2,
+        },
+      },
+    }),
+  },
+  ...(process.env.LOG_FORMAT === "json" ? [pino.destination(2)] : []),
+);
 
 /**
  * Shape of the response from GitLab's /oauth/token/info endpoint.

--- a/oauth.ts
+++ b/oauth.ts
@@ -11,10 +11,23 @@ import open from "open";
 import pkceChallenge from "pkce-challenge";
 import { pino } from "pino";
 
-const logger = pino({
-  name: "gitlab-mcp-oauth",
-  level: process.env.LOG_LEVEL || "info",
-}, pino.destination(2));
+const logger = pino(
+  {
+    name: "gitlab-mcp-oauth",
+    level: process.env.LOG_LEVEL || "info",
+    ...(process.env.LOG_FORMAT !== "json" && {
+      transport: {
+        target: "pino-pretty",
+        options: {
+          colorize: true,
+          levelFirst: true,
+          destination: 2,
+        },
+      },
+    }),
+  },
+  ...(process.env.LOG_FORMAT === "json" ? [pino.destination(2)] : []),
+);
 
 const execFileAsync = promisify(execFile);
 

--- a/oauth.ts
+++ b/oauth.ts
@@ -9,25 +9,9 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import open from "open";
 import pkceChallenge from "pkce-challenge";
-import { pino } from "pino";
+import { createLogger } from "./utils/logger.js";
 
-const logger = pino(
-  {
-    name: "gitlab-mcp-oauth",
-    level: process.env.LOG_LEVEL || "info",
-    ...(process.env.LOG_FORMAT !== "json" && {
-      transport: {
-        target: "pino-pretty",
-        options: {
-          colorize: true,
-          levelFirst: true,
-          destination: 2,
-        },
-      },
-    }),
-  },
-  ...(process.env.LOG_FORMAT === "json" ? [pino.destination(2)] : []),
-);
+const logger = createLogger("gitlab-mcp-oauth");
 
 const execFileAsync = promisify(execFile);
 

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,57 @@
+import { pino, type Logger } from "pino";
+
+const REDACT_PATHS = [
+  "token",
+  "*.token",
+  "ctx.token",
+  "context.token",
+  "authData.token",
+  "auth.token",
+  "headers.authorization",
+  "headers.Authorization",
+  'headers["private-token"]',
+  'headers["Private-Token"]',
+  'headers["job-token"]',
+  'headers["JOB-TOKEN"]',
+  'headers["mcp-session-id"]',
+  'headers["Mcp-Session-Id"]',
+  "sessionId",
+  "*.sessionId",
+  "ctx.sessionId",
+  "context.sessionId",
+];
+
+/**
+ * Create a pino logger with consistent redaction, level, format, and
+ * destination across the entire codebase.
+ *
+ * - LOG_LEVEL (default "info") controls the minimum severity.
+ * - LOG_FORMAT=json disables pino-pretty and outputs newline-delimited JSON
+ *   to stderr.
+ * - All loggers redact the same set of sensitive fields.
+ */
+export function createLogger(name?: string): Logger {
+  const isJson = process.env.LOG_FORMAT === "json";
+
+  return pino(
+    {
+      ...(name && { name }),
+      level: process.env.LOG_LEVEL || "info",
+      redact: {
+        paths: REDACT_PATHS,
+        censor: "[REDACTED]",
+      },
+      ...(!isJson && {
+        transport: {
+          target: "pino-pretty",
+          options: {
+            colorize: true,
+            levelFirst: true,
+            destination: 2,
+          },
+        },
+      }),
+    },
+    ...(isJson ? [pino.destination(2)] : []),
+  );
+}


### PR DESCRIPTION
Currently there are multiple loggers with different configs.
Logging is partly in json partly pretty printed.
This PR aligns the logger instance configs regarding log level and json / pretty printed logs.

In addition the log related env vars are documented in the relevant docs.