### PR TITLE
fix: preserve binary file content as base64

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2053,7 +2053,7 @@ async function getFileContents(
   const parsedData = GitLabContentSchema.parse(data);
 
   // Decode Base64-encoded text files while preserving binary content losslessly.
-  if (!Array.isArray(parsedData) && parsedData.content) {
+  if (!Array.isArray(parsedData) && typeof parsedData.content === "string") {
     const decodedContent = Buffer.from(parsedData.content, "base64");
     const utf8Content = decodedContent.toString("utf8");
 

--- a/index.ts
+++ b/index.ts
@@ -2052,10 +2052,15 @@ async function getFileContents(
   const data = await response.json();
   const parsedData = GitLabContentSchema.parse(data);
 
-  // Decode Base64-encoded file content to UTF-8
+  // Decode Base64-encoded text files while preserving binary content losslessly.
   if (!Array.isArray(parsedData) && parsedData.content) {
-    parsedData.content = Buffer.from(parsedData.content, "base64").toString("utf8");
-    parsedData.encoding = "utf8";
+    const decodedContent = Buffer.from(parsedData.content, "base64");
+    const utf8Content = decodedContent.toString("utf8");
+
+    if (Buffer.from(utf8Content, "utf8").equals(decodedContent)) {
+      parsedData.content = utf8Content;
+      parsedData.encoding = "utf8";
+    }
   }
 
   return parsedData;

--- a/test/test-get-file-contents.ts
+++ b/test/test-get-file-contents.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert";
+import { after, before, describe, test } from "node:test";
+import { Buffer } from "node:buffer";
+import { CustomHeaderClient } from "./clients/custom-header-client.js";
+import {
+  cleanupServers,
+  findAvailablePort,
+  HOST,
+  launchServer,
+  type ServerInstance,
+  TransportMode,
+} from "./utils/server-launcher.js";
+import { findMockServerPort, MockGitLabServer } from "./utils/mock-gitlab-server.js";
+
+const MOCK_TOKEN = "glpat-get-file-contents-test-token";
+const TEST_PROJECT_ID = "123";
+
+describe("get_file_contents", { timeout: 20_000 }, () => {
+  let mockGitLab: MockGitLabServer;
+  let server: ServerInstance;
+  let mcpUrl: string;
+
+  before(async () => {
+    const binaryContent = Buffer.from([
+      0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a, 0xc7, 0xff, 0xd8, 0x00,
+    ]).toString("base64");
+    const mockPort = await findMockServerPort();
+    mockGitLab = new MockGitLabServer({
+      port: mockPort,
+      validTokens: [MOCK_TOKEN],
+    });
+    mockGitLab.addMockHandler(
+      "get",
+      `/projects/${TEST_PROJECT_ID}/repository/files/sample.pdf`,
+      (_req, res) => {
+        res.json({
+          file_name: "sample.pdf",
+          file_path: "sample.pdf",
+          encoding: "base64",
+          content: binaryContent,
+        });
+      }
+    );
+    mockGitLab.addMockHandler(
+      "get",
+      `/projects/${TEST_PROJECT_ID}/repository/files/README.md`,
+      (_req, res) => {
+        res.json({
+          file_name: "README.md",
+          file_path: "README.md",
+          encoding: "base64",
+          content: Buffer.from("Hello, 世界\n", "utf8").toString("base64"),
+        });
+      }
+    );
+    await mockGitLab.start();
+
+    const port = await findAvailablePort(3480);
+    server = await launchServer({
+      mode: TransportMode.STREAMABLE_HTTP,
+      port,
+      timeout: 10_000,
+      env: {
+        STREAMABLE_HTTP: "true",
+        REMOTE_AUTHORIZATION: "true",
+        GITLAB_API_URL: `${mockGitLab.getUrl()}/api/v4`,
+      },
+    });
+    mcpUrl = `http://${HOST}:${port}/mcp`;
+  });
+
+  after(async () => {
+    cleanupServers([server]);
+    if (mockGitLab) await mockGitLab.stop();
+  });
+
+  test("preserves non-UTF-8 file content as base64", async () => {
+    const expectedContent = Buffer.from([
+      0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a, 0xc7, 0xff, 0xd8, 0x00,
+    ]).toString("base64");
+    const client = new CustomHeaderClient({ Authorization: `Bearer ${MOCK_TOKEN}` });
+    await client.connect(mcpUrl);
+
+    try {
+      const result = await Promise.race([
+        client.callTool("get_file_contents", {
+          project_id: TEST_PROJECT_ID,
+          file_path: "sample.pdf",
+          ref: "main",
+        }),
+        new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => reject(new Error("get_file_contents timed out")), 5_000);
+          timer.unref();
+        }),
+      ]);
+      const responseText = result.content?.[0]?.type === "text" ? result.content[0].text : "";
+      const file = JSON.parse(responseText) as { content: string; encoding: string };
+
+      assert.strictEqual(file.content, expectedContent);
+      assert.strictEqual(file.encoding, "base64");
+    } finally {
+      await client.disconnect();
+    }
+  });
+
+  test("decodes valid UTF-8 file content", async () => {
+    const client = new CustomHeaderClient({ Authorization: `Bearer ${MOCK_TOKEN}` });
+    await client.connect(mcpUrl);
+
+    try {
+      const result = await client.callTool("get_file_contents", {
+        project_id: TEST_PROJECT_ID,
+        file_path: "README.md",
+        ref: "main",
+      });
+      const responseText = result.content?.[0]?.type === "text" ? result.content[0].text : "";
+      const file = JSON.parse(responseText) as { content: string; encoding: string };
+
+      assert.strictEqual(file.content, "Hello, 世界\n");
+      assert.strictEqual(file.encoding, "utf8");
+    } finally {
+      await client.disconnect();
+    }
+  });
+});

--- a/test/test-get-file-contents.ts
+++ b/test/test-get-file-contents.ts
@@ -53,6 +53,18 @@ describe("get_file_contents", { timeout: 20_000 }, () => {
         });
       }
     );
+    mockGitLab.addMockHandler(
+      "get",
+      `/projects/${TEST_PROJECT_ID}/repository/files/empty.txt`,
+      (_req, res) => {
+        res.json({
+          file_name: "empty.txt",
+          file_path: "empty.txt",
+          encoding: "base64",
+          content: "",
+        });
+      }
+    );
     await mockGitLab.start();
 
     const port = await findAvailablePort(3480);
@@ -117,6 +129,26 @@ describe("get_file_contents", { timeout: 20_000 }, () => {
       const file = JSON.parse(responseText) as { content: string; encoding: string };
 
       assert.strictEqual(file.content, "Hello, 世界\n");
+      assert.strictEqual(file.encoding, "utf8");
+    } finally {
+      await client.disconnect();
+    }
+  });
+
+  test("decodes empty file content as UTF-8", async () => {
+    const client = new CustomHeaderClient({ Authorization: `Bearer ${MOCK_TOKEN}` });
+    await client.connect(mcpUrl);
+
+    try {
+      const result = await client.callTool("get_file_contents", {
+        project_id: TEST_PROJECT_ID,
+        file_path: "empty.txt",
+        ref: "main",
+      });
+      const responseText = result.content?.[0]?.type === "text" ? result.content[0].text : "";
+      const file = JSON.parse(responseText) as { content: string; encoding: string };
+
+      assert.strictEqual(file.content, "");
       assert.strictEqual(file.encoding, "utf8");
     } finally {
       await client.disconnect();


### PR DESCRIPTION
## Summary

- preserve the original Base64 payload and `base64` encoding for non-UTF-8 repository files
- keep the existing decoded text response and `utf8` encoding for valid UTF-8 files
- add MCP-level regression coverage for both binary and text content

## Root cause

`getFileContents` unconditionally decoded every GitLab Base64 payload with `Buffer.toString("utf8")`. Invalid UTF-8 bytes were replaced with the Unicode replacement character, so binary content could not be reconstructed from the response.

The updated read path only returns decoded text when converting the bytes to UTF-8 and back is lossless. Otherwise, it leaves GitLab's original Base64 response unchanged.

## Impact

Clients can now retrieve non-UTF-8 files without data corruption, while text-file behavior remains unchanged. This does not change the write path or public tool arguments.

## Validation

- `npm.cmd run build`
- `node --import tsx/esm --test --experimental-test-isolation=none --test-concurrency=1 test/test-get-file-contents.ts test/streamable-http-concurrent-session.test.ts` (4 tests passed)
- `npx.cmd prettier --check test/test-get-file-contents.ts`
- `npm.cmd run check:runtime-deps`
- `npx.cmd tsx test/oauth-tests.ts`

Closes #648
