### PR TITLE
docs(skill): clarify toolset count discrepancy in SKILL.md

### DIFF
--- a/skills/gitlab-mcp/SKILL.md
+++ b/skills/gitlab-mcp/SKILL.md
@@ -36,6 +36,9 @@ For exact generated parameter tables, see `docs/tools/`. Use this file for workf
 
 Enable all: `GITLAB_TOOLSETS=all`. Use `GITLAB_TOOLS` to enable individual tools outside their toolset. `discover_tools` can list and activate opt-in categories for the current session. `execute_graphql` is not in a toolset; enable it explicitly with `GITLAB_TOOLS=execute_graphql`.
 
+The per-toolset counts above sum to 218 because `get_branch` and `list_branches` are each listed
+in both `merge_requests` and `branches`; the unique tool count across all toolsets is 216.
+
 ## Key Workflows
 
 ### Code Review (see reference/code-review.md)


### PR DESCRIPTION
## What

Adds a note explaining why the per-toolset counts in `skills/gitlab-mcp/SKILL.md`
sum to 218 while the headline says "216 tools across 20 toolsets".

## Why

Flagged by coderabbitai on #671: `get_branch` and `list_branches` are each
listed in both the `merge_requests` and `branches` toolsets, so the table sum
double-counts them (218) while the unique-tool count across toolsets is 216.
Both numbers were individually correct, just unexplained — this documents the
overlap instead of changing either figure.

## How tested

- `npm run check:skill-sync` — pass