### PR TITLE
fix: add remediation hints for GHSA-2h44-8472-frjj dynamic URL rejections

### DIFF
--- a/downloads/proxy.ts
+++ b/downloads/proxy.ts
@@ -123,8 +123,9 @@ export function registerDownloadProxy(app: Express, deps: DownloadProxyDependenc
     if (deps.enableDynamicApiUrl && requestedApiUrl) {
       try {
         apiUrl = deps.resolveTrustedGitLabApiUrl(requestedApiUrl);
-      } catch {
-        res.status(400).json({ error: "Invalid X-GitLab-API-URL" });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Invalid X-GitLab-API-URL";
+        res.status(400).json({ error: message });
         return;
       }
     }

--- a/index.ts
+++ b/index.ts
@@ -1820,7 +1820,10 @@ function resolveTrustedGitLabApiUrl(value: string): string {
 
   const allowedApiUrl = GITLAB_ALLOWED_API_URLS_BY_HOST.get(parsed.host);
   if (!allowedApiUrl) {
-    throw new Error(`GitLab API URL host is not allowed: ${parsed.host}`);
+    throw new Error(
+      `GitLab API URL host is not allowed: ${parsed.host}. ` +
+        "Add the host to GITLAB_ALLOWED_HOSTS or GITLAB_API_URL."
+    );
   }
 
   return allowedApiUrl;
@@ -12930,8 +12933,9 @@ async function startStreamableHTTPServer(): Promise<void> {
     if (ENABLE_DYNAMIC_API_URL && dynamicApiUrl) {
       try {
         apiUrl = resolveTrustedGitLabApiUrl(dynamicApiUrl);
-      } catch {
-        logger.warn(`Invalid X-GitLab-API-URL provided: ${dynamicApiUrl}. Auth will fail.`);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : "Invalid X-GitLab-API-URL";
+        logger.warn(`Invalid X-GitLab-API-URL provided: ${dynamicApiUrl}. ${reason}`);
         return null; // Reject if URL is malformed or not allowed
       }
     }

--- a/test/dynamic-api-url-allowlist.test.ts
+++ b/test/dynamic-api-url-allowlist.test.ts
@@ -40,6 +40,7 @@ describe("Dynamic API URL allowlist", () => {
   let secondaryGitLab: MockGitLabServer;
   let attackerServer: Server | undefined;
   let mcpServer: ServerInstance | undefined;
+  let mcpPort: number;
   let mcpUrl: string;
   let secondaryHit = false;
   let getAttackerHits = () => 0;
@@ -62,7 +63,7 @@ describe("Dynamic API URL allowlist", () => {
     attackerServer = attacker.server;
     getAttackerHits = attacker.getHits;
 
-    const mcpPort = await findAvailablePort(3100);
+    mcpPort = await findAvailablePort(3100);
     mcpServer = await launchServer({
       mode: TransportMode.STREAMABLE_HTTP,
       port: mcpPort,
@@ -125,5 +126,27 @@ describe("Dynamic API URL allowlist", () => {
       0,
       "token-bearing requests must not reach untrusted hosts"
     );
+  });
+
+  test("returns remediation text when download proxy rejects untrusted dynamic hosts", async () => {
+    const server = attackerServer;
+    assert.ok(server, "attacker server should be running");
+    const attackerUrl = `http://${HOST}:${(server.address() as { port: number }).port}/api/v4`;
+
+    const response = await fetch(
+      `http://${HOST}:${mcpPort}/downloads/job-artifacts?project_id=1&job_id=1`,
+      {
+        headers: {
+          "Private-Token": MOCK_TOKEN,
+          "x-gitlab-api-url": attackerUrl,
+        },
+      }
+    );
+
+    assert.strictEqual(response.status, 400);
+    const body = (await response.json()) as { error: string };
+    assert.match(body.error, /not allowed/);
+    assert.match(body.error, /GITLAB_ALLOWED_HOSTS/);
+    assert.strictEqual(getAttackerHits(), 0, "download proxy must not forward to untrusted hosts");
   });
 });


### PR DESCRIPTION
## Summary
- Add `GITLAB_ALLOWED_HOSTS` / `GITLAB_API_URL` remediation text when `resolveTrustedGitLabApiUrl` rejects an untrusted host.
- Surface the underlying error in Streamable HTTP auth logs and download-proxy 400 responses instead of a generic "Invalid X-GitLab-API-URL".
- Assert remediation text in `test/dynamic-api-url-allowlist.test.ts`.

Follow-up to [GHSA-2h44-8472-frjj](https://github.com/zereight/gitlab-mcp/security/advisories/GHSA-2h44-8472-frjj) (CVE-2026-61559). Core SSRF fix landed in #553 (`v2.1.27`); this PR improves operator/debug UX only.

## Test plan
- [x] `npm run build`
- [x] `node --import tsx/esm --test test/dynamic-api-url-allowlist.test.ts`