### PR TITLE
Fall back to access_token query param when token/info rejects the Bearer header

### DIFF
--- a/oauth-proxy.ts
+++ b/oauth-proxy.ts
@@ -665,9 +665,21 @@ class GitLabOAuthServerProvider implements OAuthServerProvider {
   // ---- Verify access token -----------------------------------------------
 
   async verifyAccessToken(token: string): Promise<AuthInfo> {
-    const res = await fetch(`${this._gitlabBaseUrl}/oauth/token/info`, {
+    let res = await fetch(`${this._gitlabBaseUrl}/oauth/token/info`, {
       headers: { Authorization: `Bearer ${token}` },
     });
+
+    if (res.status === 401) {
+      // Some GitLab instances sit behind an edge cache that strips the
+      // Authorization header on /oauth/* paths (observed on
+      // git.drupalcode.org, fronted by Varnish), so a valid token 401s
+      // here while working fine against /api/v4. Doorkeeper also accepts
+      // the RFC 6750 access_token query parameter — retry with that form
+      // before rejecting the token.
+      res = await fetch(
+        `${this._gitlabBaseUrl}/oauth/token/info?access_token=${encodeURIComponent(token)}`
+      );
+    }
 
     if (!res.ok) {
       throw new InvalidTokenError("Invalid or expired GitLab OAuth token");

--- a/test/mcp-oauth-tests.ts
+++ b/test/mcp-oauth-tests.ts
@@ -512,11 +512,11 @@ describe("MCP OAuth — createGitLabOAuthProvider", () => {
     // header on /oauth/* (e.g. git.drupalcode.org behind Varnish): the
     // Bearer-header request 401s, the RFC 6750 query-param retry succeeds.
     const TOKEN = "tok+en/with?special=chars&more"; // exercises URL encoding
-    const requests: { url: string; hasAuthHeader: boolean }[] = [];
+    const requests: { url: string; authHeader: string | undefined }[] = [];
 
     const { createServer } = await import("node:http");
     const stub = createServer((req, res) => {
-      requests.push({ url: req.url!, hasAuthHeader: "authorization" in req.headers });
+      requests.push({ url: req.url!, authHeader: req.headers["authorization"] });
       const url = new URL(req.url!, "http://localhost");
       if (url.searchParams.get("access_token") === TOKEN) {
         res.writeHead(200, { "Content-Type": "application/json" });
@@ -546,10 +546,19 @@ describe("MCP OAuth — createGitLabOAuthProvider", () => {
       const authInfo = await provider.verifyAccessToken(TOKEN);
 
       assert.strictEqual(requests.length, 2, "exactly one retry after the 401");
-      assert.ok(requests[0].hasAuthHeader, "first attempt uses the Authorization header");
+      assert.strictEqual(
+        requests[0].authHeader,
+        `Bearer ${TOKEN}`,
+        "first attempt sends the token as a Bearer Authorization header"
+      );
       assert.ok(
         !requests[0].url.includes("access_token="),
         "first attempt does not use the query param"
+      );
+      assert.strictEqual(
+        requests[1].authHeader,
+        undefined,
+        "retry omits the Authorization header"
       );
       assert.ok(
         requests[1].url.includes(`access_token=${encodeURIComponent(TOKEN)}`),

--- a/test/mcp-oauth-tests.ts
+++ b/test/mcp-oauth-tests.ts
@@ -507,6 +507,124 @@ describe("MCP OAuth — createGitLabOAuthProvider", () => {
     }
   });
 
+  test("verifyAccessToken falls back to access_token query param when Bearer gets 401", async () => {
+    // Simulates a GitLab behind an edge cache that strips the Authorization
+    // header on /oauth/* (e.g. git.drupalcode.org behind Varnish): the
+    // Bearer-header request 401s, the RFC 6750 query-param retry succeeds.
+    const TOKEN = "tok+en/with?special=chars&more"; // exercises URL encoding
+    const requests: { url: string; hasAuthHeader: boolean }[] = [];
+
+    const { createServer } = await import("node:http");
+    const stub = createServer((req, res) => {
+      requests.push({ url: req.url!, hasAuthHeader: "authorization" in req.headers });
+      const url = new URL(req.url!, "http://localhost");
+      if (url.searchParams.get("access_token") === TOKEN) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            resource_owner_id: 7,
+            scopes: ["api"],
+            expires_in_seconds: 3600,
+            application: { uid: "app-uid-abc" },
+            created_at: Math.floor(Date.now() / 1000),
+          })
+        );
+      } else {
+        // Header-stripping edge: reject anything not using the query param
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "invalid_token" }));
+      }
+    });
+
+    await new Promise<void>(resolve => stub.listen(0, "127.0.0.1", resolve));
+    const addr = stub.address() as { port: number };
+    const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const { createGitLabOAuthProvider } = await import("../oauth-proxy.js");
+      const provider = createGitLabOAuthProvider(baseUrl, "test-app-id");
+      const authInfo = await provider.verifyAccessToken(TOKEN);
+
+      assert.strictEqual(requests.length, 2, "exactly one retry after the 401");
+      assert.ok(requests[0].hasAuthHeader, "first attempt uses the Authorization header");
+      assert.ok(
+        !requests[0].url.includes("access_token="),
+        "first attempt does not use the query param"
+      );
+      assert.ok(
+        requests[1].url.includes(`access_token=${encodeURIComponent(TOKEN)}`),
+        "retry carries the URL-encoded access_token query param"
+      );
+      assert.strictEqual(authInfo.token, TOKEN, "token preserved through the fallback path");
+      assert.strictEqual(authInfo.clientId, "app-uid-abc", "AuthInfo built from retry response");
+      console.log("  ✓ verifyAccessToken falls back to query param after Bearer 401");
+    } finally {
+      stub.close();
+    }
+  });
+
+  test("verifyAccessToken does not retry when the Bearer request succeeds", async () => {
+    let requestCount = 0;
+    const { createServer } = await import("node:http");
+    const stub = createServer((_req, res) => {
+      requestCount++;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          resource_owner_id: 7,
+          scopes: ["api"],
+          expires_in_seconds: 3600,
+          application: { uid: "app-uid-abc" },
+          created_at: Math.floor(Date.now() / 1000),
+        })
+      );
+    });
+
+    await new Promise<void>(resolve => stub.listen(0, "127.0.0.1", resolve));
+    const addr = stub.address() as { port: number };
+    const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const { createGitLabOAuthProvider } = await import("../oauth-proxy.js");
+      const provider = createGitLabOAuthProvider(baseUrl, "test-app-id");
+      await provider.verifyAccessToken("good-token");
+
+      assert.strictEqual(requestCount, 1, "no retry on a 200 response");
+      console.log("  ✓ verifyAccessToken makes a single request on success");
+    } finally {
+      stub.close();
+    }
+  });
+
+  test("verifyAccessToken does not retry on non-401 errors", async () => {
+    let requestCount = 0;
+    const { createServer } = await import("node:http");
+    const stub = createServer((_req, res) => {
+      requestCount++;
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "service_unavailable" }));
+    });
+
+    await new Promise<void>(resolve => stub.listen(0, "127.0.0.1", resolve));
+    const addr = stub.address() as { port: number };
+    const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const { createGitLabOAuthProvider } = await import("../oauth-proxy.js");
+      const provider = createGitLabOAuthProvider(baseUrl, "test-app-id");
+
+      await assert.rejects(
+        () => provider.verifyAccessToken("tok"),
+        /invalid or expired/i,
+        "non-401 errors still reject"
+      );
+      assert.strictEqual(requestCount, 1, "the query-param fallback is 401-only");
+      console.log("  ✓ verifyAccessToken does not retry on non-401 errors");
+    } finally {
+      stub.close();
+    }
+  });
+
   test("verifyAccessToken maps GitLab token info to AuthInfo", async () => {
     const createdAt = Math.floor(Date.now() / 1000);
     const { createServer } = await import("node:http");


### PR DESCRIPTION
## Problem

Some GitLab instances sit behind an edge cache that strips the `Authorization` header on `/oauth/*` paths while passing it through on `/api/v4/*`. Observed on **git.drupalcode.org** (Drupal's GitLab, fronted by Varnish):

- `GET /oauth/token/info` with `Authorization: Bearer <valid token>` → **401** `{"error":"invalid_token","error_description":"The access token is invalid"}`
- `GET /oauth/token/info?access_token=<same token>` → **200**
- `GET /api/v4/user` with the same Bearer header → **200**

Since `verifyAccessToken()` in the MCP OAuth proxy only uses the Bearer-header form, every `/mcp` request fails bearer validation on such instances — clients (e.g. claude.ai's connector) complete the full OAuth flow successfully, then loop refresh → 401 → refresh and give up. Nothing is logged server-side, which makes this painful to diagnose (found it via tcpdump inside the container's network namespace).

## Fix

On a 401 from the Bearer-header call, retry `/oauth/token/info` once with the RFC 6750 `access_token` query parameter, which Doorkeeper also accepts. All other responses keep the existing behavior.

Verified against git.drupalcode.org: with this change the claude.ai connector completes OAuth, initializes an MCP session, and lists tools normally.