### PR TITLE
feat: add MCP prompts capability

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -658,8 +658,10 @@ const MCP_PROMPTS = [
     ],
     render: (args: Record<string, string>) =>
       `Triage vulnerabilities for project ${args.project_id ?? "<project_id>"}:\n` +
-      `1. Call list_vulnerabilities (or list_project_vulnerabilities) filtered to state=detected/confirmed.\n` +
-      `2. Group by severity (critical > high > medium > low) and by whether a fix is already available.\n` +
+      `1. Call list_project_vulnerabilities once with state=detected and once with state=confirmed ` +
+      `(the tool only accepts one state per call). Follow pageInfo.endCursor with the "after" ` +
+      `param while pageInfo.hasNextPage is true, and aggregate both states' results.\n` +
+      `2. Group the aggregated results by severity (critical > high > medium > low) and by whether a fix is already available.\n` +
       `3. Propose a remediation order, calling out any critical/high items with no available fix.`,
   },
 ] as const;

--- a/index.ts
+++ b/index.ts
@@ -124,7 +124,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { AsyncLocalStorage } from "node:async_hooks";
 import express, { NextFunction, Request, Response } from "express";
 import fetchCookie from "fetch-cookie";
@@ -611,6 +616,55 @@ const logger = createLogger();
 const SERVER_NAME = process.env.MCP_SERVER_NAME?.trim() || "zereight-gitlab-mcp-server";
 
 /**
+ * Static MCP prompt catalog. These wrap the multi-step tool workflows documented in
+ * skills/gitlab-mcp/ so MCP clients that surface prompts (e.g. slash commands) can
+ * trigger them without the agent needing to read the Skill first. Kept inline (not
+ * loaded from skills/gitlab-mcp/*.md) since only "build" ships in the npm package.
+ */
+const MCP_PROMPTS = [
+  {
+    name: "review_merge_request",
+    description: "Review a merge request's diff in batches and leave threaded comments.",
+    arguments: [
+      { name: "project_id", description: "Numeric project ID or URL-encoded path", required: true },
+      { name: "merge_request_iid", description: "Merge request IID", required: true },
+    ],
+    render: (args: Record<string, string>) =>
+      `Review merge request !${args.merge_request_iid ?? "<iid>"} in project ${args.project_id ?? "<project_id>"}:\n` +
+      `1. Call list_merge_request_changed_files to get the changed file list (use excluded_file_patterns for lockfiles/dist/generated files).\n` +
+      `2. Call get_merge_request_file_diff in batches of 3-5 files, prioritizing source over config/tests.\n` +
+      `3. Leave findings with create_merge_request_thread (inline, position: new_path/new_line) or create_merge_request_note (general).\n` +
+      `4. Summarize the review verdict in a final top-level note.`,
+  },
+  {
+    name: "triage_pipeline_failure",
+    description: "Find the failing job in a pipeline and pull its log tail for diagnosis.",
+    arguments: [
+      { name: "project_id", description: "Numeric project ID or URL-encoded path", required: true },
+      { name: "pipeline_id", description: "Pipeline ID", required: true },
+    ],
+    render: (args: Record<string, string>) =>
+      `Diagnose pipeline ${args.pipeline_id ?? "<pipeline_id>"} in project ${args.project_id ?? "<project_id>"}:\n` +
+      `1. Call list_pipeline_jobs to find jobs with status "failed".\n` +
+      `2. Call get_pipeline_job_output (or the job trace tool) on each failed job, focusing on the tail of the log.\n` +
+      `3. Identify the root cause (compile error, test failure, timeout, runner issue) and quote the relevant log lines.\n` +
+      `4. Suggest the fix or the next diagnostic step.`,
+  },
+  {
+    name: "triage_vulnerabilities",
+    description: "List a project's open vulnerabilities and propose a remediation priority order.",
+    arguments: [
+      { name: "project_id", description: "Numeric project ID or URL-encoded path", required: true },
+    ],
+    render: (args: Record<string, string>) =>
+      `Triage vulnerabilities for project ${args.project_id ?? "<project_id>"}:\n` +
+      `1. Call list_vulnerabilities (or list_project_vulnerabilities) filtered to state=detected/confirmed.\n` +
+      `2. Group by severity (critical > high > medium > low) and by whether a fix is already available.\n` +
+      `3. Propose a remediation order, calling out any critical/high items with no available fix.`,
+  },
+] as const;
+
+/**
  * Create a new MCP Server instance with request handlers registered.
  * Each transport connection gets its own Server instance to prevent
  * cross-client data leakage (GHSA-345p-7cg4-v4c7).
@@ -678,9 +732,38 @@ function createServer(): McpServer {
         tools: {
           listChanged: true,
         },
+        prompts: {},
       },
     }
   );
+
+  mcpServer.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+    prompts: MCP_PROMPTS.map(({ name, description, arguments: args }) => ({
+      name,
+      description,
+      arguments: args,
+    })),
+  }));
+
+  mcpServer.server.setRequestHandler(GetPromptRequestSchema, async (request: any) => {
+    const prompt = MCP_PROMPTS.find(p => p.name === request.params.name);
+    if (!prompt) {
+      throw new Error(`Unknown prompt: ${request.params.name}`);
+    }
+    const args = (request.params.arguments ?? {}) as Record<string, string>;
+    return {
+      description: prompt.description,
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: prompt.render(args),
+          },
+        },
+      ],
+    };
+  });
 
   mcpServer.server.setRequestHandler(ListToolsRequestSchema, async () => {
     // Step 6: Gemini $schema cleanup + annotations (only dynamic step per request)


### PR DESCRIPTION
## Summary
- Adds MCP `prompts` capability with three static prompts: `review_merge_request`, `triage_pipeline_failure`, `triage_vulnerabilities` — each wraps a multi-step tool workflow already documented in `skills/gitlab-mcp/`.
- Follow-up to the competitive research in `docs/comparison/community-gitlab-mcp-a.md`: some community servers (e.g. `python-gitlab-mcp`) expose MCP prompts/resources as first-class primitives, not just tools. This PR covers prompts; `resources` is left as a follow-up since the npm package only ships `build/` (not `skills/`), so resource content would need to be embedded or the packaging changed.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Manual check with an MCP client that lists/renders prompts (e.g. `prompts/list` then `prompts/get` for each of the three)