### PR TITLE
fix: treat 403 as non-fatal in session warmup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1620,7 +1620,8 @@ async function ensureSessionForRequest(): Promise<void> {
       redirect: "follow",
     });
     // 401 means auth failed but the request completed - cookies were still exchanged
-    initialSessionRequestMade = response.ok || response.status === 401;
+    // 403 means insufficient scope (e.g. missing User: Read) but auth is valid
+    initialSessionRequestMade = response.ok || response.status === 401 || response.status === 403;
   } catch {
     logger.debug("Session warmup request failed, will retry on next request");
   }


### PR DESCRIPTION
## Problem

The GitLab MCP server crashes on startup if the authenticated PAT lacks the `User: Read` scope required by the `/user` endpoint. This is a **warmup initialization bug** — the `/user` call is treated as fatal, blocking all functional tools (list_projects, list_issues, etc.) even though those tools use completely different API endpoints and have their own scopes.

Fine-grained PATs scoped to specific projects commonly lack `User: Read`.

## Fix

Changes line 1623 in `index.ts` to treat 403 the same way 401 is treated — as non-fatal.

```diff
-    initialSessionRequestMade = response.ok || response.status === 401;
+    initialSessionRequestMade = response.ok || response.status === 401 || response.status === 403;
```

A 403 means the auth is valid but the token lacks a specific scope. The server should continue and let individual tools handle their own scope requirements.

## Testing

Tested locally: server starts and serves tools normally with a PAT that has `Project: Read` but not `User: Read` scope.