### PR TITLE
fix: accept null merged_yaml/includes in CI lint result

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -318,8 +318,10 @@ export const GitLabCiLintResultSchema = z.object({
   valid: z.coerce.boolean(),
   errors: z.array(z.string()),
   warnings: z.array(z.string()).optional(),
-  merged_yaml: z.string().optional(),
-  includes: z.array(z.unknown()).optional(),
+  // GitLab sends null (not an omitted field) for both when the config is
+  // invalid, which is exactly when this tool is called. See #638.
+  merged_yaml: z.string().nullish(),
+  includes: z.array(z.unknown()).nullish(),
   jobs: z.array(z.unknown()).optional(),
 });
 

--- a/test/nullable-gitlab-response-fields.test.ts
+++ b/test/nullable-gitlab-response-fields.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  GitLabCiLintResultSchema,
   GitLabCompareResultSchema,
   GitLabProtectedBranchAccessLevelSchema,
 } from "../schemas.js";
@@ -24,4 +25,20 @@ test("branch compare accepts null commit", () => {
     diffs: [],
   });
   assert.equal(parsed.commit, null);
+});
+
+test("ci lint result accepts null merged_yaml/includes on an invalid config", () => {
+  // #638: GitLab nulls both fields whenever the config is invalid — i.e. in
+  // exactly the case validate_ci_lint exists to report on.
+  const parsed = GitLabCiLintResultSchema.parse({
+    valid: false,
+    errors: ["image is defined in top-level and `default:` entry"],
+    warnings: [],
+    merged_yaml: null,
+    includes: null,
+  });
+  assert.equal(parsed.valid, false);
+  assert.equal(parsed.merged_yaml, null);
+  assert.equal(parsed.includes, null);
+  assert.deepEqual(parsed.errors, ["image is defined in top-level and `default:` entry"]);
 });


### PR DESCRIPTION
Fixes #638.

## Problem

`validate_ci_lint` (and `validate_project_ci_lint`) throw instead of returning a result **whenever the CI config is invalid** — exactly the case the tool is called for. On a valid config they work, which is why the bug stays invisible until a user actually has a broken `.gitlab-ci.yml`.

GitLab returns `merged_yaml: null` and `includes: null` for an invalid config. `GitLabCiLintResultSchema` declared both as `.optional()`, which in Zod accepts `undefined` but rejects `null`, so `.parse()` threw and the caller got a schema error instead of the lint result:

```
-32603  Invalid arguments: merged_yaml: Expected string, received null, includes: Expected array, received null
```

The actual explanation from GitLab — e.g. ``image is defined in top-level and `default:` entry`` — never reached the caller.

## Change

`.optional()` → `.nullish()` on the two fields GitLab actually nulls. Same class as #575, so the regression test goes next to those cases in `test/nullable-gitlab-response-fields.test.ts`.

Scope is deliberately minimal: `warnings` and `jobs` come back as arrays in every response I observed, so I left them alone rather than widening the schema speculatively.

## Verification

The new test reproduces the reported failure before the schema change:

```
not ok 3 - ci lint result accepts null merged_yaml/includes on an invalid config
        "message": "Expected string, received null"
# pass 2
# fail 1
```

and passes after it. All three CI gates pass locally:

| Gate | Result |
|---|---|
| `npm run test:mock` | exit 0, 66 suites, 0 failures |
| `npm run test:consumer-smoke` | `Consumer install smoke passed.` |
| `npx tsc --noEmit` | clean |

Reproduced against a self-hosted GitLab 19.2.0-ee on 2.1.42 and 2.1.46, stdio transport with PAT auth, using this config:

```yaml
default:
  image: alpine:3.20

stages:
  - build

image:
  stage: build
  script:
    - echo build
```

Direct API response for it:

```json
{"valid":false,"errors":["image is defined in top-level and `default:` entry"],"warnings":[],"merged_yaml":null,"includes":null}
```

## Why it matters

An agent using this tool to validate CI changes cannot distinguish "the config is invalid" from "the tool is broken". In our case the agent concluded the latter, fell back to `prettier --check` — which checks YAML formatting, not GitLab CI semantics — and reported success on a config that was invalid. The two errors it needed to catch (a job named `image`, and `needs` referencing a nonexistent job) are both caught by the lint endpoint in under a second and are both invisible to a formatter.
