### PR TITLE
fix(test): remove unused catch binding

### DIFF
--- a/test/test-list-group-merge-requests.ts
+++ b/test/test-list-group-merge-requests.ts
@@ -86,7 +86,7 @@ async function callListGroupMergeRequests(
           if (content) {
             try {
               resolve(JSON.parse(content));
-            } catch (e) {
+            } catch {
               reject(new Error(`Failed to parse tool output JSON: ${content}`));
             }
           } else {


### PR DESCRIPTION
## What

Removes the unused `e` binding in the JSON-parse catch clause added in #671's
`test/test-list-group-merge-requests.ts`.

## Why

Flagged by coderabbitai on #671: violates `@typescript-eslint/no-unused-vars`.

## How tested

- `npx tsx test/test-list-group-merge-requests.ts` — 3/3 pass
- `npx tsc --noEmit` — clean