### PR TITLE
fix: return 404 for expired stateful Streamable HTTP sessions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14577,8 +14577,32 @@ async function startStreamableHTTPServer(): Promise<void> {
       ? staticMcpBearerAuth
       : (_req: Request, _res: Response, next: NextFunction) => next();
 
+  // Stateful mode: a request carrying an Mcp-Session-Id that isn't (or is no
+  // longer) in streamableTransports must get the spec-mandated 404 before
+  // rate limiting or auth can mask that signal with an unrelated 429/401 —
+  // otherwise conforming clients can't tell to re-initialize. New sessions
+  // (no header at all) and stateless mode (its own 404 path, see
+  // hasStatelessSessionId above) are unaffected.
+  const rejectUnknownStreamableSession = (req: Request, res: Response, next: NextFunction) => {
+    if (OAUTH_STATELESS_MODE && STATELESS_MATERIAL && (REMOTE_AUTHORIZATION || GITLAB_MCP_OAUTH)) {
+      next();
+      return;
+    }
+    const sessionId = readMcpSessionIdHeader(req);
+    if (sessionId && !streamableTransports[sessionId]) {
+      res.status(404).json({ error: "Session not found" });
+      return;
+    }
+    next();
+  };
+
   // Streamable HTTP endpoint - handles both session creation and message handling
-  app.post("/mcp", mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
+  app.post(
+    "/mcp",
+    rejectUnknownStreamableSession,
+    mcpRequestRateLimit,
+    mcpBearerAuth,
+    async (req: Request, res: Response) => {
     const sessionId = readMcpSessionIdHeader(req);
     const publicBaseUrl = getForwardedPublicBaseUrl(req, MCP_TRUST_PROXY);
 
@@ -14880,10 +14904,16 @@ async function startStreamableHTTPServer(): Promise<void> {
       // Standard execution (no per-session auth or no session yet)
       await handleRequest();
     }
-  });
+  }
+  );
 
   // Streamable HTTP GET endpoint for listening to server-sent events (SSE)
-  app.get("/mcp", mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
+  app.get(
+    "/mcp",
+    rejectUnknownStreamableSession,
+    mcpRequestRateLimit,
+    mcpBearerAuth,
+    async (req: Request, res: Response) => {
     const sessionId = readMcpSessionIdHeader(req);
     const acceptHeader = readAcceptHeader(req);
 
@@ -14969,7 +14999,8 @@ async function startStreamableHTTPServer(): Promise<void> {
         setAuthTimeout(sessionId);
       }
     }
-  });
+  }
+  );
 
   const getMetricsSnapshot = () => ({
     ...metrics,
@@ -15017,34 +15048,40 @@ async function startStreamableHTTPServer(): Promise<void> {
   });
 
   // to delete a mcp server session explicitly
-  app.delete("/mcp", mcpRequestRateLimit, mcpBearerAuth, async (req: Request, res: Response) => {
-    const sessionId = readMcpSessionIdHeader(req);
+  app.delete(
+    "/mcp",
+    rejectUnknownStreamableSession,
+    mcpRequestRateLimit,
+    mcpBearerAuth,
+    async (req: Request, res: Response) => {
+      const sessionId = readMcpSessionIdHeader(req);
 
-    if (!sessionId) {
-      res.status(400).json({ error: "mcp-session-id header is required" });
-      return;
-    }
-
-    const transport = streamableTransports[sessionId];
-
-    if (transport) {
-      try {
-        await transport.close();
-        logger.info(`Explicitly closed session via DELETE request: ${sessionId}`);
-        if (REMOTE_AUTHORIZATION || GITLAB_MCP_OAUTH) {
-          cleanupSessionAuth(sessionId);
-          delete sessionRequestCounts[sessionId];
-          logger.info(`Session ${sessionId}: cleaned up auth mapping on DELETE`);
-        }
-        res.status(204).send();
-      } catch (error) {
-        logger.error({ err: error }, `Error closing session ${sessionId}`);
-        res.status(500).json({ error: "Failed to close session" });
+      if (!sessionId) {
+        res.status(400).json({ error: "mcp-session-id header is required" });
+        return;
       }
-    } else {
-      res.status(404).json({ error: "Session not found" });
+
+      const transport = streamableTransports[sessionId];
+
+      if (transport) {
+        try {
+          await transport.close();
+          logger.info(`Explicitly closed session via DELETE request: ${sessionId}`);
+          if (REMOTE_AUTHORIZATION || GITLAB_MCP_OAUTH) {
+            cleanupSessionAuth(sessionId);
+            delete sessionRequestCounts[sessionId];
+            logger.info(`Session ${sessionId}: cleaned up auth mapping on DELETE`);
+          }
+          res.status(204).send();
+        } catch (error) {
+          logger.error({ err: error }, `Error closing session ${sessionId}`);
+          res.status(500).json({ error: "Failed to close session" });
+        }
+      } else {
+        res.status(404).json({ error: "Session not found" });
+      }
     }
-  });
+  );
 
   // Reject unsupported methods on /mcp
   app.all("/mcp", (_req: Request, res: Response) => {

--- a/index.ts
+++ b/index.ts
@@ -14798,6 +14798,16 @@ async function startStreamableHTTPServer(): Promise<void> {
       try {
         let transport: StreamableHTTPServerTransport;
 
+        // Re-check session existence here, not just in rejectUnknownStreamableSession:
+        // the session can expire and close its transport while this request was
+        // waiting on rate-limit/auth checks above, which are async. Without this,
+        // a session id that expired mid-request would fall into the "no session"
+        // branch below and get a wrongly-issued new transport instead of a 404.
+        if (sessionId && !Object.prototype.hasOwnProperty.call(streamableTransports, sessionId)) {
+          res.status(404).json({ error: "Session not found" });
+          return;
+        }
+
         if (sessionId && streamableTransports[sessionId]) {
           // Reuse existing transport for ongoing session
           transport = streamableTransports[sessionId];

--- a/index.ts
+++ b/index.ts
@@ -14589,7 +14589,10 @@ async function startStreamableHTTPServer(): Promise<void> {
       return;
     }
     const sessionId = readMcpSessionIdHeader(req);
-    if (sessionId && !streamableTransports[sessionId]) {
+    if (
+      sessionId &&
+      !Object.prototype.hasOwnProperty.call(streamableTransports, sessionId)
+    ) {
       res.status(404).json({ error: "Session not found" });
       return;
     }

--- a/test/streamable-http-expired-session-404.test.ts
+++ b/test/streamable-http-expired-session-404.test.ts
@@ -138,4 +138,20 @@ describe("Expired stateful session returns 404", { timeout: 20_000 }, () => {
     });
     assert.strictEqual(deleteResponse.status, 404, deleteResponse.text);
   });
+
+  test("a session id matching an inherited Object property still gets 404", async () => {
+    const { server, mcpUrl } = await launchExpiringSessionServer();
+    servers.push(server);
+
+    for (const sessionId of ["toString", "constructor", "__proto__", "hasOwnProperty"]) {
+      const response = await rawMcpRequest(
+        mcpUrl,
+        "POST",
+        { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+        { "mcp-session-id": sessionId }
+      );
+      assert.strictEqual(response.status, 404, `${sessionId}: ${response.text}`);
+      assert.strictEqual(response.data?.error, "Session not found");
+    }
+  });
 });

--- a/test/streamable-http-expired-session-404.test.ts
+++ b/test/streamable-http-expired-session-404.test.ts
@@ -1,0 +1,141 @@
+import { after, describe, test } from "node:test";
+import assert from "node:assert";
+import {
+  cleanupServers,
+  findAvailablePort,
+  HOST,
+  launchServer,
+  ServerInstance,
+  TransportMode,
+} from "./utils/server-launcher.js";
+
+async function rawMcpRequest(
+  url: string,
+  method: string,
+  body: object | null,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; data: any; text: string }> {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await response.text();
+  return { status: response.status, data: text ? JSON.parse(text) : null, text };
+}
+
+const initializeBody = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: { name: "expired-session-test", version: "1.0.0" },
+  },
+};
+
+async function initialize(mcpUrl: string, headers: Record<string, string> = {}) {
+  const response = await fetch(mcpUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(initializeBody),
+  });
+  assert.strictEqual(response.status, 200, await response.text());
+  const sessionId = response.headers.get("mcp-session-id");
+  assert.ok(sessionId, "initialize should return Mcp-Session-Id");
+  return sessionId!;
+}
+
+let portOffset = 0;
+
+async function launchExpiringSessionServer() {
+  const port = await findAvailablePort(3700 + portOffset++ * 10);
+  const server = await launchServer({
+    mode: TransportMode.STREAMABLE_HTTP,
+    port,
+    timeout: 10_000,
+    env: {
+      STREAMABLE_HTTP: "true",
+      REMOTE_AUTHORIZATION: "true",
+      GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY: "true",
+      GITLAB_API_URL: "https://gitlab.example.com/api/v4",
+      SESSION_TIMEOUT_SECONDS: "1",
+      MAX_REQUESTS_PER_MINUTE: "1",
+    },
+  });
+  return { server, mcpUrl: `http://${HOST}:${port}/mcp` };
+}
+
+describe("Expired stateful session returns 404", { timeout: 20_000 }, () => {
+  let servers: ServerInstance[] = [];
+
+  after(() => {
+    cleanupServers(servers);
+    servers = [];
+  });
+
+  test("POST with an expired Mcp-Session-Id gets 404 even once the rate limit is exhausted", async () => {
+    const { server, mcpUrl } = await launchExpiringSessionServer();
+    servers.push(server);
+
+    const sessionId = await initialize(mcpUrl);
+    await new Promise(resolve => setTimeout(resolve, 2_000));
+
+    // First request after expiry burns the single-request-per-minute budget.
+    const first = await rawMcpRequest(
+      mcpUrl,
+      "POST",
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      { "mcp-session-id": sessionId }
+    );
+    assert.strictEqual(first.status, 404, first.text);
+    assert.strictEqual(first.data?.error, "Session not found");
+
+    // Rate limit is now exhausted for this client, but the stale session
+    // must still surface as 404, not 429.
+    const second = await rawMcpRequest(
+      mcpUrl,
+      "POST",
+      { jsonrpc: "2.0", id: 3, method: "tools/list", params: {} },
+      { "mcp-session-id": sessionId }
+    );
+    assert.strictEqual(second.status, 404, second.text);
+  });
+
+  test("a fresh initialization (no session id) still succeeds normally", async () => {
+    const { server, mcpUrl } = await launchExpiringSessionServer();
+    servers.push(server);
+
+    const sessionId = await initialize(mcpUrl);
+    assert.ok(sessionId);
+  });
+
+  test("GET and DELETE with an expired Mcp-Session-Id also get 404", async () => {
+    const { server, mcpUrl } = await launchExpiringSessionServer();
+    servers.push(server);
+
+    const sessionId = await initialize(mcpUrl);
+    await new Promise(resolve => setTimeout(resolve, 2_000));
+
+    const getResponse = await rawMcpRequest(mcpUrl, "GET", null, {
+      "mcp-session-id": sessionId,
+      Accept: "text/event-stream",
+    });
+    assert.strictEqual(getResponse.status, 404, getResponse.text);
+
+    const deleteResponse = await rawMcpRequest(mcpUrl, "DELETE", null, {
+      "mcp-session-id": sessionId,
+    });
+    assert.strictEqual(deleteResponse.status, 404, deleteResponse.text);
+  });
+});


### PR DESCRIPTION
## Summary
- In stateful Streamable HTTP mode, a request carrying an expired or otherwise unknown `Mcp-Session-Id` fell through rate limiting, auth, and (on POST) the new-transport path instead of the spec-mandated 404, so another status code could mask the session-lifecycle signal.
- Conforming clients rely on 404 to know the server terminated the session and that they must re-initialize with a fresh `InitializeRequest` (no expired id).
- Adds `rejectUnknownStreamableSession` middleware, applied before rate limiting and auth on `POST`, `GET`, and `DELETE /mcp`: any request carrying a session id not present in `streamableTransports` now returns 404 immediately.
- Stateless mode (`OAUTH_STATELESS_MODE` + `STATELESS_MATERIAL`) is unaffected — it already has its own 404 path for sealed session ids.

Fixes #697

## Test plan
- [x] `npm run build`
- [x] New `test/streamable-http-expired-session-404.test.ts`:
  - POST with an expired session id gets 404, even after the rate limit is exhausted by a follow-up request with the same expired id
  - GET and DELETE with an expired session id also get 404
  - A fresh initialization (no session header) still succeeds normally
- [x] Existing streamable-http suites (`streamable-http-sse-stream`, `streamable-http-unauthenticated-discovery`, `streamable-http-concurrent-session`) pass unchanged
- [x] Full `scripts/run-mock-tests.sh` — no regressions (pre-existing `tsx: command not found` in the OAuth device-flow step is an unrelated local environment gap)