### PR TITLE
fix: allow unauthenticated server discovery

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -288,7 +288,7 @@ MCP 클라이언트 설정:
 | `STREAMABLE_HTTP`                                                | 예   | 반드시 `true`                                                                                                           |
 | `ENABLE_DYNAMIC_API_URL`                                         | 선택 | 요청별 `X-GitLab-API-URL` 헤더 허용                                                                                     |
 | `GITLAB_ALLOWED_HOSTS`                                           | 선택 | 허용할 `X-GitLab-API-URL` 호스트의 쉼표 구분 목록; `GITLAB_API_URL` 호스트는 항상 허용                                  |
-| `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY`                    | 선택 | 인증 없이 `initialize`, `notifications/initialized`, `tools/list`만 허용(도구 호출은 여전히 인증 필요)                  |
+| `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY`                    | 선택 | 인증 없이 `initialize`, `notifications/initialized`, `tools/list`, `server/discover`만 허용(도구 호출은 여전히 인증 필요)                  |
 | `MCP_SERVER_URL` / `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` | 선택 | DNS rebinding 방지를 위한 허용 `/mcp` 호스트/오리진 값                                                                  |
 | `MCP_TRUST_PROXY`                                                | 선택 | 리버스 프록시 뒤에서 `Forwarded` / `X-Forwarded-*` 헤더 신뢰(다운로드 URL, Express `req.ip`, `/mcp` IP rate limit, OAuth rate limit) |
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ the token to GitLab on behalf of the caller.
 | `STREAMABLE_HTTP`                             | ✅       | Must be `true`                                                                                                          |
 | `ENABLE_DYNAMIC_API_URL`                      | optional | Allow per-request GitLab URL via `X-GitLab-API-URL` header                                                              |
 | `GITLAB_ALLOWED_HOSTS`                        | optional | Comma-separated allowed `X-GitLab-API-URL` hosts; `GITLAB_API_URL` hosts are always allowed                             |
-| `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY` | optional | Allow unauthenticated `initialize`, `notifications/initialized`, and `tools/list` only (tool calls still require auth)  |
+| `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY` | optional | Allow unauthenticated `initialize`, `notifications/initialized`, `tools/list`, and `server/discover` only (tool calls still require auth)  |
 | `MCP_SERVER_URL` / `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` | optional | Allowed public `/mcp` host/origin values for DNS rebinding protection                                   |
 | `MCP_TRUST_PROXY`                             | optional | Trust `Forwarded` / `X-Forwarded-*` headers behind a reverse proxy (download URLs, Express `req.ip`, `/mcp` IP rate limits, OAuth rate limits) |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -289,7 +289,7 @@ MCP 客户端配置：
 | `STREAMABLE_HTTP`                                                | 是   | 必须为 `true`                                                                                                           |
 | `ENABLE_DYNAMIC_API_URL`                                         | 可选 | 允许按请求通过 `X-GitLab-API-URL` 请求头指定 GitLab URL                                                                 |
 | `GITLAB_ALLOWED_HOSTS`                                           | 可选 | 允许的 `X-GitLab-API-URL` 主机逗号分隔列表；`GITLAB_API_URL` 中的主机始终允许                                          |
-| `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY`                    | 可选 | 仅允许未认证的 `initialize`、`notifications/initialized`、`tools/list`（工具调用仍需认证）                                |
+| `GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY`                    | 可选 | 仅允许未认证的 `initialize`、`notifications/initialized`、`tools/list`、`server/discover`（工具调用仍需认证）                                |
 | `MCP_SERVER_URL` / `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` | 可选 | 用于 DNS rebinding 防护的允许 `/mcp` 主机/来源值                                                                        |
 | `MCP_TRUST_PROXY`                                                | 可选 | 在反向代理后信任 `Forwarded` / `X-Forwarded-*` 请求头（下载 URL、Express `req.ip`、`/mcp` IP 速率限制、OAuth 速率限制） |
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -106,8 +106,9 @@ Default:
 
 Security notes:
 
-- Only `initialize`, `notifications/initialized`, and `tools/list` may proceed without auth.
+- Only `initialize`, `notifications/initialized`, `tools/list`, and `server/discover` may proceed without auth.
 - `tools/call` and all GitLab API access still require request auth headers.
+- This is a compatibility pass-through for clients that send `server/discover`; it does not indicate MCP v2 support.
 - Tool names and schemas can reveal enabled server capabilities; enable this only when that metadata is safe to expose.
 
 ### `SESSION_TIMEOUT_SECONDS`

--- a/server/request-helpers.ts
+++ b/server/request-helpers.ts
@@ -32,7 +32,10 @@ export function isUnauthenticatedDiscoveryRequestBody(body: unknown): boolean {
     if (typeof m !== "object" || m === null) return false;
     const method = (m as { method?: unknown }).method;
     return (
-      method === "initialize" || method === "notifications/initialized" || method === "tools/list"
+      method === "initialize" ||
+      method === "notifications/initialized" ||
+      method === "tools/list" ||
+      method === "server/discover"
     );
   };
   if (Array.isArray(body)) return body.every(isDiscoveryMethod);

--- a/test/server/request-helpers.test.ts
+++ b/test/server/request-helpers.test.ts
@@ -42,6 +42,13 @@ describe("streamable request helpers", () => {
       isUnauthenticatedDiscoveryRequestBody([{ method: "tools/list" }, { method: "call_tool" }]),
       false
     );
+    assert.strictEqual(
+      isUnauthenticatedDiscoveryRequestBody([
+        { method: "server/discover" },
+        { method: "tools/call" },
+      ]),
+      false
+    );
     assert.strictEqual(isUnauthenticatedDiscoveryRequestBody(undefined), false);
   });
 

--- a/test/server/request-helpers.test.ts
+++ b/test/server/request-helpers.test.ts
@@ -28,11 +28,13 @@ describe("streamable request helpers", () => {
 
   test("allows only discovery methods in unauthenticated discovery bodies", () => {
     assert.strictEqual(isUnauthenticatedDiscoveryRequestBody({ method: "tools/list" }), true);
+    assert.strictEqual(isUnauthenticatedDiscoveryRequestBody({ method: "server/discover" }), true);
     assert.strictEqual(
       isUnauthenticatedDiscoveryRequestBody([
         { method: "initialize" },
         { method: "notifications/initialized" },
         { method: "tools/list" },
+        { method: "server/discover" },
       ]),
       true
     );

--- a/test/server/request-helpers.test.ts
+++ b/test/server/request-helpers.test.ts
@@ -39,7 +39,11 @@ describe("streamable request helpers", () => {
       true
     );
     assert.strictEqual(
-      isUnauthenticatedDiscoveryRequestBody([{ method: "tools/list" }, { method: "call_tool" }]),
+      isUnauthenticatedDiscoveryRequestBody([
+        { method: "tools/list" },
+        { method: "call_tool" },
+        { method: "tools/call" },
+      ]),
       false
     );
     assert.strictEqual(

--- a/test/streamable-http-unauthenticated-discovery.test.ts
+++ b/test/streamable-http-unauthenticated-discovery.test.ts
@@ -146,6 +146,27 @@ describe("Streamable HTTP unauthenticated tool discovery", { timeout: 20_000 }, 
     assert.ok(listResponse.data.result.tools.length > 0, "tools/list should not be empty");
   });
 
+  test("allows unauthenticated server/discover in individual and batch requests", async () => {
+    const { server, mcpUrl } = await launchRemoteAuthServer({
+      GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY: "true",
+    });
+    servers.push(server);
+
+    const individual = await rawMcpRequest(mcpUrl, {
+      jsonrpc: "2.0",
+      id: 10,
+      method: "server/discover",
+      params: {},
+    });
+    assert.notStrictEqual(individual.status, 401, individual.text);
+
+    const batch = await rawMcpRequest(mcpUrl, [
+      { jsonrpc: "2.0", id: 11, method: "server/discover", params: {} },
+      { jsonrpc: "2.0", id: 12, method: "tools/list", params: {} },
+    ]);
+    assert.notStrictEqual(batch.status, 401, batch.text);
+  });
+
   test("expires unauthenticated discovery sessions and frees capacity", async () => {
     const { server, mcpUrl } = await launchRemoteAuthServer({
       GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY: "true",


### PR DESCRIPTION
Closes #705

## Summary
- allow server/discover through unauthenticated discovery when GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY=true
- cover individual and batch discovery requests
- keep tools/call authentication required
- document the compatibility behavior

This is a compatibility pass-through and does not migrate the MCP SDK to v2.