### PR TITLE
fix: honor configured npm registry in version-check

### DIFF
--- a/test/utils/version-check.test.ts
+++ b/test/utils/version-check.test.ts
@@ -33,12 +33,16 @@ function throwingResolver(): string {
   throw new Error("npm not found");
 }
 
-async function withNpmrc(contents: string, run: () => Promise<void>): Promise<void> {
+async function withNpmrc(
+  contents: string,
+  run: () => Promise<void>,
+  globalContents = ""
+): Promise<void> {
   const configDir = mkdtempSync(join(tmpdir(), "gitlab-mcp-npmrc-"));
   const userconfigPath = join(configDir, ".npmrc");
   const globalconfigPath = join(configDir, "global.npmrc");
   writeFileSync(userconfigPath, contents);
-  writeFileSync(globalconfigPath, "");
+  writeFileSync(globalconfigPath, globalContents);
 
   const previousUserconfig = process.env.NPM_CONFIG_USERCONFIG;
   const previousGlobalconfig = process.env.NPM_CONFIG_GLOBALCONFIG;
@@ -212,6 +216,55 @@ describe("When fetchLatestVersion authenticates against a protected registry", (
         assert.equal(calls[0]?.authorization, null);
         assert.equal(calls[0]?.redirect, undefined);
       });
+    });
+  });
+
+  describe("when the token is on a parent registry path", () => {
+    test("should fall back to the host-level _authToken", async () => {
+      await withNpmrc(
+        [
+          "@zereight:registry=https://scoped.example/npm",
+          "//scoped.example/:_authToken=host-level-token",
+        ].join("\n"),
+        async () => {
+          const calls: CapturedFetch[] = [];
+          const latest = await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(latest, "2.1.31");
+          assert.equal(calls[0]?.url, "https://scoped.example/npm/@zereight/mcp-gitlab/latest");
+          assert.equal(calls[0]?.authorization, "Bearer host-level-token");
+        }
+      );
+    });
+  });
+
+  describe("when both a path token and a host token exist", () => {
+    test("should prefer the more specific path token", async () => {
+      await withNpmrc(
+        [
+          "@zereight:registry=https://scoped.example/npm",
+          "//scoped.example/npm/:_authToken=path-token",
+          "//scoped.example/:_authToken=host-level-token",
+        ].join("\n"),
+        async () => {
+          const calls: CapturedFetch[] = [];
+          await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(calls[0]?.authorization, "Bearer path-token");
+        }
+      );
+    });
+  });
+
+  describe("when the token is only in the global npmrc", () => {
+    test("should send a Bearer token from globalconfig", async () => {
+      await withNpmrc(
+        "@zereight:registry=https://scoped.example/\n",
+        async () => {
+          const calls: CapturedFetch[] = [];
+          await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(calls[0]?.authorization, "Bearer global-registry-token");
+        },
+        "//scoped.example/:_authToken=global-registry-token\n"
+      );
     });
   });
 

--- a/test/utils/version-check.test.ts
+++ b/test/utils/version-check.test.ts
@@ -90,4 +90,16 @@ describe("When fetchLatestVersion resolves the registry", () => {
     assert.equal(latest, null);
     assert.equal(requestedUrl, undefined);
   });
+
+  test("should fall back to the public registry when the resolved value has no hostname", async () => {
+    let requestedUrl: string | undefined;
+    const spyFetch = (async (url: string | URL) => {
+      requestedUrl = url.toString();
+      return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const latest = await fetchLatestVersion(spyFetch, 3000, () => "https:///");
+    assert.equal(latest, "2.1.31");
+    assert.equal(requestedUrl, "https://registry.npmjs.org/@zereight/mcp-gitlab/latest");
+  });
 });

--- a/test/utils/version-check.test.ts
+++ b/test/utils/version-check.test.ts
@@ -5,8 +5,54 @@ import { join } from "node:path";
 import { describe, test } from "node:test";
 import { checkForNewVersion, fetchLatestVersion, isNewerVersion } from "../../utils/version-check.js";
 
-function fetchReturning(status: number, body: unknown): typeof fetch {
-  return (async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+type CapturedFetch = {
+  url: string;
+  authorization: string | null;
+  redirect: RequestRedirect | undefined;
+};
+
+function fetchReturning(status: number, body: unknown): FetchLike {
+  return async () => new Response(JSON.stringify(body), { status });
+}
+
+function fetchCapturing(calls: CapturedFetch[], status: number, body: unknown): FetchLike {
+  return async (url, init) => {
+    const headers = new Headers(init?.headers);
+    calls.push({
+      url: url.toString(),
+      authorization: headers.get("authorization"),
+      redirect: init?.redirect,
+    });
+    return new Response(JSON.stringify(body), { status });
+  };
+}
+
+function throwingResolver(): string {
+  throw new Error("npm not found");
+}
+
+async function withNpmrc(contents: string, run: () => Promise<void>): Promise<void> {
+  const configDir = mkdtempSync(join(tmpdir(), "gitlab-mcp-npmrc-"));
+  const userconfigPath = join(configDir, ".npmrc");
+  const globalconfigPath = join(configDir, "global.npmrc");
+  writeFileSync(userconfigPath, contents);
+  writeFileSync(globalconfigPath, "");
+
+  const previousUserconfig = process.env.NPM_CONFIG_USERCONFIG;
+  const previousGlobalconfig = process.env.NPM_CONFIG_GLOBALCONFIG;
+  process.env.NPM_CONFIG_USERCONFIG = userconfigPath;
+  process.env.NPM_CONFIG_GLOBALCONFIG = globalconfigPath;
+  try {
+    await run();
+  } finally {
+    if (previousUserconfig === undefined) delete process.env.NPM_CONFIG_USERCONFIG;
+    else process.env.NPM_CONFIG_USERCONFIG = previousUserconfig;
+    if (previousGlobalconfig === undefined) delete process.env.NPM_CONFIG_GLOBALCONFIG;
+    else process.env.NPM_CONFIG_GLOBALCONFIG = previousGlobalconfig;
+    rmSync(configDir, { recursive: true, force: true });
+  }
 }
 
 describe("When isNewerVersion compares versions", () => {
@@ -40,19 +86,15 @@ describe("When checkForNewVersion runs", () => {
   });
 
   test("should return null without fetching when current version is unknown", async () => {
-    let called = false;
-    const spyFetch = (async () => {
-      called = true;
-      return new Response("{}", { status: 200 });
-    }) as unknown as typeof fetch;
-    assert.equal(await checkForNewVersion("unknown", spyFetch), null);
-    assert.equal(called, false);
+    const calls: CapturedFetch[] = [];
+    assert.equal(await checkForNewVersion("unknown", fetchCapturing(calls, 200, {})), null);
+    assert.equal(calls.length, 0);
   });
 
   test("should return null on registry errors instead of throwing", async () => {
-    const failingFetch = (async () => {
+    const failingFetch: FetchLike = async () => {
       throw new Error("network down");
-    }) as unknown as typeof fetch;
+    };
     assert.equal(await checkForNewVersion("2.1.29", failingFetch), null);
     assert.equal(await checkForNewVersion("2.1.29", fetchReturning(500, {})), null);
   });
@@ -68,82 +110,141 @@ describe("When checkForNewVersion runs", () => {
 
 describe("When fetchLatestVersion resolves the registry", () => {
   test("should fetch from the resolved registry instead of a hardcoded one", async () => {
-    let requestedUrl: string | undefined;
-    const spyFetch = (async (url: string | URL) => {
-      requestedUrl = url.toString();
-      return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
-    }) as unknown as typeof fetch;
-
-    const latest = await fetchLatestVersion(spyFetch, 3000, () => "https://npm.internal.example/");
+    const calls: CapturedFetch[] = [];
+    const latest = await fetchLatestVersion(
+      fetchCapturing(calls, 200, { version: "2.1.31" }),
+      3000,
+      () => "https://npm.internal.example/"
+    );
     assert.equal(latest, "2.1.31");
-    assert.equal(requestedUrl, "https://npm.internal.example/@zereight/mcp-gitlab/latest");
+    assert.equal(calls[0]?.url, "https://npm.internal.example/@zereight/mcp-gitlab/latest");
   });
 
   test("should fall back to the public registry when the resolver throws", async () => {
-    let requestedUrl: string | undefined;
-    const spyFetch = (async (url: string | URL) => {
-      requestedUrl = url.toString();
-      return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
-    }) as unknown as typeof fetch;
-    const throwingResolver = () => {
-      throw new Error("npm not found");
-    };
-
-    const latest = await fetchLatestVersion(spyFetch, 3000, throwingResolver as unknown as () => string);
+    const calls: CapturedFetch[] = [];
+    const latest = await fetchLatestVersion(
+      fetchCapturing(calls, 200, { version: "2.1.31" }),
+      3000,
+      throwingResolver
+    );
     assert.equal(latest, null);
-    assert.equal(requestedUrl, undefined);
+    assert.equal(calls.length, 0);
   });
 
   test("should fall back to the public registry when the resolved value has no hostname", async () => {
-    let requestedUrl: string | undefined;
-    const spyFetch = (async (url: string | URL) => {
-      requestedUrl = url.toString();
-      return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
-    }) as unknown as typeof fetch;
-
-    const latest = await fetchLatestVersion(spyFetch, 3000, () => "https:///");
+    const calls: CapturedFetch[] = [];
+    const latest = await fetchLatestVersion(
+      fetchCapturing(calls, 200, { version: "2.1.31" }),
+      3000,
+      () => "https:///"
+    );
     assert.equal(latest, "2.1.31");
-    assert.equal(requestedUrl, "https://registry.npmjs.org/@zereight/mcp-gitlab/latest");
+    assert.equal(calls[0]?.url, "https://registry.npmjs.org/@zereight/mcp-gitlab/latest");
   });
 
   test("should fall back to the public registry when the resolved value has a query string", async () => {
-    let requestedUrl: string | undefined;
-    const spyFetch = (async (url: string | URL) => {
-      requestedUrl = url.toString();
-      return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
-    }) as unknown as typeof fetch;
-
-    const latest = await fetchLatestVersion(spyFetch, 3000, () => "https://registry.example/npm?tenant=a");
+    const calls: CapturedFetch[] = [];
+    const latest = await fetchLatestVersion(
+      fetchCapturing(calls, 200, { version: "2.1.31" }),
+      3000,
+      () => "https://registry.example/npm?tenant=a"
+    );
     assert.equal(latest, "2.1.31");
-    assert.equal(requestedUrl, "https://registry.npmjs.org/@zereight/mcp-gitlab/latest");
+    assert.equal(calls[0]?.url, "https://registry.npmjs.org/@zereight/mcp-gitlab/latest");
   });
 });
 
 describe("When resolving the registry from npm config", () => {
-  test("should prefer the @zereight-scoped registry over the unscoped one", async () => {
-    const configDir = mkdtempSync(join(tmpdir(), "gitlab-mcp-npmrc-"));
-    const configPath = join(configDir, ".npmrc");
-    writeFileSync(
-      configPath,
-      "registry=https://unscoped.example/\n@zereight:registry=https://scoped.example/\n"
-    );
+  describe("with a scoped @zereight:registry", () => {
+    test("should prefer the scoped registry over the unscoped one", async () => {
+      await withNpmrc(
+        "registry=https://unscoped.example/\n@zereight:registry=https://scoped.example/\n",
+        async () => {
+          const calls: CapturedFetch[] = [];
+          const latest = await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(latest, "2.1.31");
+          assert.equal(calls[0]?.url, "https://scoped.example/@zereight/mcp-gitlab/latest");
+        }
+      );
+    });
+  });
+});
 
-    const previousUserconfig = process.env.NPM_CONFIG_USERCONFIG;
-    process.env.NPM_CONFIG_USERCONFIG = configPath;
-    try {
-      let requestedUrl: string | undefined;
-      const spyFetch = (async (url: string | URL) => {
-        requestedUrl = url.toString();
-        return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
-      }) as unknown as typeof fetch;
+describe("When fetchLatestVersion authenticates against a protected registry", () => {
+  describe("with a scoped _authToken in .npmrc", () => {
+    test("should send a Bearer token only to that HTTPS registry", async () => {
+      await withNpmrc(
+        [
+          "registry=https://unscoped.example/",
+          "@zereight:registry=https://scoped.example/",
+          "//scoped.example/:_authToken=scoped-registry-token",
+        ].join("\n"),
+        async () => {
+          const calls: CapturedFetch[] = [];
+          const latest = await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(latest, "2.1.31");
+          assert.equal(calls[0]?.url, "https://scoped.example/@zereight/mcp-gitlab/latest");
+          assert.equal(calls[0]?.authorization, "Bearer scoped-registry-token");
+        }
+      );
+    });
 
-      const latest = await fetchLatestVersion(spyFetch);
-      assert.equal(latest, "2.1.31");
-      assert.equal(requestedUrl, "https://scoped.example/@zereight/mcp-gitlab/latest");
-    } finally {
-      if (previousUserconfig === undefined) delete process.env.NPM_CONFIG_USERCONFIG;
-      else process.env.NPM_CONFIG_USERCONFIG = previousUserconfig;
-      rmSync(configDir, { recursive: true, force: true });
-    }
+    test("should refuse to follow redirects when a token is attached", async () => {
+      await withNpmrc(
+        [
+          "@zereight:registry=https://scoped.example/",
+          "//scoped.example/:_authToken=scoped-registry-token",
+        ].join("\n"),
+        async () => {
+          const calls: CapturedFetch[] = [];
+          await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(calls[0]?.redirect, "error");
+        }
+      );
+    });
+  });
+
+  describe("without a matching token", () => {
+    test("should omit Authorization", async () => {
+      await withNpmrc("@zereight:registry=https://scoped.example/\n", async () => {
+        const calls: CapturedFetch[] = [];
+        await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+        assert.equal(calls[0]?.authorization, null);
+        assert.equal(calls[0]?.redirect, undefined);
+      });
+    });
+  });
+
+  describe("with a token for a different host", () => {
+    test("should omit Authorization", async () => {
+      await withNpmrc(
+        [
+          "@zereight:registry=https://scoped.example/",
+          "//other.example/:_authToken=other-host-token",
+        ].join("\n"),
+        async () => {
+          const calls: CapturedFetch[] = [];
+          await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(calls[0]?.authorization, null);
+        }
+      );
+    });
+  });
+
+  describe("when the registry is HTTP", () => {
+    test("should omit Authorization even if a token is configured", async () => {
+      await withNpmrc(
+        [
+          "@zereight:registry=http://insecure.example/",
+          "//insecure.example/:_authToken=http-registry-token",
+        ].join("\n"),
+        async () => {
+          const calls: CapturedFetch[] = [];
+          await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(calls[0]?.url, "http://insecure.example/@zereight/mcp-gitlab/latest");
+          assert.equal(calls[0]?.authorization, null);
+        }
+      );
+    });
   });
 });

--- a/test/utils/version-check.test.ts
+++ b/test/utils/version-check.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { checkForNewVersion, isNewerVersion } from "../../utils/version-check.js";
+import { checkForNewVersion, fetchLatestVersion, isNewerVersion } from "../../utils/version-check.js";
 
 function fetchReturning(status: number, body: unknown): typeof fetch {
   return (async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
@@ -60,5 +60,34 @@ describe("When checkForNewVersion runs", () => {
       fetchReturning(200, { version: "2.2.0-beta.1" })
     );
     assert.equal(latest, null);
+  });
+});
+
+describe("When fetchLatestVersion resolves the registry", () => {
+  test("should fetch from the resolved registry instead of a hardcoded one", async () => {
+    let requestedUrl: string | undefined;
+    const spyFetch = (async (url: string | URL) => {
+      requestedUrl = url.toString();
+      return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const latest = await fetchLatestVersion(spyFetch, 3000, () => "https://npm.internal.example/");
+    assert.equal(latest, "2.1.31");
+    assert.equal(requestedUrl, "https://npm.internal.example/@zereight/mcp-gitlab/latest");
+  });
+
+  test("should fall back to the public registry when the resolver throws", async () => {
+    let requestedUrl: string | undefined;
+    const spyFetch = (async (url: string | URL) => {
+      requestedUrl = url.toString();
+      return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
+    }) as unknown as typeof fetch;
+    const throwingResolver = () => {
+      throw new Error("npm not found");
+    };
+
+    const latest = await fetchLatestVersion(spyFetch, 3000, throwingResolver as unknown as () => string);
+    assert.equal(latest, null);
+    assert.equal(requestedUrl, undefined);
   });
 });

--- a/test/utils/version-check.test.ts
+++ b/test/utils/version-check.test.ts
@@ -105,6 +105,18 @@ describe("When fetchLatestVersion resolves the registry", () => {
     assert.equal(latest, "2.1.31");
     assert.equal(requestedUrl, "https://registry.npmjs.org/@zereight/mcp-gitlab/latest");
   });
+
+  test("should fall back to the public registry when the resolved value has a query string", async () => {
+    let requestedUrl: string | undefined;
+    const spyFetch = (async (url: string | URL) => {
+      requestedUrl = url.toString();
+      return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const latest = await fetchLatestVersion(spyFetch, 3000, () => "https://registry.example/npm?tenant=a");
+    assert.equal(latest, "2.1.31");
+    assert.equal(requestedUrl, "https://registry.npmjs.org/@zereight/mcp-gitlab/latest");
+  });
 });
 
 describe("When resolving the registry from npm config", () => {

--- a/test/utils/version-check.test.ts
+++ b/test/utils/version-check.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, test } from "node:test";
 import { checkForNewVersion, fetchLatestVersion, isNewerVersion } from "../../utils/version-check.js";
 
@@ -101,5 +104,34 @@ describe("When fetchLatestVersion resolves the registry", () => {
     const latest = await fetchLatestVersion(spyFetch, 3000, () => "https:///");
     assert.equal(latest, "2.1.31");
     assert.equal(requestedUrl, "https://registry.npmjs.org/@zereight/mcp-gitlab/latest");
+  });
+});
+
+describe("When resolving the registry from npm config", () => {
+  test("should prefer the @zereight-scoped registry over the unscoped one", async () => {
+    const configDir = mkdtempSync(join(tmpdir(), "gitlab-mcp-npmrc-"));
+    const configPath = join(configDir, ".npmrc");
+    writeFileSync(
+      configPath,
+      "registry=https://unscoped.example/\n@zereight:registry=https://scoped.example/\n"
+    );
+
+    const previousUserconfig = process.env.NPM_CONFIG_USERCONFIG;
+    process.env.NPM_CONFIG_USERCONFIG = configPath;
+    try {
+      let requestedUrl: string | undefined;
+      const spyFetch = (async (url: string | URL) => {
+        requestedUrl = url.toString();
+        return new Response(JSON.stringify({ version: "2.1.31" }), { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const latest = await fetchLatestVersion(spyFetch);
+      assert.equal(latest, "2.1.31");
+      assert.equal(requestedUrl, "https://scoped.example/@zereight/mcp-gitlab/latest");
+    } finally {
+      if (previousUserconfig === undefined) delete process.env.NPM_CONFIG_USERCONFIG;
+      else process.env.NPM_CONFIG_USERCONFIG = previousUserconfig;
+      rmSync(configDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/utils/version-check.test.ts
+++ b/test/utils/version-check.test.ts
@@ -268,6 +268,28 @@ describe("When fetchLatestVersion authenticates against a protected registry", (
     });
   });
 
+  describe("when the registry path contains underscores", () => {
+    test("should send a Bearer token for an Azure Artifacts-style registry path", async () => {
+      const registry =
+        "https://pkgs.dev.azure.com/org/_packaging/feed/npm/registry";
+      const authKey =
+        "//pkgs.dev.azure.com/org/_packaging/feed/npm/registry/:_authToken";
+      await withNpmrc(
+        [`@zereight:registry=${registry}`, `${authKey}=azure-feed-token`].join("\n"),
+        async () => {
+          const calls: CapturedFetch[] = [];
+          const latest = await fetchLatestVersion(fetchCapturing(calls, 200, { version: "2.1.31" }));
+          assert.equal(latest, "2.1.31");
+          assert.equal(
+            calls[0]?.url,
+            `${registry}/@zereight/mcp-gitlab/latest`
+          );
+          assert.equal(calls[0]?.authorization, "Bearer azure-feed-token");
+        }
+      );
+    });
+  });
+
   describe("with a token for a different host", () => {
     test("should omit Authorization", async () => {
       await withNpmrc(

--- a/utils/version-check.ts
+++ b/utils/version-check.ts
@@ -10,7 +10,7 @@ const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
 const PACKAGE_LATEST_PATH = "@zereight/mcp-gitlab/latest";
 const RELEASE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
 const AUTH_TOKEN_KEY_PATTERN =
-  /^\/\/[-A-Za-z0-9.]+(?::\d+)?(?:\/[-A-Za-z0-9.]+)*\/:_authToken$/;
+  /^\/\/[-A-Za-z0-9.]+(?::\d+)?(?:\/[-A-Za-z0-9._]+)*\/:_authToken$/;
 const NPMRC_ENV_PATTERN = /\$\{([A-Za-z_]\w*)\}/g;
 
 type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;

--- a/utils/version-check.ts
+++ b/utils/version-check.ts
@@ -1,5 +1,26 @@
-const NPM_REGISTRY_LATEST_URL = "https://registry.npmjs.org/@zereight/mcp-gitlab/latest";
+import { execSync } from "node:child_process";
+
+const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
+const PACKAGE_LATEST_PATH = "@zereight/mcp-gitlab/latest";
 const RELEASE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+/** Resolves the npm registry to use, honoring `.npmrc` / `npm_config_registry` when available. */
+function resolveConfiguredRegistry(): string {
+  try {
+    const registry = execSync("npm config get registry", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+      windowsHide: true,
+    })
+      .trim()
+      .replace(/\/$/, "");
+    if (registry && registry !== "undefined" && /^https?:\/\//.test(registry)) return registry;
+  } catch {
+    // npm unavailable or the lookup failed — fall back to the public registry.
+  }
+  return DEFAULT_NPM_REGISTRY;
+}
 
 export function isNewerVersion(candidate: string, current: string): boolean {
   const parse = (version: string) => version.split(".").map(part => Number.parseInt(part, 10));
@@ -14,10 +35,12 @@ export function isNewerVersion(candidate: string, current: string): boolean {
 
 export async function fetchLatestVersion(
   fetchFn: typeof fetch = fetch,
-  timeoutMs = 3000
+  timeoutMs = 3000,
+  resolveRegistry: () => string = resolveConfiguredRegistry
 ): Promise<string | null> {
   try {
-    const response = await fetchFn(NPM_REGISTRY_LATEST_URL, {
+    const registryLatestUrl = `${resolveRegistry().replace(/\/$/, "")}/${PACKAGE_LATEST_PATH}`;
+    const response = await fetchFn(registryLatestUrl, {
       signal: AbortSignal.timeout(timeoutMs),
       headers: { accept: "application/json" },
     });

--- a/utils/version-check.ts
+++ b/utils/version-check.ts
@@ -7,11 +7,22 @@ const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
 const PACKAGE_LATEST_PATH = "@zereight/mcp-gitlab/latest";
 const RELEASE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
 
-/** A configured registry is only used when it parses as a valid HTTP(S) URL with a hostname. */
+/**
+ * A configured registry is only used when it parses as a plain HTTP(S) URL
+ * with a hostname. A query or fragment is rejected too: the package path is
+ * appended to this value with plain string concatenation below, so a query
+ * string like "?tenant=a" would swallow the appended path instead of the
+ * request reaching the intended endpoint.
+ */
 function isUsableRegistryUrl(registry: string): boolean {
   try {
     const parsed = new URL(registry);
-    return (parsed.protocol === "http:" || parsed.protocol === "https:") && parsed.hostname !== "";
+    return (
+      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      parsed.hostname !== "" &&
+      parsed.search === "" &&
+      parsed.hash === ""
+    );
   } catch {
     return false;
   }

--- a/utils/version-check.ts
+++ b/utils/version-check.ts
@@ -69,18 +69,26 @@ async function resolveConfiguredRegistry(): Promise<string> {
   return DEFAULT_NPM_REGISTRY;
 }
 
-function authTokenConfigKey(registry: string): string | null {
-  if (!isUsableRegistryUrl(registry)) return null;
+function authTokenConfigKeys(registry: string): string[] {
+  if (!isUsableRegistryUrl(registry)) return [];
   const parsed = new URL(registry);
-  if (parsed.protocol !== "https:") return null;
-  const path = parsed.pathname.replace(/\/$/, "");
-  const key = `//${parsed.host}${path}/:_authToken`;
-  return AUTH_TOKEN_KEY_PATTERN.test(key) ? key : null;
+  if (parsed.protocol !== "https:") return [];
+  const keys: string[] = [];
+  let path = parsed.pathname.replace(/\/$/, "");
+  while (true) {
+    const key = `//${parsed.host}${path}/:_authToken`;
+    if (AUTH_TOKEN_KEY_PATTERN.test(key)) keys.push(key);
+    if (path === "") break;
+    const slash = path.lastIndexOf("/");
+    path = slash <= 0 ? "" : path.slice(0, slash);
+  }
+  return keys;
 }
 
-function npmrcCandidatePaths(): string[] {
+async function npmrcCandidatePaths(): Promise<string[]> {
   const paths: string[] = [];
-  const globalconfig = process.env.NPM_CONFIG_GLOBALCONFIG;
+  const configuredGlobal = process.env.NPM_CONFIG_GLOBALCONFIG;
+  const globalconfig = configuredGlobal || (await npmConfigGet("globalconfig"));
   if (globalconfig) paths.push(globalconfig);
   paths.push(process.env.NPM_CONFIG_USERCONFIG ?? join(homedir(), ".npmrc"));
   paths.push(join(process.cwd(), ".npmrc"));
@@ -125,21 +133,24 @@ async function readNpmrcFile(path: string): Promise<Map<string, string>> {
 }
 
 /**
- * Reads `//host[:port][/path]/:_authToken` from npmrc files.
+ * Reads `//host[:port][/path]/:_authToken` from npmrc files, then walks up
+ * parent paths to `//host/:_authToken`, matching npm-registry-fetch.
  * `npm config get` refuses to print protected auth keys, so this parses the
  * files npm itself would consult instead of asking the CLI.
  */
 async function resolveRegistryAuthToken(registry: string): Promise<string | null> {
-  const key = authTokenConfigKey(registry);
-  if (!key) return null;
+  const keys = authTokenConfigKeys(registry);
+  if (keys.length === 0) return null;
   const merged = new Map<string, string>();
-  for (const path of npmrcCandidatePaths()) {
+  for (const path of await npmrcCandidatePaths()) {
     const entries = await readNpmrcFile(path);
     for (const [entryKey, value] of entries) merged.set(entryKey, value);
   }
-  const token = merged.get(key);
-  if (!token) return null;
-  return token;
+  for (const key of keys) {
+    const token = merged.get(key);
+    if (token) return token;
+  }
+  return null;
 }
 
 function requestIsUnderRegistry(registry: string, requestUrl: string): boolean {

--- a/utils/version-check.ts
+++ b/utils/version-check.ts
@@ -1,4 +1,7 @@
 import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -6,6 +9,11 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
 const PACKAGE_LATEST_PATH = "@zereight/mcp-gitlab/latest";
 const RELEASE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const AUTH_TOKEN_KEY_PATTERN =
+  /^\/\/[-A-Za-z0-9.]+(?::\d+)?(?:\/[-A-Za-z0-9.]+)*\/:_authToken$/;
+const NPMRC_ENV_PATTERN = /\$\{([A-Za-z_]\w*)\}/g;
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
 /**
  * A configured registry is only used when it parses as a plain HTTP(S) URL
@@ -61,6 +69,100 @@ async function resolveConfiguredRegistry(): Promise<string> {
   return DEFAULT_NPM_REGISTRY;
 }
 
+function authTokenConfigKey(registry: string): string | null {
+  if (!isUsableRegistryUrl(registry)) return null;
+  const parsed = new URL(registry);
+  if (parsed.protocol !== "https:") return null;
+  const path = parsed.pathname.replace(/\/$/, "");
+  const key = `//${parsed.host}${path}/:_authToken`;
+  return AUTH_TOKEN_KEY_PATTERN.test(key) ? key : null;
+}
+
+function npmrcCandidatePaths(): string[] {
+  const paths: string[] = [];
+  const globalconfig = process.env.NPM_CONFIG_GLOBALCONFIG;
+  if (globalconfig) paths.push(globalconfig);
+  paths.push(process.env.NPM_CONFIG_USERCONFIG ?? join(homedir(), ".npmrc"));
+  paths.push(join(process.cwd(), ".npmrc"));
+  return paths;
+}
+
+function unquoteNpmrcValue(value: string): string {
+  if (value.length >= 2) {
+    const start = value[0];
+    const end = value[value.length - 1];
+    if ((start === '"' && end === '"') || (start === "'" && end === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+function expandNpmrcEnv(value: string): string {
+  return value.replace(NPMRC_ENV_PATTERN, (_match, name: string) => process.env[name] ?? "");
+}
+
+function parseNpmrc(content: string): Map<string, string> {
+  const entries = new Map<string, string>();
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) continue;
+    const key = line.slice(0, separator).trim();
+    const value = expandNpmrcEnv(unquoteNpmrcValue(line.slice(separator + 1).trim()));
+    entries.set(key, value);
+  }
+  return entries;
+}
+
+async function readNpmrcFile(path: string): Promise<Map<string, string>> {
+  try {
+    return parseNpmrc(await readFile(path, "utf8"));
+  } catch {
+    return new Map();
+  }
+}
+
+/**
+ * Reads `//host[:port][/path]/:_authToken` from npmrc files.
+ * `npm config get` refuses to print protected auth keys, so this parses the
+ * files npm itself would consult instead of asking the CLI.
+ */
+async function resolveRegistryAuthToken(registry: string): Promise<string | null> {
+  const key = authTokenConfigKey(registry);
+  if (!key) return null;
+  const merged = new Map<string, string>();
+  for (const path of npmrcCandidatePaths()) {
+    const entries = await readNpmrcFile(path);
+    for (const [entryKey, value] of entries) merged.set(entryKey, value);
+  }
+  const token = merged.get(key);
+  if (!token) return null;
+  return token;
+}
+
+function requestIsUnderRegistry(registry: string, requestUrl: string): boolean {
+  try {
+    const parsedRegistry = new URL(registry);
+    const parsedRequest = new URL(requestUrl);
+    if (parsedRegistry.protocol !== "https:" || parsedRequest.protocol !== "https:") return false;
+    if (parsedRegistry.origin !== parsedRequest.origin) return false;
+    const basePath = parsedRegistry.pathname.replace(/\/$/, "");
+    if (basePath === "") return true;
+    return parsedRequest.pathname === basePath || parsedRequest.pathname.startsWith(`${basePath}/`);
+  } catch {
+    return false;
+  }
+}
+
+function readVersionField(data: unknown): string | null {
+  if (typeof data !== "object" || data === null) return null;
+  if (!("version" in data)) return null;
+  const version = data.version;
+  return typeof version === "string" ? version : null;
+}
+
 export function isNewerVersion(candidate: string, current: string): boolean {
   const parse = (version: string) => version.split(".").map(part => Number.parseInt(part, 10));
   const a = parse(candidate);
@@ -73,7 +175,7 @@ export function isNewerVersion(candidate: string, current: string): boolean {
 }
 
 export async function fetchLatestVersion(
-  fetchFn: typeof fetch = fetch,
+  fetchFn: FetchLike = fetch,
   timeoutMs = 3000,
   resolveRegistry: () => string | Promise<string> = resolveConfiguredRegistry
 ): Promise<string | null> {
@@ -81,13 +183,23 @@ export async function fetchLatestVersion(
     const resolved = (await resolveRegistry()).replace(/\/$/, "");
     const registry = isUsableRegistryUrl(resolved) ? resolved : DEFAULT_NPM_REGISTRY;
     const registryLatestUrl = `${registry}/${PACKAGE_LATEST_PATH}`;
-    const response = await fetchFn(registryLatestUrl, {
+    const headers: Record<string, string> = { accept: "application/json" };
+    const init: RequestInit = {
       signal: AbortSignal.timeout(timeoutMs),
-      headers: { accept: "application/json" },
-    });
+      headers,
+    };
+
+    const token = await resolveRegistryAuthToken(registry).catch(() => null);
+    if (token && requestIsUnderRegistry(registry, registryLatestUrl)) {
+      headers.authorization = `Bearer ${token}`;
+      // Never follow redirects with a token attached — fetch would otherwise
+      // forward Authorization to a different origin.
+      init.redirect = "error";
+    }
+
+    const response = await fetchFn(registryLatestUrl, init);
     if (!response.ok) return null;
-    const data = (await response.json()) as { version?: unknown };
-    return typeof data.version === "string" ? data.version : null;
+    return readVersionField(await response.json());
   } catch {
     // Fail silent: the update check must never break or delay server startup
     // (offline machines, air-gapped networks, registry outages).
@@ -98,7 +210,7 @@ export async function fetchLatestVersion(
 /** Returns the latest published version when it is newer than `currentVersion`, otherwise null. */
 export async function checkForNewVersion(
   currentVersion: string,
-  fetchFn: typeof fetch = fetch
+  fetchFn: FetchLike = fetch
 ): Promise<string | null> {
   if (!RELEASE_VERSION_PATTERN.test(currentVersion)) return null;
   const latest = await fetchLatestVersion(fetchFn);

--- a/utils/version-check.ts
+++ b/utils/version-check.ts
@@ -1,21 +1,31 @@
-import { execSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
 const PACKAGE_LATEST_PATH = "@zereight/mcp-gitlab/latest";
 const RELEASE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
 
-/** Resolves the npm registry to use, honoring `.npmrc` / `npm_config_registry` when available. */
-function resolveConfiguredRegistry(): string {
+/** A configured registry is only used when it parses as a valid HTTP(S) URL with a hostname. */
+function isUsableRegistryUrl(registry: string): boolean {
   try {
-    const registry = execSync("npm config get registry", {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
+    const parsed = new URL(registry);
+    return (parsed.protocol === "http:" || parsed.protocol === "https:") && parsed.hostname !== "";
+  } catch {
+    return false;
+  }
+}
+
+/** Resolves the npm registry to use, honoring `.npmrc` / `npm_config_registry` when available. */
+async function resolveConfiguredRegistry(): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("npm", ["config", "get", "registry"], {
       timeout: 5000,
       windowsHide: true,
-    })
-      .trim()
-      .replace(/\/$/, "");
-    if (registry && registry !== "undefined" && /^https?:\/\//.test(registry)) return registry;
+    });
+    const registry = stdout.trim().replace(/\/$/, "");
+    if (registry && registry !== "undefined") return registry;
   } catch {
     // npm unavailable or the lookup failed — fall back to the public registry.
   }
@@ -36,10 +46,12 @@ export function isNewerVersion(candidate: string, current: string): boolean {
 export async function fetchLatestVersion(
   fetchFn: typeof fetch = fetch,
   timeoutMs = 3000,
-  resolveRegistry: () => string = resolveConfiguredRegistry
+  resolveRegistry: () => string | Promise<string> = resolveConfiguredRegistry
 ): Promise<string | null> {
   try {
-    const registryLatestUrl = `${resolveRegistry().replace(/\/$/, "")}/${PACKAGE_LATEST_PATH}`;
+    const resolved = (await resolveRegistry()).replace(/\/$/, "");
+    const registry = isUsableRegistryUrl(resolved) ? resolved : DEFAULT_NPM_REGISTRY;
+    const registryLatestUrl = `${registry}/${PACKAGE_LATEST_PATH}`;
     const response = await fetchFn(registryLatestUrl, {
       signal: AbortSignal.timeout(timeoutMs),
       headers: { accept: "application/json" },

--- a/utils/version-check.ts
+++ b/utils/version-check.ts
@@ -17,23 +17,36 @@ function isUsableRegistryUrl(registry: string): boolean {
   }
 }
 
-/** Resolves the npm registry to use, honoring `.npmrc` / `npm_config_registry` when available. */
-async function resolveConfiguredRegistry(): Promise<string> {
+/** Runs `npm config get <key>` and returns the trimmed value, or null if unavailable/unset. */
+async function npmConfigGet(key: string): Promise<string | null> {
   try {
     // On Windows "npm" resolves to npm.cmd, which execFile can't launch
     // directly — route through cmd.exe instead. Command and args are fixed
-    // literals on both platforms, so this doesn't open a shell-injection surface.
+    // literals (only `key` varies, and only with our own constant inputs), so
+    // this doesn't open a shell-injection surface.
     const isWindows = process.platform === "win32";
     const { stdout } = await execFileAsync(
       isWindows ? "cmd.exe" : "npm",
-      isWindows ? ["/d", "/s", "/c", "npm", "config", "get", "registry"] : ["config", "get", "registry"],
+      isWindows ? ["/d", "/s", "/c", "npm", "config", "get", key] : ["config", "get", key],
       { timeout: 5000, windowsHide: true }
     );
-    const registry = stdout.trim().replace(/\/$/, "");
-    if (registry && registry !== "undefined") return registry;
+    const value = stdout.trim().replace(/\/$/, "");
+    return value && value !== "undefined" ? value : null;
   } catch {
-    // npm unavailable or the lookup failed — fall back to the public registry.
+    return null;
   }
+}
+
+/**
+ * Resolves the npm registry to use, honoring `.npmrc` / `npm_config_registry`.
+ * Package-scoped config (`@zereight:registry`) takes precedence, matching how
+ * npm itself resolves the registry for a scoped package like this one.
+ */
+async function resolveConfiguredRegistry(): Promise<string> {
+  const scoped = await npmConfigGet("@zereight:registry");
+  if (scoped) return scoped;
+  const unscoped = await npmConfigGet("registry");
+  if (unscoped) return unscoped;
   return DEFAULT_NPM_REGISTRY;
 }
 

--- a/utils/version-check.ts
+++ b/utils/version-check.ts
@@ -20,10 +20,15 @@ function isUsableRegistryUrl(registry: string): boolean {
 /** Resolves the npm registry to use, honoring `.npmrc` / `npm_config_registry` when available. */
 async function resolveConfiguredRegistry(): Promise<string> {
   try {
-    const { stdout } = await execFileAsync("npm", ["config", "get", "registry"], {
-      timeout: 5000,
-      windowsHide: true,
-    });
+    // On Windows "npm" resolves to npm.cmd, which execFile can't launch
+    // directly — route through cmd.exe instead. Command and args are fixed
+    // literals on both platforms, so this doesn't open a shell-injection surface.
+    const isWindows = process.platform === "win32";
+    const { stdout } = await execFileAsync(
+      isWindows ? "cmd.exe" : "npm",
+      isWindows ? ["/d", "/s", "/c", "npm", "config", "get", "registry"] : ["config", "get", "registry"],
+      { timeout: 5000, windowsHide: true }
+    );
     const registry = stdout.trim().replace(/\/$/, "");
     if (registry && registry !== "undefined") return registry;
   } catch {


### PR DESCRIPTION
## Summary
- `fetchLatestVersion()` hardcoded `https://registry.npmjs.org`, ignoring any configured private/internal npm registry (`.npmrc`, `npm_config_registry`).
- In locked-down environments this made every server startup attempt a direct outbound call to the public registry, which network policy (proxy/EDR/DLP) blocks and alerts on — noisy even though the check fails silently by design and doesn't affect functionality.
- Now resolves the registry via `npm config get registry` first, falling back to the public registry when that lookup fails or returns something unusable.

Fixes #699

## Test plan
- [x] `npm run build`
- [x] `node --test build/test/utils/version-check.test.js` — added cases covering resolver override and fallback-on-throw