### PR TITLE
fix: return 404 for expired streamable HTTP sessions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13891,9 +13891,10 @@ async function startSSEServer(): Promise<void> {
  */
 async function startStreamableHTTPServer(): Promise<void> {
   const app = express();
-  const streamableTransports: {
-    [sessionId: string]: StreamableHTTPServerTransport;
-  } = {};
+  // Session IDs are untrusted map keys. A null prototype prevents inherited
+  // names such as "constructor" from masquerading as live transports.
+  const streamableTransports: Record<string, StreamableHTTPServerTransport> =
+    Object.create(null);
 
   const authTimeouts: Record<string, NodeJS.Timeout> = {};
 
@@ -14577,8 +14578,21 @@ async function startStreamableHTTPServer(): Promise<void> {
       ? staticMcpBearerAuth
       : (_req: Request, _res: Response, next: NextFunction) => next();
 
+  const rejectUnknownStatefulSession = (req: Request, res: Response, next: NextFunction) => {
+    const usesStatelessSessions =
+      OAUTH_STATELESS_MODE &&
+      STATELESS_MATERIAL &&
+      (REMOTE_AUTHORIZATION || GITLAB_MCP_OAUTH);
+    const sessionId = readMcpSessionIdHeader(req);
+    if (!usesStatelessSessions && sessionId && !streamableTransports[sessionId]) {
+      res.status(404).json({ error: "Session not found" });
+      return;
+    }
+    next();
+  };
+
   // Streamable HTTP endpoint - handles both session creation and message handling
-  app.post("/mcp", mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
+  app.post("/mcp", rejectUnknownStatefulSession, mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
     const sessionId = readMcpSessionIdHeader(req);
     const publicBaseUrl = getForwardedPublicBaseUrl(req, MCP_TRUST_PROXY);
 
@@ -14883,7 +14897,7 @@ async function startStreamableHTTPServer(): Promise<void> {
   });
 
   // Streamable HTTP GET endpoint for listening to server-sent events (SSE)
-  app.get("/mcp", mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
+  app.get("/mcp", rejectUnknownStatefulSession, mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
     const sessionId = readMcpSessionIdHeader(req);
     const acceptHeader = readAcceptHeader(req);
 
@@ -15017,7 +15031,7 @@ async function startStreamableHTTPServer(): Promise<void> {
   });
 
   // to delete a mcp server session explicitly
-  app.delete("/mcp", mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
+  app.delete("/mcp", rejectUnknownStatefulSession, mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
     const sessionId = readMcpSessionIdHeader(req);
 
     if (!sessionId) {

--- a/test/remote-auth-simple-test.ts
+++ b/test/remote-auth-simple-test.ts
@@ -335,35 +335,23 @@ describe('Remote Authorization - Session Timeout', () => {
     await waitForSessionDecrease(mcpUrl, beforeTimeout);
     console.log('  ✓ Timeout closed transport and released active session slot');
 
-    // Step 3: Try to make request WITHOUT auth header - should fail with 401
-    try {
-      const response = await fetch(mcpUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'mcp-session-id': sessionId,
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'tools/list'
-        })
-      });
+    // Step 3: A stale stateful session must return the MCP re-initialization signal.
+    const response = await fetch(mcpUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'mcp-session-id': sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list'
+      })
+    });
 
-      if (!response.ok) {
-        assert.strictEqual(response.status, 401, 'Should return 401 Unauthorized');
-        console.log(`  ✓ Request correctly failed with status ${response.status}`);
-        const body = await response.text();
-        console.log(`  ℹ️  Error: ${body.substring(0, 100)}...`);
-      } else {
-        assert.fail('Should have failed due to expired auth token');
-      }
-    } catch (error) {
-      // Network errors are also acceptable
-      assert.ok(error instanceof Error, 'Should throw error');
-      console.log('  ✓ Request correctly failed after timeout');
-      console.log(`  ℹ️  Error: ${error.message.substring(0, 100)}...`);
-    }
+    assert.strictEqual(response.status, 404, 'Should return 404 Session Not Found');
+    assert.deepStrictEqual(await response.json(), { error: 'Session not found' });
+    console.log('  ✓ Expired session returned 404 so the client can re-initialize');
 
     await clientWithAuth.disconnect();
   });

--- a/test/streamable-http-unauthenticated-discovery.test.ts
+++ b/test/streamable-http-unauthenticated-discovery.test.ts
@@ -150,19 +150,49 @@ describe("Streamable HTTP unauthenticated tool discovery", { timeout: 20_000 }, 
     const { server, mcpUrl } = await launchRemoteAuthServer({
       GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY: "true",
       MAX_SESSIONS: "1",
+      MAX_REQUESTS_PER_MINUTE: "1",
+      MCP_TRUST_PROXY: "true",
       SESSION_TIMEOUT_SECONDS: "1",
     });
     servers.push(server);
 
-    await initialize(mcpUrl);
+    const expiredSessionId = await initialize(mcpUrl);
     await new Promise(resolve => setTimeout(resolve, 2_000));
+
+    const expiredResponse = await rawMcpRequest(
+      mcpUrl,
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      { "mcp-session-id": expiredSessionId }
+    );
+    assert.strictEqual(expiredResponse.status, 404, expiredResponse.text);
+    assert.deepStrictEqual(expiredResponse.data, { error: "Session not found" });
 
     const healthResponse = await fetch(mcpUrl.replace("/mcp", "/health"));
     assert.strictEqual(healthResponse.status, 200);
 
-    const nextSession = await rawMcpRequest(mcpUrl, initializeBody);
+    const nextSession = await rawMcpRequest(mcpUrl, initializeBody, {
+      "x-forwarded-for": "192.0.2.10",
+    });
     assert.strictEqual(nextSession.status, 200, nextSession.text);
     assert.ok(nextSession.sessionId, "expired discovery session should free capacity");
+  });
+
+  test("rejects inherited object-property names as unknown session IDs", async () => {
+    const { server, mcpUrl } = await launchRemoteAuthServer({
+      GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY: "true",
+    });
+    servers.push(server);
+
+    for (const sessionId of ["constructor", "toString", "__proto__"]) {
+      const response = await rawMcpRequest(
+        mcpUrl,
+        { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+        { "mcp-session-id": sessionId }
+      );
+
+      assert.strictEqual(response.status, 404, `${sessionId}: ${response.text}`);
+      assert.deepStrictEqual(response.data, { error: "Session not found" });
+    }
   });
 
   test("still blocks unauthenticated tools/call when discovery is enabled", async () => {


### PR DESCRIPTION
Fixes #697

## What

Add a shared `/mcp` middleware that rejects a presented session ID when stateful Streamable HTTP mode no longer has a transport for it. Apply the check to POST, GET, and DELETE before request rate limiting and authentication.

The middleware deliberately bypasses stateless mode, whose sealed session IDs are validated by the existing stateless request handler.

The regression coverage now verifies both an ordinary timed-out authenticated session and an unauthenticated discovery session. The discovery test also exhausts the old session's rate-limit bucket to prove that 404 remains the first lifecycle response, then initializes a fresh session to prove capacity was released. The transport registry uses a null-prototype record so untrusted session IDs such as `constructor`, `toString`, and `__proto__` cannot resolve inherited object properties as live transports.

## Why

The MCP Streamable HTTP session-management contract requires the server to return HTTP 404 when a client sends a session ID for a session the server has terminated. The client can then start a fresh session with a new `InitializeRequest`:

https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management

PR #506 already closes an idle stateful transport and identifies `404 -> re-initialize` as the intended recovery path. Before this change, POST requests with the expired ID could instead be masked by authentication or rate limiting, or fall into the new-transport path.

Returning 404 before authentication does reveal whether an unguessable session ID is currently known, but it is the protocol-required session lifecycle response. Valid sessions still proceed through the existing authentication and rate-limit middleware.

## How tested

Passed locally:

- `npm run build`
- `npm run test:mock`
- `npx tsx --test test/remote-auth-simple-test.ts` (9/9)
- `node --import tsx/esm --test --experimental-test-isolation=none test/streamable-http-unauthenticated-discovery.test.ts` (6/6)
- `npm run test:consumer-smoke`
- `npm run check:runtime-deps`
- `npm run check:skill-sync`
- `git diff --check`

Local repository-wide style caveats, both reproducible on unchanged `main` files (the current PR workflow treats both checks as non-blocking warnings with `|| echo`):

- `npm run lint` invokes ESLint 9.27.0, which does not find an `eslint.config.js`, `eslint.config.mjs`, or `eslint.config.cjs` in the repository.
- a changed-file Prettier check reports pre-existing whole-file formatting differences in `index.ts` and `test/remote-auth-simple-test.ts`; this PR intentionally does not add a large unrelated formatting rewrite. The new focused discovery test passes Prettier.

## Breaking changes

None. The only response change is for requests that present an unknown stateful Streamable HTTP session ID; those requests now receive the protocol-required 404.
