### PR TITLE
feat: add ENABLE_DYNAMIC_PROJECT_SCOPE and ENABLE_STRICT_PROJECT_SCOPE

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -123,6 +123,8 @@ export const ENABLE_DYNAMIC_API_URL =
   getConfig("enable-dynamic-api-url", "ENABLE_DYNAMIC_API_URL") === "true";
 export const ENABLE_DYNAMIC_PROJECT_SCOPE =
   getConfig("enable-dynamic-project-scope", "ENABLE_DYNAMIC_PROJECT_SCOPE") === "true";
+export const ENABLE_STRICT_PROJECT_SCOPE =
+  getConfig("enable-strict-project-scope", "ENABLE_STRICT_PROJECT_SCOPE") === "true";
 
 // ---------------------------------------------------------------------------
 // Stateless mode (multi-pod safe OAuth / session encoding)

--- a/config.ts
+++ b/config.ts
@@ -121,6 +121,8 @@ export const GITLAB_OAUTH_ALLOWED_GROUPS = (() => {
 })();
 export const ENABLE_DYNAMIC_API_URL =
   getConfig("enable-dynamic-api-url", "ENABLE_DYNAMIC_API_URL") === "true";
+export const ENABLE_DYNAMIC_PROJECT_SCOPE =
+  getConfig("enable-dynamic-project-scope", "ENABLE_DYNAMIC_PROJECT_SCOPE") === "true";
 
 // ---------------------------------------------------------------------------
 // Stateless mode (multi-pod safe OAuth / session encoding)

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -235,7 +235,7 @@ Notes:
 
 Example:
 
-```
+```text
 X-GitLab-Allowed-Project-Ids: 42
 Private-Token: glpat-xxxxxxxxxxxxxxxxxxxx
 ```

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -205,6 +205,41 @@ Notes:
 - Uses the `X-GitLab-API-URL` request header in HTTP mode
 - The header URL must use an allowed host: any host in `GITLAB_API_URL`, plus any host in `GITLAB_ALLOWED_HOSTS`
 
+### `ENABLE_DYNAMIC_PROJECT_SCOPE`
+
+Set to `true` to allow a caller to narrow its own project allowlist per session
+via the `X-GitLab-Allowed-Project-Ids` request header (comma-separated project
+IDs or full paths).
+
+Notes:
+
+- Requires `REMOTE_AUTHORIZATION=true`
+- The header can only **narrow**, never widen. When `GITLAB_ALLOWED_PROJECT_IDS`
+  is set, every requested id must appear in it; a request naming anything outside
+  it is rejected with `401` rather than silently narrowed to the intersection.
+  The comparison is textual, so header entries must match the configured entries
+  verbatim — a numeric id does not match a path entry for the same project.
+- When `GITLAB_ALLOWED_PROJECT_IDS` is unset, the header narrows from "every
+  project the token can reach" to the listed ones.
+- The resulting scope behaves exactly like `GITLAB_ALLOWED_PROJECT_IDS` for that
+  session: a single id acts as the default project, tools that cannot be project
+  scoped (`execute_graphql`, `create_repository`, `create_group`,
+  `fork_repository`, the group variable and dependency proxy tools) are refused,
+  and `group:<id-or-path>` targets are refused.
+- In stateless mode the scope is sealed into the `Mcp-Session-Id` alongside the
+  token, so a caller cannot widen it by editing the sid.
+- The scope is only as trustworthy as the caller. This is intended for
+  deployments where one trusted process (an agent gateway, a chat bot with its
+  own per-room ACLs) fans out to several logical tenants and wants each tool call
+  bounded to that tenant's project — not as a defence against a hostile client.
+
+Example:
+
+```
+X-GitLab-Allowed-Project-Ids: 42
+Private-Token: glpat-xxxxxxxxxxxxxxxxxxxx
+```
+
 ### `GITLAB_ALLOWED_HOSTS`
 
 Comma-separated additional hosts or GitLab base/API URLs allowed for
@@ -332,6 +367,9 @@ Behavior:
 
 - One project ID: acts like a default locked project
 - Multiple project IDs: restricts access to those projects only
+
+This is process-level and fixed at startup. To let a caller narrow the scope
+per session, see `ENABLE_DYNAMIC_PROJECT_SCOPE`.
 
 ### `GITLAB_READ_ONLY_MODE`
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -251,7 +251,9 @@ still return everything the token can see.
 While an allowlist is in effect, strict scope:
 
 - filters `list_projects`, `list_group_projects`, and `search_repositories`
-  results down to the allowlist
+  results down to the allowlist (`count` and `total_pages` deliberately keep
+  reflecting the unfiltered GitLab totals so pagination still covers every
+  page; callers can infer how many upstream matches exist, but never see them)
 - routes `list_issues` and `list_merge_requests` without a `project_id` to the
   allowed project instead of the instance-wide endpoint (a multi-project
   allowlist requires an explicit `project_id`)

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -240,6 +240,26 @@ X-GitLab-Allowed-Project-Ids: 42
 Private-Token: glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
+### `ENABLE_STRICT_PROJECT_SCOPE`
+
+Set to `true` to close the discovery gaps a project allowlist
+(`GITLAB_ALLOWED_PROJECT_IDS`, or the session scope under
+`ENABLE_DYNAMIC_PROJECT_SCOPE`) leaves open. Without this flag, the allowlist
+only restricts which projects tools may operate on — listings and searches
+still return everything the token can see.
+
+While an allowlist is in effect, strict scope:
+
+- filters `list_projects`, `list_group_projects`, and `search_repositories`
+  results down to the allowlist
+- routes `list_issues` and `list_merge_requests` without a `project_id` to the
+  allowed project instead of the instance-wide endpoint (a multi-project
+  allowlist requires an explicit `project_id`)
+- refuses instance-wide and group-wide tools that cannot be limited to allowed
+  projects: `search_code`, `search_group_code`, `list_events`, the todo tools,
+  group webhooks, and the group merge request, member, wiki, milestone, and
+  iteration tools
+
 ### `GITLAB_ALLOWED_HOSTS`
 
 Comma-separated additional hosts or GitLab base/API URLs allowed for

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@
 import {
   getConfig,
   ENABLE_DYNAMIC_API_URL,
+  ENABLE_DYNAMIC_PROJECT_SCOPE,
   GITLAB_AUTH_COOKIE_PATH,
   GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY,
   GITLAB_CA_CERT_PATH,
@@ -1315,6 +1316,12 @@ function validateConfiguration(): void {
     errors.push("ENABLE_DYNAMIC_API_URL=true requires REMOTE_AUTHORIZATION=true");
   }
 
+  const enableDynamicProjectScope =
+    getConfig("enable-dynamic-project-scope", "ENABLE_DYNAMIC_PROJECT_SCOPE") === "true";
+  if (enableDynamicProjectScope && !remoteAuth) {
+    errors.push("ENABLE_DYNAMIC_PROJECT_SCOPE=true requires REMOTE_AUTHORIZATION=true");
+  }
+
   if (errors.length > 0) {
     logger.error("Configuration validation failed:");
     errors.forEach(err => logger.error(`  - ${err}`));
@@ -1637,6 +1644,7 @@ interface SessionAuth {
   lastUsed: number;
   apiUrl: string; // The API URL for the current request
   publicBaseUrl?: string;
+  allowedProjectIds?: string[]; // Session-narrowed project allowlist; undefined means env config
 }
 
 interface AuthData {
@@ -1645,6 +1653,7 @@ interface AuthData {
   lastUsed: number;
   apiUrl: string;
   publicBaseUrl?: string;
+  allowedProjectIds?: string[];
 }
 
 const sessionAuthStore = new AsyncLocalStorage<SessionAuth>();
@@ -1741,6 +1750,23 @@ function getEffectiveApiUrl(): string {
     );
   }
   return GITLAB_API_URL;
+}
+
+/**
+ * Get the effective project allowlist for the current request
+ * In REMOTE_AUTHORIZATION mode with ENABLE_DYNAMIC_PROJECT_SCOPE, reads the scope
+ * narrowed via the X-GitLab-Allowed-Project-Ids header from session context
+ * (already validated against GITLAB_ALLOWED_PROJECT_IDS by parseAuthHeaders)
+ * Otherwise, uses environment GITLAB_ALLOWED_PROJECT_IDS
+ */
+function getEffectiveAllowedProjectIds(): string[] {
+  if (ENABLE_DYNAMIC_PROJECT_SCOPE) {
+    const ctx = sessionAuthStore.getStore();
+    if (ctx?.allowedProjectIds && ctx.allowedProjectIds.length > 0) {
+      return ctx.allowedProjectIds;
+    }
+  }
+  return GITLAB_ALLOWED_PROJECT_IDS;
 }
 
 /**
@@ -2006,27 +2032,28 @@ async function handleGitLabError(response: UndiciResponse): Promise<void> {
  * @throws {Error} If GITLAB_ALLOWED_PROJECT_IDS is set and the requested project is not in the whitelist
  */
 function getEffectiveProjectId(projectId: string): string {
-  if (GITLAB_ALLOWED_PROJECT_IDS.length > 0) {
+  const allowedProjectIds = getEffectiveAllowedProjectIds();
+  if (allowedProjectIds.length > 0) {
     // If there's only one allowed project, use it as default
-    if (GITLAB_ALLOWED_PROJECT_IDS.length === 1 && !projectId) {
-      return GITLAB_ALLOWED_PROJECT_IDS[0];
+    if (allowedProjectIds.length === 1 && !projectId) {
+      return allowedProjectIds[0];
     }
 
     // If a project ID is provided, check if it's in the whitelist
-    if (projectId && !GITLAB_ALLOWED_PROJECT_IDS.includes(projectId)) {
+    if (projectId && !allowedProjectIds.includes(projectId)) {
       throw new Error(
-        `Access denied: Project ${projectId} is not in the allowed project list: ${GITLAB_ALLOWED_PROJECT_IDS.join(", ")}`
+        `Access denied: Project ${projectId} is not in the allowed project list: ${allowedProjectIds.join(", ")}`
       );
     }
 
     // If no project ID provided but we have multiple allowed projects, require an explicit choice
-    if (!projectId && GITLAB_ALLOWED_PROJECT_IDS.length > 1) {
+    if (!projectId && allowedProjectIds.length > 1) {
       throw new Error(
-        `Multiple projects allowed (${GITLAB_ALLOWED_PROJECT_IDS.join(", ")}). Please specify a project ID.`
+        `Multiple projects allowed (${allowedProjectIds.join(", ")}). Please specify a project ID.`
       );
     }
 
-    return projectId || GITLAB_ALLOWED_PROJECT_IDS[0];
+    return projectId || allowedProjectIds[0];
   }
   // Prioritize the passed projectId over GITLAB_PROJECT_ID to allow querying different projects
   if (projectId) {
@@ -2044,9 +2071,9 @@ function rejectIfProjectScopedDeployment(toolName: string): void {
       `${toolName} is not allowed when GITLAB_PROJECT_ID is set (server is locked to a single project)`
     );
   }
-  if (GITLAB_ALLOWED_PROJECT_IDS.length > 0) {
+  if (getEffectiveAllowedProjectIds().length > 0) {
     throw new Error(
-      `${toolName} is not allowed when GITLAB_ALLOWED_PROJECT_IDS is set (server access is restricted to configured projects)`
+      `${toolName} is not allowed while a project allowlist is in effect (GITLAB_ALLOWED_PROJECT_IDS or a session scope restricts access to configured projects)`
     );
   }
 }
@@ -3329,9 +3356,9 @@ async function resolveProjectOrGroupPath(
   const explicitKind = namespaceMatch?.[1]?.toLowerCase() as "group" | "project" | undefined;
   const requestedProjectId = namespaceMatch ? namespaceMatch[2] : decodedProjectId;
 
-  if (explicitKind === "group" && GITLAB_ALLOWED_PROJECT_IDS.length > 0) {
+  if (explicitKind === "group" && getEffectiveAllowedProjectIds().length > 0) {
     throw new Error(
-      "group:<id-or-path> cannot be used when GITLAB_ALLOWED_PROJECT_IDS is set, because the project allowlist does not cover groups"
+      "group:<id-or-path> cannot be used while a project allowlist is in effect (GITLAB_ALLOWED_PROJECT_IDS or a session scope), because the project allowlist does not cover groups"
     );
   }
 
@@ -3363,7 +3390,7 @@ async function resolveProjectOrGroupPath(
   if (
     projectResponse.status === 404 &&
     !explicitKind &&
-    GITLAB_ALLOWED_PROJECT_IDS.length === 0 &&
+    getEffectiveAllowedProjectIds().length === 0 &&
     !/^\d+$/.test(effectiveProjectId)
   ) {
     const groupUrl = new URL(
@@ -9643,19 +9670,20 @@ function assertVulnerabilityProjectAllowed(
   vulnerabilityId: string,
   project: { id?: string | null; fullPath?: string | null } | null | undefined
 ): void {
-  if (GITLAB_ALLOWED_PROJECT_IDS.length === 0) {
+  const allowedProjectIds = getEffectiveAllowedProjectIds();
+  if (allowedProjectIds.length === 0) {
     return;
   }
   const fullPath = project?.fullPath ?? undefined;
   const numericId = project?.id?.match(/^gid:\/\/gitlab\/Project\/(\d+)$/)?.[1];
   const allowed =
-    (fullPath !== undefined && GITLAB_ALLOWED_PROJECT_IDS.includes(fullPath)) ||
-    (numericId !== undefined && GITLAB_ALLOWED_PROJECT_IDS.includes(numericId));
+    (fullPath !== undefined && allowedProjectIds.includes(fullPath)) ||
+    (numericId !== undefined && allowedProjectIds.includes(numericId));
   if (!allowed) {
     throw new Error(
       `Access denied: Vulnerability ${vulnerabilityId} belongs to project ${
         fullPath ?? numericId ?? "unknown"
-      }, which is not in the allowed project list: ${GITLAB_ALLOWED_PROJECT_IDS.join(", ")}`
+      }, which is not in the allowed project list: ${allowedProjectIds.join(", ")}`
     );
   }
 }
@@ -9667,7 +9695,7 @@ function assertVulnerabilityProjectAllowed(
  * is not configured.
  */
 async function ensureVulnerabilityProjectAllowed(vulnerabilityId: string): Promise<void> {
-  if (GITLAB_ALLOWED_PROJECT_IDS.length === 0) {
+  if (getEffectiveAllowedProjectIds().length === 0) {
     return;
   }
   const data = await executeGraphQL<{
@@ -14052,8 +14080,37 @@ async function startStreamableHTTPServer(): Promise<void> {
     const privateToken = (req.headers["private-token"] as string | undefined) || "";
     const jobToken = (req.headers["job-token"] as string | undefined) || "";
     const dynamicApiUrl = (req.headers["x-gitlab-api-url"] as string | undefined)?.trim();
+    const requestedProjectScope = (
+      req.headers["x-gitlab-allowed-project-ids"] as string | undefined
+    )?.trim();
 
     let apiUrl = GITLAB_API_URL; // Default API URL
+    let allowedProjectIds: string[] | undefined;
+
+    // Only process the requested project scope if the feature is enabled
+    if (ENABLE_DYNAMIC_PROJECT_SCOPE && requestedProjectScope) {
+      const requested = requestedProjectScope
+        .split(",")
+        .map(id => id.trim())
+        .filter(Boolean);
+
+      if (requested.length === 0) {
+        logger.warn("Empty X-GitLab-Allowed-Project-Ids provided");
+        return null;
+      }
+
+      if (GITLAB_ALLOWED_PROJECT_IDS.length > 0) {
+        const outOfScope = requested.filter(id => !GITLAB_ALLOWED_PROJECT_IDS.includes(id));
+        if (outOfScope.length > 0) {
+          logger.warn(
+            `X-GitLab-Allowed-Project-Ids requested projects outside GITLAB_ALLOWED_PROJECT_IDS: ${outOfScope.join(", ")}`
+          );
+          return null; // Reject if the header tries to widen the configured allowlist
+        }
+      }
+
+      allowedProjectIds = requested;
+    }
 
     // Only process dynamic URL if the feature is enabled
     if (ENABLE_DYNAMIC_API_URL && dynamicApiUrl) {
@@ -14090,7 +14147,7 @@ async function startStreamableHTTPServer(): Promise<void> {
 
     // Validate token and return AuthData object
     if (token && header && validateToken(token)) {
-      return { header, token, lastUsed: Date.now(), apiUrl };
+      return { header, token, lastUsed: Date.now(), apiUrl, allowedProjectIds };
     }
 
     return null;
@@ -14242,6 +14299,7 @@ async function startStreamableHTTPServer(): Promise<void> {
       header: SessionAuthHeader;
       token: string;
       apiUrl: string;
+      allowedProjectIds?: string[];
     } | null = null;
     let freshAuthPresent = false;
     if (headerAuth) {
@@ -14267,6 +14325,7 @@ async function startStreamableHTTPServer(): Promise<void> {
         header: headerAuth.header,
         token: headerAuth.token,
         apiUrl: headerAuth.apiUrl,
+        allowedProjectIds: headerAuth.allowedProjectIds,
       };
       freshAuthPresent = true;
     } else if (GITLAB_MCP_OAUTH) {
@@ -14294,7 +14353,12 @@ async function startStreamableHTTPServer(): Promise<void> {
       if (looksLikeStatelessSessionId(incomingSid)) {
         const opened = openSessionId(material, incomingSid, sessionTtlSeconds);
         if (opened) {
-          effective = { header: opened.h, token: opened.t, apiUrl: opened.u };
+          effective = {
+            header: opened.h,
+            token: opened.t,
+            apiUrl: opened.u,
+            allowedProjectIds: opened.p,
+          };
           metrics.statelessAuthFromSealedSid++;
         } else {
           sidPresentedButInvalid = true;
@@ -14342,6 +14406,7 @@ async function startStreamableHTTPServer(): Promise<void> {
       header: effective.header,
       token: effective.token,
       apiUrl: effective.apiUrl,
+      allowedProjectIds: effective.allowedProjectIds,
     });
     if (freshAuthPresent) {
       metrics.statelessSidRotated++;
@@ -14365,6 +14430,7 @@ async function startStreamableHTTPServer(): Promise<void> {
       lastUsed: Date.now(),
       apiUrl: effective.apiUrl,
       publicBaseUrl: getForwardedPublicBaseUrl(req, MCP_TRUST_PROXY),
+      allowedProjectIds: effective.allowedProjectIds,
     };
 
     // Step 4: create a fresh transport per request.
@@ -14964,6 +15030,7 @@ async function startStreamableHTTPServer(): Promise<void> {
         lastUsed: authData.lastUsed,
         apiUrl: authData.apiUrl,
         publicBaseUrl: authData.publicBaseUrl,
+        allowedProjectIds: authData.allowedProjectIds,
       };
 
       // Run the entire request handling within AsyncLocalStorage context

--- a/index.ts
+++ b/index.ts
@@ -987,6 +987,7 @@ function createServer(): McpServer {
           lastUsed: authData.lastUsed,
           apiUrl: authData.apiUrl,
           publicBaseUrl: authData.publicBaseUrl,
+          allowedProjectIds: authData.allowedProjectIds,
         };
         // Run the handler within the retrieved context
         const result = await sessionAuthStore.run(sessionContext, () =>
@@ -15194,6 +15195,7 @@ async function startStreamableHTTPServer(): Promise<void> {
           lastUsed: authData.lastUsed,
           apiUrl: authData.apiUrl,
           publicBaseUrl: authData.publicBaseUrl,
+          allowedProjectIds: authData.allowedProjectIds,
         };
         await sessionAuthStore.run(ctx, handleGetRequest);
       } else {

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import {
   getConfig,
   ENABLE_DYNAMIC_API_URL,
   ENABLE_DYNAMIC_PROJECT_SCOPE,
+  ENABLE_STRICT_PROJECT_SCOPE,
   GITLAB_AUTH_COOKIE_PATH,
   GITLAB_ALLOW_UNAUTHENTICATED_TOOL_DISCOVERY,
   GITLAB_CA_CERT_PATH,
@@ -1770,6 +1771,38 @@ function getEffectiveAllowedProjectIds(): string[] {
 }
 
 /**
+ * Reject tools that cannot be limited to allowed projects when
+ * ENABLE_STRICT_PROJECT_SCOPE is set and an allowlist is in effect
+ */
+function rejectIfStrictProjectScope(toolName: string): void {
+  if (ENABLE_STRICT_PROJECT_SCOPE) {
+    rejectIfProjectScopedDeployment(toolName);
+  }
+}
+
+/**
+ * Filter a project listing down to the effective allowlist
+ * Applies only when ENABLE_STRICT_PROJECT_SCOPE is set and an allowlist is in effect
+ * Allowlist entries may be numeric IDs or full namespace paths
+ */
+function filterProjectsByAllowlist<T extends Pick<GitLabProject, "id" | "path_with_namespace">>(
+  projects: T[]
+): T[] {
+  if (!ENABLE_STRICT_PROJECT_SCOPE) {
+    return projects;
+  }
+  const allowedProjectIds = getEffectiveAllowedProjectIds();
+  if (allowedProjectIds.length === 0) {
+    return projects;
+  }
+  return projects.filter(
+    project =>
+      allowedProjectIds.includes(String(project.id)) ||
+      allowedProjectIds.includes(project.path_with_namespace)
+  );
+}
+
+/**
  * Get fetch configuration with proper client from pool
  * Uses connection pooling when dynamic API URLs are enabled
  */
@@ -2266,9 +2299,11 @@ async function listIssues(
   options: Omit<z.infer<typeof ListIssuesSchema>, "project_id"> = {}
 ): Promise<GitLabIssue[]> {
   let url: URL;
-  if (projectId) {
-    projectId = decodeURIComponent(projectId); // Decode project ID
-    const effectiveProjectId = getEffectiveProjectId(projectId);
+  if (projectId || (ENABLE_STRICT_PROJECT_SCOPE && getEffectiveAllowedProjectIds().length > 0)) {
+    // In strict scope, never fall back to the instance-wide endpoint;
+    // resolve the default project (or fail for a multi-project allowlist)
+    const decodedProjectId = projectId ? decodeURIComponent(projectId) : "";
+    const effectiveProjectId = getEffectiveProjectId(decodedProjectId);
     url = new URL(
       `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}/issues`
     );
@@ -2376,11 +2411,21 @@ async function listMergeRequests(
   projectId?: string,
   options: Omit<z.infer<typeof ListMergeRequestsSchema>, "project_id"> = {}
 ): Promise<GitLabMergeRequest[]> {
-  const decodedProjectId = projectId ? decodeURIComponent(projectId) : undefined;
-  const endpoint = decodedProjectId
-    ? `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(decodedProjectId))}/merge_requests`
-    : `${getEffectiveApiUrl()}/merge_requests`;
-  const url = new URL(endpoint);
+  const decodedProjectId = projectId ? decodeURIComponent(projectId) : "";
+  let url: URL;
+  if (
+    decodedProjectId ||
+    (ENABLE_STRICT_PROJECT_SCOPE && getEffectiveAllowedProjectIds().length > 0)
+  ) {
+    // In strict scope, never fall back to the instance-wide endpoint;
+    // resolve the default project (or fail for a multi-project allowlist)
+    const effectiveProjectId = getEffectiveProjectId(decodedProjectId);
+    url = new URL(
+      `${getEffectiveApiUrl()}/projects/${encodeURIComponent(effectiveProjectId)}/merge_requests`
+    );
+  } else {
+    url = new URL(`${getEffectiveApiUrl()}/merge_requests`);
+  }
 
   appendMergeRequestFilters(url, options);
 
@@ -5139,16 +5184,24 @@ async function searchProjects(
     throw new Error(`GitLab API error: ${response.status} ${response.statusText}\n${errorBody}`);
   }
 
-  const projects = (await response.json()) as GitLabRepository[];
+  const unfiltered = (await response.json()) as GitLabRepository[];
+  const projects = filterProjectsByAllowlist(unfiltered);
   const totalCount = response.headers.get("x-total");
   const totalPages = response.headers.get("x-total-pages");
 
   // GitLab API doesn't return these headers for results > 10,000
-  const count = totalCount ? Number.parseInt(totalCount, 10) : projects.length;
+  // Header counts are meaningless once the allowlist filter dropped results
+  const count =
+    projects.length === unfiltered.length && totalCount
+      ? Number.parseInt(totalCount, 10)
+      : projects.length;
 
   return GitLabSearchResponseSchema.parse({
     count,
-    total_pages: totalPages ? Number.parseInt(totalPages, 10) : Math.ceil(count / perPage),
+    total_pages:
+      projects.length === unfiltered.length && totalPages
+        ? Number.parseInt(totalPages, 10)
+        : Math.ceil(count / perPage),
     current_page: page,
     items: projects,
   });
@@ -6669,7 +6722,7 @@ async function listProjects(
 
   // Parse and return the data
   const data = await response.json();
-  return z.array(GitLabProjectSchema).parse(data);
+  return filterProjectsByAllowlist(z.array(GitLabProjectSchema).parse(data));
 }
 
 /**
@@ -6887,7 +6940,7 @@ async function listGroupProjects(
 
   await handleGitLabError(response);
   const projects = await response.json();
-  return GitLabProjectSchema.array().parse(projects);
+  return filterProjectsByAllowlist(GitLabProjectSchema.array().parse(projects));
 }
 
 // Webhook API helper functions
@@ -6900,6 +6953,7 @@ function buildWebhookBaseUrl(projectId?: string, groupId?: string): string {
     projectId = decodeURIComponent(projectId);
     return `${getEffectiveApiUrl()}/projects/${encodeURIComponent(getEffectiveProjectId(projectId))}/hooks`;
   }
+  rejectIfStrictProjectScope("group webhooks");
   const decodedGroupId = decodeURIComponent(groupId!);
   return `${getEffectiveApiUrl()}/groups/${encodeURIComponent(decodedGroupId)}/hooks`;
 }
@@ -10674,6 +10728,7 @@ async function handleToolCall(params: any) {
       }
 
       case "search_code": {
+        rejectIfStrictProjectScope("search_code");
         const args = SearchCodeSchema.parse(params.arguments);
         const results = await searchBlobs({
           search: args.search,
@@ -10706,6 +10761,7 @@ async function handleToolCall(params: any) {
       }
 
       case "search_group_code": {
+        rejectIfStrictProjectScope("search_group_code");
         const args = SearchGroupCodeSchema.parse(params.arguments);
         const results = await searchBlobs({
           search: args.search,
@@ -11091,6 +11147,7 @@ async function handleToolCall(params: any) {
       }
 
       case "list_todos": {
+        rejectIfStrictProjectScope("list_todos");
         const args = ListTodosSchema.parse(params.arguments);
         const todos = await listTodos(args);
         return {
@@ -11099,6 +11156,7 @@ async function handleToolCall(params: any) {
       }
 
       case "mark_todo_done": {
+        rejectIfStrictProjectScope("mark_todo_done");
         const args = MarkTodoDoneSchema.parse(params.arguments);
         const todo = await markTodoDone(args.id);
         return {
@@ -11107,6 +11165,7 @@ async function handleToolCall(params: any) {
       }
 
       case "mark_all_todos_done": {
+        rejectIfStrictProjectScope("mark_all_todos_done");
         MarkAllTodosDoneSchema.parse(params.arguments);
         await markAllTodosDone();
         return {
@@ -11468,6 +11527,7 @@ async function handleToolCall(params: any) {
       }
 
       case "list_group_members": {
+        rejectIfStrictProjectScope("list_group_members");
         const args = ListGroupMembersSchema.parse(params.arguments);
         const { group_id, ...options } = args;
         const members = await listGroupMembers(group_id, options);
@@ -12142,6 +12202,7 @@ async function handleToolCall(params: any) {
       }
 
       case "list_group_wiki_pages": {
+        rejectIfStrictProjectScope("list_group_wiki_pages");
         const { group_id, page, per_page, with_content, render_html } =
           ListGroupWikiPagesSchema.parse(params.arguments);
         const wikiPages = await listGroupWikiPages(group_id, {
@@ -12156,6 +12217,7 @@ async function handleToolCall(params: any) {
       }
 
       case "get_group_wiki_page": {
+        rejectIfStrictProjectScope("get_group_wiki_page");
         const { group_id, slug, render_html } = GetGroupWikiPageSchema.parse(params.arguments);
         const wikiPage = await getGroupWikiPage(group_id, slug, render_html);
         return {
@@ -12164,6 +12226,7 @@ async function handleToolCall(params: any) {
       }
 
       case "create_group_wiki_page": {
+        rejectIfStrictProjectScope("create_group_wiki_page");
         const { group_id, title, content, format } = CreateGroupWikiPageSchema.parse(
           params.arguments
         );
@@ -12174,6 +12237,7 @@ async function handleToolCall(params: any) {
       }
 
       case "update_group_wiki_page": {
+        rejectIfStrictProjectScope("update_group_wiki_page");
         const { group_id, slug, title, content, format } = UpdateGroupWikiPageSchema.parse(
           params.arguments
         );
@@ -12184,6 +12248,7 @@ async function handleToolCall(params: any) {
       }
 
       case "delete_group_wiki_page": {
+        rejectIfStrictProjectScope("delete_group_wiki_page");
         const { group_id, slug } = DeleteGroupWikiPageSchema.parse(params.arguments);
         await deleteGroupWikiPage(group_id, slug);
         return {
@@ -12799,6 +12864,7 @@ async function handleToolCall(params: any) {
       }
 
       case "list_group_merge_requests": {
+        rejectIfStrictProjectScope("list_group_merge_requests");
         const { group_id, ...options } = ListGroupMergeRequestsSchema.parse(params.arguments);
         const cleanedOptions = cleanMutuallyExclusiveIdUsernameOptions(
           options,
@@ -12944,6 +13010,7 @@ async function handleToolCall(params: any) {
       }
 
       case "list_group_milestones": {
+        rejectIfStrictProjectScope("list_group_milestones");
         const { group_id, ...options } = ListGroupMilestonesSchema.parse(params.arguments);
         const milestones = await listGroupMilestones(group_id, options);
         return {
@@ -12957,6 +13024,7 @@ async function handleToolCall(params: any) {
       }
 
       case "get_group_milestone": {
+        rejectIfStrictProjectScope("get_group_milestone");
         const { group_id, milestone_id } = GetGroupMilestoneSchema.parse(params.arguments);
         const milestone = await getGroupMilestone(group_id, milestone_id);
         return {
@@ -12970,6 +13038,7 @@ async function handleToolCall(params: any) {
       }
 
       case "create_group_milestone": {
+        rejectIfStrictProjectScope("create_group_milestone");
         const { group_id, ...options } = CreateGroupMilestoneSchema.parse(params.arguments);
         const milestone = await createGroupMilestone(group_id, options);
         return {
@@ -12983,6 +13052,7 @@ async function handleToolCall(params: any) {
       }
 
       case "edit_group_milestone": {
+        rejectIfStrictProjectScope("edit_group_milestone");
         const { group_id, milestone_id, ...options } = EditGroupMilestoneSchema.parse(
           params.arguments
         );
@@ -12998,6 +13068,7 @@ async function handleToolCall(params: any) {
       }
 
       case "delete_group_milestone": {
+        rejectIfStrictProjectScope("delete_group_milestone");
         const { group_id, milestone_id } = DeleteGroupMilestoneSchema.parse(params.arguments);
         await deleteGroupMilestone(group_id, milestone_id);
         return {
@@ -13018,6 +13089,7 @@ async function handleToolCall(params: any) {
       }
 
       case "get_group_milestone_issue": {
+        rejectIfStrictProjectScope("get_group_milestone_issue");
         const { group_id, milestone_id, ...options } = GetGroupMilestoneIssuesSchema.parse(
           params.arguments
         );
@@ -13033,6 +13105,7 @@ async function handleToolCall(params: any) {
       }
 
       case "get_group_milestone_merge_requests": {
+        rejectIfStrictProjectScope("get_group_milestone_merge_requests");
         const { group_id, milestone_id, ...options } = GetGroupMilestoneMergeRequestsSchema.parse(
           params.arguments
         );
@@ -13052,6 +13125,7 @@ async function handleToolCall(params: any) {
       }
 
       case "get_group_milestone_burndown_events": {
+        rejectIfStrictProjectScope("get_group_milestone_burndown_events");
         const { group_id, milestone_id, ...options } =
           GetGroupMilestoneBurndownEventsSchema.parse(params.arguments);
         const events = await getGroupMilestoneBurndownEvents(group_id, milestone_id, options);
@@ -13117,6 +13191,7 @@ async function handleToolCall(params: any) {
       }
 
       case "list_group_iterations": {
+        rejectIfStrictProjectScope("list_group_iterations");
         const args = ListGroupIterationsSchema.parse(params.arguments);
         const iterations = await listGroupIterations(args.group_id, args);
         return {
@@ -13367,6 +13442,7 @@ async function handleToolCall(params: any) {
       }
 
       case "list_events": {
+        rejectIfStrictProjectScope("list_events");
         const args = ListEventsSchema.parse(params.arguments);
         const events = await listEvents(args);
         return {

--- a/index.ts
+++ b/index.ts
@@ -5189,20 +5189,17 @@ async function searchProjects(
   const projects = filterProjectsByAllowlist(unfiltered);
   const totalCount = response.headers.get("x-total");
   const totalPages = response.headers.get("x-total-pages");
+  const nextPage = response.headers.get("x-next-page");
 
-  // GitLab API doesn't return these headers for results > 10,000
-  // Header counts are meaningless once the allowlist filter dropped results
-  const count =
-    projects.length === unfiltered.length && totalCount
-      ? Number.parseInt(totalCount, 10)
-      : projects.length;
+  // GitLab API doesn't return the total headers for results > 10,000
+  // Keep the unfiltered totals so callers paginate past pages the allowlist filter thinned out;
+  // without them, total_pages stays unset and next_page carries the continuation signal
+  const count = totalCount ? Number.parseInt(totalCount, 10) : projects.length;
 
   return GitLabSearchResponseSchema.parse({
     count,
-    total_pages:
-      projects.length === unfiltered.length && totalPages
-        ? Number.parseInt(totalPages, 10)
-        : Math.ceil(count / perPage),
+    total_pages: totalPages ? Number.parseInt(totalPages, 10) : undefined,
+    next_page: nextPage ? Number.parseInt(nextPage, 10) : undefined,
     current_page: page,
     items: projects,
   });

--- a/index.ts
+++ b/index.ts
@@ -14165,7 +14165,7 @@ async function startStreamableHTTPServer(): Promise<void> {
     let allowedProjectIds: string[] | undefined;
 
     // Only process the requested project scope if the feature is enabled
-    if (ENABLE_DYNAMIC_PROJECT_SCOPE && requestedProjectScope) {
+    if (ENABLE_DYNAMIC_PROJECT_SCOPE && requestedProjectScope !== undefined) {
       const requested = requestedProjectScope
         .split(",")
         .map(id => id.trim())

--- a/schemas.ts
+++ b/schemas.ts
@@ -1353,6 +1353,7 @@ export const GitLabCreateUpdateFileResponseSchema = z.object({
 export const GitLabSearchResponseSchema = z.object({
   count: z.coerce.number().optional(),
   total_pages: z.coerce.number().optional(),
+  next_page: z.coerce.number().optional(),
   current_page: z.coerce.number().optional(),
   items: z.array(GitLabRepositorySchema),
 });

--- a/stateless/session-id.ts
+++ b/stateless/session-id.ts
@@ -40,12 +40,15 @@ export interface SessionIdPayload extends StatelessBasePayload {
   t: string;
   /** Effective GitLab API URL for this session (supports dynamic routing). */
   u: string;
+  /** Project allowlist narrowed for this session, if any (dynamic project scope). */
+  p?: string[];
 }
 
 export interface MintSessionIdInput {
   header: SessionAuthHeader;
   token: string;
   apiUrl: string;
+  allowedProjectIds?: string[];
   now?: () => number;
 }
 
@@ -64,6 +67,9 @@ export function mintSessionId(
     h: input.header,
     t: input.token,
     u: input.apiUrl,
+    ...(input.allowedProjectIds && input.allowedProjectIds.length > 0
+      ? { p: input.allowedProjectIds }
+      : {}),
   };
   return seal(material, STATELESS_PURPOSES.SESSION_ID, payload);
 }
@@ -92,7 +98,9 @@ export function openSessionId(
         payload.h !== "JOB-TOKEN") ||
       typeof payload.t !== "string" ||
       payload.t.length === 0 ||
-      typeof payload.u !== "string"
+      typeof payload.u !== "string" ||
+      (payload.p !== undefined &&
+        (!Array.isArray(payload.p) || payload.p.some(id => typeof id !== "string")))
     ) {
       return null;
     }

--- a/test/stateless/session-id.test.ts
+++ b/test/stateless/session-id.test.ts
@@ -29,6 +29,34 @@ function load(current: string, previous?: string): StatelessKeyMaterial {
 }
 
 describe("mintSessionId / openSessionId", () => {
+  test("seals and restores a narrowed project scope", () => {
+    const s = secret();
+    const a = load(s);
+    const b = load(s);
+    const sid = mintSessionId(a, {
+      header: "Private-Token",
+      token: "glpat-ABCDEFG123456789-abcdef",
+      apiUrl: "https://gitlab.example.com/api/v4",
+      allowedProjectIds: ["42", "org/theorg"],
+    });
+    const opened = openSessionId(b, sid, 3600);
+    assert.ok(opened);
+    assert.deepEqual(opened!.p, ["42", "org/theorg"]);
+  });
+
+  test("omits the scope field when no scope was narrowed", () => {
+    const s = secret();
+    const m = load(s);
+    const sid = mintSessionId(m, {
+      header: "Private-Token",
+      token: "glpat-ABCDEFG123456789-abcdef",
+      apiUrl: "https://gitlab.example.com/api/v4",
+    });
+    const opened = openSessionId(m, sid, 3600);
+    assert.ok(opened);
+    assert.equal(opened!.p, undefined);
+  });
+
   test("roundtrips across pods", () => {
     const s = secret();
     const a = load(s);

--- a/test/test-dynamic-project-scope.ts
+++ b/test/test-dynamic-project-scope.ts
@@ -113,6 +113,26 @@ describe("Dynamic project scope", { concurrency: 1 }, () => {
       assert.strictEqual(connected, false, "out-of-scope header must not initialize a session");
     });
 
+    test("empty header rejects the session", async () => {
+      const client = new CustomHeaderClient({
+        authorization: `Bearer ${MOCK_TOKEN}`,
+        [SCOPE_HEADER]: "  ",
+      });
+
+      let connected = false;
+      try {
+        await client.connect(mcpUrl);
+        connected = true;
+        await client.callTool("get_project", { project_id: "1" });
+      } catch {
+        // Expected: the session is rejected before any tool call is possible.
+      } finally {
+        await client.disconnect();
+      }
+
+      assert.strictEqual(connected, false, "an empty header must not initialize a session");
+    });
+
     test("scoped session refuses non-scopable tools", async () => {
       const client = await connectClient(mcpUrl, "1");
       try {

--- a/test/test-dynamic-project-scope.ts
+++ b/test/test-dynamic-project-scope.ts
@@ -36,7 +36,7 @@ async function getProjectId(client: CustomHeaderClient, projectId: string): Prom
 describe("Dynamic project scope", { concurrency: 1 }, () => {
   describe("with GITLAB_ALLOWED_PROJECT_IDS set", () => {
     let mockGitLab: MockGitLabServer;
-    let servers: ServerInstance[] = [];
+    const servers: ServerInstance[] = [];
     let mcpUrl: string;
 
     before(async () => {
@@ -220,7 +220,7 @@ describe("Dynamic project scope", { concurrency: 1 }, () => {
 
   describe("without GITLAB_ALLOWED_PROJECT_IDS", () => {
     let mockGitLab: MockGitLabServer;
-    let servers: ServerInstance[] = [];
+    const servers: ServerInstance[] = [];
     let mcpUrl: string;
 
     before(async () => {
@@ -324,7 +324,7 @@ describe("Dynamic project scope", { concurrency: 1 }, () => {
 
   describe("with ENABLE_DYNAMIC_PROJECT_SCOPE disabled", () => {
     let mockGitLab: MockGitLabServer;
-    let servers: ServerInstance[] = [];
+    const servers: ServerInstance[] = [];
     let mcpUrl: string;
 
     before(async () => {

--- a/test/test-dynamic-project-scope.ts
+++ b/test/test-dynamic-project-scope.ts
@@ -42,7 +42,16 @@ describe("Dynamic project scope", { concurrency: 1 }, () => {
     before(async () => {
       const mockPort = await findMockServerPort();
       mockGitLab = new MockGitLabServer({ port: mockPort, validTokens: [MOCK_TOKEN] });
-      mockGitLab.addMockHandler("get", "/projects", (_req, res) => {
+      mockGitLab.addMockHandler("get", "/projects", (req, res) => {
+        if (req.query.search === "no-totals") {
+          const requestedPage = Number(req.query.page ?? "1");
+          if (requestedPage < 3) {
+            res.set("x-next-page", String(requestedPage + 1));
+          }
+        } else {
+          res.set("x-total", "3");
+          res.set("x-total-pages", "2");
+        }
         res.json(
           ["1", "2", "3"].map(id => ({
             id: Number(id),
@@ -178,6 +187,62 @@ describe("Dynamic project scope", { concurrency: 1 }, () => {
           () => client.callTool("list_todos", {}),
           /not allowed while a project allowlist is in effect/
         );
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("search_repositories keeps the unfiltered pagination totals", async () => {
+      const client = await connectClient(mcpUrl, "1");
+      try {
+        const result = await client.callTool("search_repositories", { search: "project" });
+        assert.ok(result.content, "Should have content");
+        const content = result.content[0];
+        assert.ok("text" in content, "Content should have text");
+        const search = JSON.parse(content.text as string) as {
+          count: number;
+          total_pages: number;
+          items: { id: string }[];
+        };
+        assert.deepStrictEqual(
+          search.items.map(item => item.id),
+          ["1"]
+        );
+        assert.strictEqual(search.count, 3, "count must reflect the unfiltered GitLab total");
+        assert.strictEqual(search.total_pages, 2, "total_pages must cover the unfiltered pages");
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("search_repositories follows next_page across all pages when totals are missing", async () => {
+      const client = await connectClient(mcpUrl, "1");
+      try {
+        let page: number | undefined = 1;
+        const visited: number[] = [];
+        while (page !== undefined) {
+          const result = await client.callTool("search_repositories", {
+            search: "no-totals",
+            page,
+          });
+          assert.ok(result.content, "Should have content");
+          const content = result.content[0];
+          assert.ok("text" in content, "Content should have text");
+          const search = JSON.parse(content.text as string) as {
+            total_pages?: number;
+            next_page?: number;
+            current_page: number;
+            items: { id: string }[];
+          };
+          assert.strictEqual(search.total_pages, undefined, "total_pages must stay unset");
+          assert.deepStrictEqual(
+            search.items.map(item => item.id),
+            ["1"]
+          );
+          visited.push(search.current_page);
+          page = search.next_page;
+        }
+        assert.deepStrictEqual(visited, [1, 2, 3], "next_page must make every page reachable");
       } finally {
         await client.disconnect();
       }

--- a/test/test-dynamic-project-scope.ts
+++ b/test/test-dynamic-project-scope.ts
@@ -42,6 +42,19 @@ describe("Dynamic project scope", { concurrency: 1 }, () => {
     before(async () => {
       const mockPort = await findMockServerPort();
       mockGitLab = new MockGitLabServer({ port: mockPort, validTokens: [MOCK_TOKEN] });
+      mockGitLab.addMockHandler("get", "/projects", (_req, res) => {
+        res.json(
+          ["1", "2", "3"].map(id => ({
+            id: Number(id),
+            name: `Project ${id}`,
+            path: `project-${id}`,
+            path_with_namespace: `group/project-${id}`,
+            description: null,
+            visibility: "private",
+            namespace: { id: 1, name: "Group", path: "group", kind: "group", full_path: "group" },
+          }))
+        );
+      });
       await mockGitLab.start();
 
       const mcpPort = await findAvailablePort(3200);
@@ -53,6 +66,7 @@ describe("Dynamic project scope", { concurrency: 1 }, () => {
           STREAMABLE_HTTP: "true",
           REMOTE_AUTHORIZATION: "true",
           ENABLE_DYNAMIC_PROJECT_SCOPE: "true",
+          ENABLE_STRICT_PROJECT_SCOPE: "true",
           GITLAB_API_URL: `${mockGitLab.getUrl()}/api/v4`,
           GITLAB_ALLOWED_PROJECT_IDS: "1,2",
         },
@@ -115,6 +129,69 @@ describe("Dynamic project scope", { concurrency: 1 }, () => {
       const client = await connectClient(mcpUrl);
       try {
         assert.strictEqual(await getProjectId(client, "2"), "2");
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("list_issues without project_id stays within the session scope", async () => {
+      const client = await connectClient(mcpUrl, "1");
+      try {
+        const result = await client.callTool("list_issues", {});
+        assert.ok(result.content, "Should have content");
+        const content = result.content[0];
+        assert.ok("text" in content, "Content should have text");
+        const issues = JSON.parse(content.text as string) as { web_url: string }[];
+        assert.ok(
+          issues.every(issue => issue.web_url.includes("/project/1/")),
+          "Should only return issues of the scoped project"
+        );
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("list_todos is refused under strict scope", async () => {
+      const client = await connectClient(mcpUrl, "1");
+      try {
+        await assert.rejects(
+          () => client.callTool("list_todos", {}),
+          /not allowed while a project allowlist is in effect/
+        );
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("list_projects is filtered to the session scope", async () => {
+      const client = await connectClient(mcpUrl, "1");
+      try {
+        const result = await client.callTool("list_projects", {});
+        assert.ok(result.content, "Should have content");
+        const content = result.content[0];
+        assert.ok("text" in content, "Content should have text");
+        const projects = JSON.parse(content.text as string) as { id: string }[];
+        assert.deepStrictEqual(
+          projects.map(project => project.id),
+          ["1"]
+        );
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("list_projects is filtered to the env allowlist without the header", async () => {
+      const client = await connectClient(mcpUrl);
+      try {
+        const result = await client.callTool("list_projects", {});
+        assert.ok(result.content, "Should have content");
+        const content = result.content[0];
+        assert.ok("text" in content, "Content should have text");
+        const projects = JSON.parse(content.text as string) as { id: string }[];
+        assert.deepStrictEqual(
+          projects.map(project => project.id),
+          ["1", "2"]
+        );
       } finally {
         await client.disconnect();
       }

--- a/test/test-dynamic-project-scope.ts
+++ b/test/test-dynamic-project-scope.ts
@@ -1,0 +1,267 @@
+import { describe, test, before, after } from "node:test";
+import assert from "node:assert";
+import {
+  cleanupServers,
+  findAvailablePort,
+  HOST,
+  launchServer,
+  ServerInstance,
+  TransportMode,
+} from "./utils/server-launcher.js";
+import { MockGitLabServer, findMockServerPort } from "./utils/mock-gitlab-server.js";
+import { CustomHeaderClient } from "./clients/custom-header-client.js";
+
+const MOCK_TOKEN = "glpat-dynamic-scope-token";
+const SCOPE_HEADER = "x-gitlab-allowed-project-ids";
+
+async function connectClient(mcpUrl: string, scope?: string): Promise<CustomHeaderClient> {
+  const headers: Record<string, string> = { authorization: `Bearer ${MOCK_TOKEN}` };
+  if (scope !== undefined) {
+    headers[SCOPE_HEADER] = scope;
+  }
+  const client = new CustomHeaderClient(headers);
+  await client.connect(mcpUrl);
+  return client;
+}
+
+async function getProjectId(client: CustomHeaderClient, projectId: string): Promise<string> {
+  const result = await client.callTool("get_project", { project_id: projectId });
+  assert.ok(result.content, "Should have content");
+  const content = result.content[0];
+  assert.ok("text" in content, "Content should have text");
+  const project = JSON.parse(content.text as string);
+  return project.id.toString();
+}
+
+describe("Dynamic project scope", { concurrency: 1 }, () => {
+  describe("with GITLAB_ALLOWED_PROJECT_IDS set", () => {
+    let mockGitLab: MockGitLabServer;
+    let servers: ServerInstance[] = [];
+    let mcpUrl: string;
+
+    before(async () => {
+      const mockPort = await findMockServerPort();
+      mockGitLab = new MockGitLabServer({ port: mockPort, validTokens: [MOCK_TOKEN] });
+      await mockGitLab.start();
+
+      const mcpPort = await findAvailablePort(3200);
+      const server = await launchServer({
+        mode: TransportMode.STREAMABLE_HTTP,
+        port: mcpPort,
+        timeout: 5000,
+        env: {
+          STREAMABLE_HTTP: "true",
+          REMOTE_AUTHORIZATION: "true",
+          ENABLE_DYNAMIC_PROJECT_SCOPE: "true",
+          GITLAB_API_URL: `${mockGitLab.getUrl()}/api/v4`,
+          GITLAB_ALLOWED_PROJECT_IDS: "1,2",
+        },
+      });
+      servers.push(server);
+      mcpUrl = `http://${HOST}:${mcpPort}/mcp`;
+    });
+
+    after(async () => {
+      cleanupServers(servers);
+      await mockGitLab?.stop();
+    });
+
+    test("header narrows the allowlist to the requested projects", async () => {
+      const client = await connectClient(mcpUrl, "1");
+      try {
+        assert.strictEqual(await getProjectId(client, ""), "1");
+        await assert.rejects(
+          () => client.callTool("get_project", { project_id: "2" }),
+          /Access denied/
+        );
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("project outside GITLAB_ALLOWED_PROJECT_IDS rejects the session", async () => {
+      const client = new CustomHeaderClient({
+        authorization: `Bearer ${MOCK_TOKEN}`,
+        [SCOPE_HEADER]: "1,3",
+      });
+
+      let connected = false;
+      try {
+        await client.connect(mcpUrl);
+        connected = true;
+        await client.callTool("get_project", { project_id: "1" });
+      } catch {
+        // Expected: the session is rejected before any tool call is possible.
+      } finally {
+        await client.disconnect();
+      }
+
+      assert.strictEqual(connected, false, "out-of-scope header must not initialize a session");
+    });
+
+    test("scoped session refuses non-scopable tools", async () => {
+      const client = await connectClient(mcpUrl, "1");
+      try {
+        await assert.rejects(
+          () => client.callTool("execute_graphql", { query: "query { currentUser { id } }" }),
+          /not allowed while a project allowlist is in effect/
+        );
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("session without the header keeps the full env allowlist", async () => {
+      const client = await connectClient(mcpUrl);
+      try {
+        assert.strictEqual(await getProjectId(client, "2"), "2");
+      } finally {
+        await client.disconnect();
+      }
+    });
+  });
+
+  describe("without GITLAB_ALLOWED_PROJECT_IDS", () => {
+    let mockGitLab: MockGitLabServer;
+    let servers: ServerInstance[] = [];
+    let mcpUrl: string;
+
+    before(async () => {
+      const mockPort = await findMockServerPort();
+      mockGitLab = new MockGitLabServer({ port: mockPort, validTokens: [MOCK_TOKEN] });
+      mockGitLab.addRootHandler("post", "/api/graphql", (req, res) => {
+        const { query } = req.body as { query: string };
+        if (query.includes("vulnerability(")) {
+          res.json({
+            data: {
+              vulnerability: {
+                id: "gid://gitlab/Vulnerability/42",
+                title: "Mock vulnerability",
+                project: {
+                  id: "gid://gitlab/Project/8",
+                  name: "Other project",
+                  fullPath: "other/project",
+                },
+              },
+            },
+          });
+          return;
+        }
+        res.status(500).json({ message: `Unexpected GraphQL query: ${query}` });
+      });
+      await mockGitLab.start();
+
+      const mcpPort = await findAvailablePort(3200);
+      const server = await launchServer({
+        mode: TransportMode.STREAMABLE_HTTP,
+        port: mcpPort,
+        timeout: 5000,
+        env: {
+          STREAMABLE_HTTP: "true",
+          REMOTE_AUTHORIZATION: "true",
+          ENABLE_DYNAMIC_PROJECT_SCOPE: "true",
+          GITLAB_API_URL: `${mockGitLab.getUrl()}/api/v4`,
+        },
+      });
+      servers.push(server);
+      mcpUrl = `http://${HOST}:${mcpPort}/mcp`;
+    });
+
+    after(async () => {
+      cleanupServers(servers);
+      await mockGitLab?.stop();
+    });
+
+    test("header bounds an otherwise unrestricted server", async () => {
+      const client = await connectClient(mcpUrl, "7");
+      try {
+        assert.strictEqual(await getProjectId(client, ""), "7");
+        await assert.rejects(
+          () => client.callTool("get_project", { project_id: "8" }),
+          /Access denied/
+        );
+        await assert.rejects(
+          () => client.callTool("execute_graphql", { query: "query { currentUser { id } }" }),
+          /not allowed while a project allowlist is in effect/
+        );
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("session without the header stays unrestricted", async () => {
+      const client = await connectClient(mcpUrl);
+      try {
+        assert.strictEqual(await getProjectId(client, "8"), "8");
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("scoped session cannot reach vulnerabilities of other projects", async () => {
+      const client = await connectClient(mcpUrl, "7");
+      try {
+        await assert.rejects(
+          () => client.callTool("get_vulnerability", { vulnerability_id: "42" }),
+          /Access denied/
+        );
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    test("unscoped session can reach vulnerabilities", async () => {
+      const client = await connectClient(mcpUrl);
+      try {
+        const result = await client.callTool("get_vulnerability", { vulnerability_id: "42" });
+        assert.ok(result.content, "Should have content");
+        const content = result.content[0];
+        assert.ok("text" in content, "Content should have text");
+        const vulnerability = JSON.parse(content.text as string);
+        assert.strictEqual(vulnerability.project.fullPath, "other/project");
+      } finally {
+        await client.disconnect();
+      }
+    });
+  });
+
+  describe("with ENABLE_DYNAMIC_PROJECT_SCOPE disabled", () => {
+    let mockGitLab: MockGitLabServer;
+    let servers: ServerInstance[] = [];
+    let mcpUrl: string;
+
+    before(async () => {
+      const mockPort = await findMockServerPort();
+      mockGitLab = new MockGitLabServer({ port: mockPort, validTokens: [MOCK_TOKEN] });
+      await mockGitLab.start();
+
+      const mcpPort = await findAvailablePort(3200);
+      const server = await launchServer({
+        mode: TransportMode.STREAMABLE_HTTP,
+        port: mcpPort,
+        timeout: 5000,
+        env: {
+          STREAMABLE_HTTP: "true",
+          REMOTE_AUTHORIZATION: "true",
+          GITLAB_API_URL: `${mockGitLab.getUrl()}/api/v4`,
+        },
+      });
+      servers.push(server);
+      mcpUrl = `http://${HOST}:${mcpPort}/mcp`;
+    });
+
+    after(async () => {
+      cleanupServers(servers);
+      await mockGitLab?.stop();
+    });
+
+    test("header is ignored when the feature flag is off", async () => {
+      const client = await connectClient(mcpUrl, "1");
+      try {
+        assert.strictEqual(await getProjectId(client, "2"), "2");
+      } finally {
+        await client.disconnect();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds two opt-in flags for multi-tenant deployments.

`ENABLE_DYNAMIC_PROJECT_SCOPE` (needs `REMOTE_AUTHORIZATION=true`): a client can send an `X-GitLab-Allowed-Project-Ids` header to restrict its own session to a subset of projects. My use case is a chat bot talking to one gitlab-mcp instance where each room maps to a different project; without this I'd have to run a container per room. The header can only restrict further, never widen: if `GITLAB_ALLOWED_PROJECT_IDS` is set and the header names anything outside it, the request gets a 401.

`ENABLE_STRICT_PROJECT_SCOPE`: closes the discovery gaps an allowlist leaves open. Today the allowlist only guards tools that take a project_id, listings and searches still return everything the token can see. With this flag, project listings and `search_repositories` are filtered to the allowlist, `list_issues`/`list_merge_requests` without a project_id resolve to the allowed project instead of the instance-wide endpoint, and tools that can't be limited to allowed projects (instance-wide code search, todos, the group tools) are refused.

Both flags off: nothing changes. Tests and docs included, test suite passes.

One thing to note is that I reworded two error messages from "when GITLAB_ALLOWED_PROJECT_IDS is set" to "while a project allowlist is in effect (GITLAB_ALLOWED_PROJECT_IDS or a session scope)" because the allowlist can now come from the session.
