### PR TITLE
fix: path traversal in download_job_artifacts local_path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7486,7 +7486,21 @@ async function downloadJobArtifacts(
   await handleGitLabError(response);
 
   const filename = `artifacts_job_${encodeGitLabPathSegment(jobId)}.zip`;
-  const savePath = localPath ? path.join(localPath, filename) : filename;
+  let savePath: string;
+  if (localPath) {
+    const normalizedLocalPath = path.normalize(localPath);
+    if (
+      path.isAbsolute(normalizedLocalPath) ||
+      normalizedLocalPath === ".." ||
+      normalizedLocalPath.startsWith(".." + path.sep) ||
+      normalizedLocalPath.includes(path.sep + ".." + path.sep)
+    ) {
+      throw new Error("Invalid local_path: directory traversal is not allowed.");
+    }
+    savePath = path.join(normalizedLocalPath, filename);
+  } else {
+    savePath = filename;
+  }
   fs.mkdirSync(path.dirname(savePath), { recursive: true });
 
   if (!response.body) {

--- a/index.ts
+++ b/index.ts
@@ -7466,6 +7466,19 @@ async function downloadJobArtifacts(
   jobId: string,
   localPath?: string
 ): Promise<string> {
+  if (localPath) {
+    const normalizedLocalPath = path.normalize(localPath);
+    if (
+      path.isAbsolute(normalizedLocalPath) ||
+      path.parse(normalizedLocalPath).root !== "" ||
+      normalizedLocalPath === ".." ||
+      normalizedLocalPath.startsWith(".." + path.sep) ||
+      normalizedLocalPath.includes(path.sep + ".." + path.sep)
+    ) {
+      throw new Error("Invalid local_path: directory traversal is not allowed.");
+    }
+  }
+
   projectId = decodeURIComponent(projectId);
   const effectiveProjectId = getEffectiveProjectId(projectId);
 
@@ -7486,21 +7499,7 @@ async function downloadJobArtifacts(
   await handleGitLabError(response);
 
   const filename = `artifacts_job_${encodeGitLabPathSegment(jobId)}.zip`;
-  let savePath: string;
-  if (localPath) {
-    const normalizedLocalPath = path.normalize(localPath);
-    if (
-      path.isAbsolute(normalizedLocalPath) ||
-      normalizedLocalPath === ".." ||
-      normalizedLocalPath.startsWith(".." + path.sep) ||
-      normalizedLocalPath.includes(path.sep + ".." + path.sep)
-    ) {
-      throw new Error("Invalid local_path: directory traversal is not allowed.");
-    }
-    savePath = path.join(normalizedLocalPath, filename);
-  } else {
-    savePath = filename;
-  }
+  const savePath = localPath ? path.join(path.normalize(localPath), filename) : filename;
   fs.mkdirSync(path.dirname(savePath), { recursive: true });
 
   if (!response.body) {

--- a/test/test-job-artifacts.ts
+++ b/test/test-job-artifacts.ts
@@ -214,6 +214,7 @@ describe('job artifacts tools', () => {
   });
 
   test('download_job_artifacts rejects local_path directory traversal', async () => {
+    let error: any;
     try {
       await callTool(
         'download_job_artifacts',
@@ -223,16 +224,18 @@ describe('job artifacts tools', () => {
           GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
         }
       );
-      assert.fail('Expected download_job_artifacts to reject a traversal local_path');
-    } catch (error: any) {
-      assert.ok(
-        typeof error?.message === 'string' && error.message.toLowerCase().includes('traversal'),
-        `Expected a traversal error, got: ${error?.message}`
-      );
+    } catch (err: any) {
+      error = err;
     }
+    assert.ok(error, 'Expected download_job_artifacts to reject a traversal local_path');
+    assert.ok(
+      typeof error?.message === 'string' && error.message.toLowerCase().includes('traversal'),
+      `Expected a traversal error, got: ${error?.message}`
+    );
   });
 
   test('download_job_artifacts rejects absolute local_path', async () => {
+    let error: any;
     try {
       await callTool(
         'download_job_artifacts',
@@ -242,13 +245,14 @@ describe('job artifacts tools', () => {
           GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
         }
       );
-      assert.fail('Expected download_job_artifacts to reject an absolute local_path');
-    } catch (error: any) {
-      assert.ok(
-        typeof error?.message === 'string' && error.message.toLowerCase().includes('traversal'),
-        `Expected a traversal error, got: ${error?.message}`
-      );
+    } catch (err: any) {
+      error = err;
     }
+    assert.ok(error, 'Expected download_job_artifacts to reject an absolute local_path');
+    assert.ok(
+      typeof error?.message === 'string' && error.message.toLowerCase().includes('traversal'),
+      `Expected a traversal error, got: ${error?.message}`
+    );
   });
 
   test('get_job_artifact_file returns file content', async () => {

--- a/test/test-job-artifacts.ts
+++ b/test/test-job-artifacts.ts
@@ -4,7 +4,6 @@ import { spawn } from 'child_process';
 import { MockGitLabServer, findMockServerPort } from './utils/mock-gitlab-server.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
 
 const MOCK_TOKEN = 'glpat-mock-token-12345';
 const TEST_PROJECT_ID = '123';
@@ -143,8 +142,12 @@ describe('job artifacts tools', () => {
     await mockGitLab.start();
     mockGitLabUrl = mockGitLab.getUrl();
 
-    // Create a temp directory for download tests
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitlab-mcp-test-'));
+    // Create a temp directory for download tests. Must be relative to the
+    // process cwd — download_job_artifacts rejects absolute local_path
+    // values as directory traversal (see downloadJobArtifacts/downloadAttachment).
+    tmpDir = `gitlab-mcp-test-artifacts-${process.pid}`;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.mkdirSync(tmpDir, { recursive: true });
   });
 
   after(async () => {
@@ -208,6 +211,44 @@ describe('job artifacts tools', () => {
     assert.ok(result.success, 'Download should succeed');
     assert.ok(fs.existsSync(result.file_path), `File should exist at ${result.file_path}`);
     assert.ok(fs.existsSync(nestedLocalPath), `Directory should be created at ${nestedLocalPath}`);
+  });
+
+  test('download_job_artifacts rejects local_path directory traversal', async () => {
+    try {
+      await callTool(
+        'download_job_artifacts',
+        { project_id: TEST_PROJECT_ID, job_id: TEST_JOB_ID, local_path: '../../../tmp' },
+        {
+          GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+          GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        }
+      );
+      assert.fail('Expected download_job_artifacts to reject a traversal local_path');
+    } catch (error: any) {
+      assert.ok(
+        typeof error?.message === 'string' && error.message.toLowerCase().includes('traversal'),
+        `Expected a traversal error, got: ${error?.message}`
+      );
+    }
+  });
+
+  test('download_job_artifacts rejects absolute local_path', async () => {
+    try {
+      await callTool(
+        'download_job_artifacts',
+        { project_id: TEST_PROJECT_ID, job_id: TEST_JOB_ID, local_path: '/tmp' },
+        {
+          GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+          GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+        }
+      );
+      assert.fail('Expected download_job_artifacts to reject an absolute local_path');
+    } catch (error: any) {
+      assert.ok(
+        typeof error?.message === 'string' && error.message.toLowerCase().includes('traversal'),
+        `Expected a traversal error, got: ${error?.message}`
+      );
+    }
   });
 
   test('get_job_artifact_file returns file content', async () => {


### PR DESCRIPTION
## Summary
- `downloadJobArtifacts()` (`index.ts`, backing the `download_job_artifacts` tool) joined the caller-supplied `local_path` into the filesystem save path with no validation, allowing an absolute path or `../` traversal to write the downloaded artifact zip anywhere the process has write permission.
- The sibling `downloadAttachment()` function already validates its own `local_path` the same way; this brings `downloadJobArtifacts` in line with that existing, hardened pattern (reject absolute paths and `..` traversal).

## Why
Security issue: an MCP client (or anything able to issue tool calls in local/stdio mode) could pass `local_path: "/etc/cron.d"` or `local_path: "../../../../home/user/.ssh"` to `download_job_artifacts` and get an arbitrary file write on the host.

Reported privately to the maintainer alongside a second, unrelated finding before opening this PR.

## How tested
- `npx tsc --noEmit`
- `npm run test:mock` (all suites pass; added two new tests to `test/test-job-artifacts.ts` covering traversal and absolute-path rejection, and updated two existing tests that relied on an absolute `local_path` to use a relative one, matching the contract already established by `downloadAttachment`'s test suite)
- `npm run test:consumer-smoke`

## Breaking changes
`local_path` for `download_job_artifacts` must now be a relative, non-traversal path — matching the existing contract for `download_attachment`'s `local_path`. Absolute paths or `..` segments now return an error instead of silently writing outside the intended location.