### PR TITLE
feat: add configurable rate limit for client registration

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -577,6 +577,20 @@ limits are separate upstream constraints.
 Monitor rejections via `/metrics` → `rejectedByRateLimit` or
 `gitlab_mcp_requests_rejected_total{reason="rate_limit"}`.
 
+### `OAUTH_REGISTER_RATE_LIMIT_PER_HOUR`
+
+Maximum client registration (`POST /register`) requests allowed per IP per
+rolling 1-hour window. Applies when `GITLAB_MCP_OAUTH=true`.
+
+Valid range: `1`-`1000`.
+
+Default:
+
+- `20`
+
+Raise this if legitimate MCP clients are being throttled during dynamic client
+registration, or lower it to harden against registration abuse.
+
 ### `MAX_SESSIONS`
 
 Maximum concurrent MCP sessions on a single server instance (Streamable HTTP /

--- a/index.ts
+++ b/index.ts
@@ -1065,6 +1065,15 @@ function validateConfiguration(): void {
     }
   }
 
+  // Validate OAUTH_REGISTER_RATE_LIMIT_PER_HOUR
+  const registerRateLimitStr = process.env.OAUTH_REGISTER_RATE_LIMIT_PER_HOUR;
+  if (registerRateLimitStr) {
+    const limit = Number.parseInt(registerRateLimitStr, 10);
+    if (Number.isNaN(limit) || limit < 1 || limit > 1000) {
+      errors.push(`OAUTH_REGISTER_RATE_LIMIT_PER_HOUR must be between 1 and 1000, got: ${registerRateLimitStr}`);
+    }
+  }
+
   // Validate PORT
   const portStr = getConfig("port", "PORT");
   if (portStr) {
@@ -13782,6 +13791,15 @@ async function startStreamableHTTPServer(): Promise<void> {
     // ERR_ERL_INVALID_IP_ADDRESS. Strip the port first, then delegate to
     // ipKeyGenerator for correct IPv6 subnet handling.
     const rateLimitOptions = { keyGenerator: mcpRateLimitKeyGenerator };
+    const OAUTH_REGISTER_RATE_LIMIT_PER_HOUR = Number.parseInt(
+      process.env.OAUTH_REGISTER_RATE_LIMIT_PER_HOUR || "20",
+      10
+    );
+    const clientRegistrationRateLimitOptions = {
+      ...rateLimitOptions,
+      windowMs: 60 * 60 * 1000, // 1 hour
+      max: OAUTH_REGISTER_RATE_LIMIT_PER_HOUR,
+    };
     app.use(
       mcpAuthRouter({
         provider: oauthProvider,
@@ -13792,7 +13810,7 @@ async function startStreamableHTTPServer(): Promise<void> {
         authorizationOptions: { rateLimit: rateLimitOptions },
         tokenOptions: { rateLimit: rateLimitOptions },
         revocationOptions: { rateLimit: rateLimitOptions },
-        clientRegistrationOptions: { rateLimit: rateLimitOptions },
+        clientRegistrationOptions: { rateLimit: clientRegistrationRateLimitOptions },
       })
     );
 

--- a/index.ts
+++ b/index.ts
@@ -1068,9 +1068,9 @@ function validateConfiguration(): void {
   // Validate OAUTH_REGISTER_RATE_LIMIT_PER_HOUR
   const registerRateLimitStr = process.env.OAUTH_REGISTER_RATE_LIMIT_PER_HOUR;
   if (registerRateLimitStr) {
-    const limit = Number.parseInt(registerRateLimitStr, 10);
-    if (Number.isNaN(limit) || limit < 1 || limit > 1000) {
-      errors.push(`OAUTH_REGISTER_RATE_LIMIT_PER_HOUR must be between 1 and 1000, got: ${registerRateLimitStr}`);
+    const limit = Number(registerRateLimitStr);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
+      errors.push(`OAUTH_REGISTER_RATE_LIMIT_PER_HOUR must be an integer between 1 and 1000, got: ${registerRateLimitStr}`);
     }
   }
 
@@ -13791,10 +13791,11 @@ async function startStreamableHTTPServer(): Promise<void> {
     // ERR_ERL_INVALID_IP_ADDRESS. Strip the port first, then delegate to
     // ipKeyGenerator for correct IPv6 subnet handling.
     const rateLimitOptions = { keyGenerator: mcpRateLimitKeyGenerator };
-    const OAUTH_REGISTER_RATE_LIMIT_PER_HOUR = Number.parseInt(
-      process.env.OAUTH_REGISTER_RATE_LIMIT_PER_HOUR || "20",
-      10
-    );
+    const parsedRegisterLimit = Number(process.env.OAUTH_REGISTER_RATE_LIMIT_PER_HOUR);
+    const OAUTH_REGISTER_RATE_LIMIT_PER_HOUR =
+      Number.isInteger(parsedRegisterLimit) && parsedRegisterLimit >= 1
+        ? parsedRegisterLimit
+        : 20;
     const clientRegistrationRateLimitOptions = {
       ...rateLimitOptions,
       windowMs: 60 * 60 * 1000, // 1 hour


### PR DESCRIPTION
In certain scenarios, like using multiple windows of Kiro IDE, clients will multiple registrations at once (e.g. n windows of Kiro IDE open => n client registrations).
Currently the mcp uses the default upstream rate limit of 20 requests per hour for the `POST /register` endpoint. This PR adds the capability to adjust this rate limit to account for client specific technical details like the one mentioned above.