### PR TITLE
fix: redact GitLab token from debug/warn logs in auth context

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1562,7 +1562,10 @@ const BASE_HEADERS: Record<string, string> = {
 function buildAuthHeaders(): Record<string, string> {
   if (REMOTE_AUTHORIZATION || GITLAB_MCP_OAUTH) {
     const ctx = sessionAuthStore.getStore();
-    logger.debug({ context: ctx }, "buildAuthHeaders: session context");
+    logger.debug(
+      { sessionId: ctx?.sessionId, header: ctx?.header, apiUrl: ctx?.apiUrl },
+      "buildAuthHeaders: session context"
+    );
     if (ctx?.token) {
       return {
         [ctx.header]: ctx.header === "Authorization" ? `Bearer ${ctx.token}` : ctx.token,
@@ -1612,7 +1615,10 @@ function getEffectiveApiUrl(): string {
     if (ctx?.apiUrl) {
       return ctx.apiUrl;
     }
-    logger.warn({ ctx }, "getEffectiveApiUrl: No context or apiUrl found, falling back to default");
+    logger.warn(
+      { sessionId: ctx?.sessionId, header: ctx?.header, apiUrl: ctx?.apiUrl },
+      "getEffectiveApiUrl: No context or apiUrl found, falling back to default"
+    );
   }
   return GITLAB_API_URL;
 }


### PR DESCRIPTION
## Summary
- `buildAuthHeaders()` (`index.ts`) logged the entire `SessionAuth` context object at debug level via `logger.debug({ context: ctx }, ...)`. That object includes the raw GitLab bearer token / PAT / job token.
- `getEffectiveApiUrl()` had the identical pattern on its fallback path (`logger.warn({ ctx }, ...)`).
- Both now log only the non-sensitive fields (`sessionId`, `header`, `apiUrl`) instead of the full context object.

## Why
Security issue: `buildAuthHeaders()` runs on essentially every proxied tool call when `REMOTE_AUTHORIZATION` or `GITLAB_MCP_OAUTH` is enabled (multi-tenant HTTP/stateless server mode). With `LOG_LEVEL=debug` set, which the project's own docs suggest for troubleshooting, anyone with read access to the resulting logs could harvest live GitLab tokens for every active session and reuse them directly against the GitLab API.

Reported privately to the maintainer alongside a second, unrelated finding before opening this PR.

## How tested
- `npx tsc --noEmit`
- `npm run test:mock` (all suites pass, including `npm run test:remote-auth`, which exercises `sessionAuthStore` / session auth headers end to end)
- `npm run test:consumer-smoke`

## Breaking changes
None. Only log output changes; no behavior or API surface change.