### PR TITLE
fix: use direct Node launcher for Smithery

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -43,8 +43,8 @@ startCommand:
         description: Optional comma-separated list of toolsets to enable (e.g. projects,issues,merge_requests,pipelines)
   commandFunction: |-
     (config) => ({
-      command: 'npx',
-      args: ['-y', '@zereight/mcp-gitlab'],
+      command: 'node',
+      args: ['build/index.js'],
       env: {
         GITLAB_PERSONAL_ACCESS_TOKEN: config.gitlabPersonalAccessToken,
         ...(config.gitlabApiUrl ? { GITLAB_API_URL: config.gitlabApiUrl } : {}),


### PR DESCRIPTION
## Summary
- Run the Smithery stdio server with the local `build/index.js` through Node.
- Avoid npx package resolution, registry access, cache, and binary lookup during startup.
- Addresses the startup regression reported in #662.

## Test plan
- [x] `npm run build`
- [x] `npm run test:consumer-smoke`
- [x] `npm run test:mock`
- [x] `npm run check:runtime-deps`
- [x] Direct `node build/index.js` startup smoke test
- [ ] Verify Smithery deployment with the reporter's environment

Refs #662