### PR TITLE
chore(homebrew): sync formula for release

### DIFF
--- a/Formula/zereight-mcp-gitlab.rb
+++ b/Formula/zereight-mcp-gitlab.rb
@@ -1,8 +1,8 @@
 class ZereightMcpGitlab < Formula
   desc "GitLab Model Context Protocol server for AI clients"
   homepage "https://github.com/zereight/gitlab-mcp"
-  url "https://registry.npmjs.org/@zereight/mcp-gitlab/-/mcp-gitlab-2.1.43.tgz"
-  sha256 "19983864cc11105416ec61474605b6177b255026ffcfa64d5b7d34daa43fe1d7"
+  url "https://registry.npmjs.org/@zereight/mcp-gitlab/-/mcp-gitlab-2.1.45.tgz"
+  sha256 "88ca044e33d95e4e262bd47796184dafb13dc8f43ab1939a5dd2077b03aac97c"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
Automated Homebrew formula sync after npm publish v2.1.45.

Release workflow `sync-homebrew` failed because `create-pull-request` needs an explicit `base` when checkout is on a release tag (fixed on main in 9d7c160).

Made with [Cursor](https://cursor.com)