### PR TITLE
Package gitlab-mcp for Nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# Loads the Nix devShell from flake.nix (requires direnv + nix-direnv).
+# Run `direnv allow` once after cloning.
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ docs/plans/
 site/
 .venv-docs/
 .direnv/
+
+# nix build output
+result
+result-*

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs/plans/
 # MkDocs build artifacts
 site/
 .venv-docs/
+.direnv/

--- a/README.ko.md
+++ b/README.ko.md
@@ -96,6 +96,18 @@ npm으로 설치할 수도 있습니다:
 npm install -g @zereight/mcp-gitlab
 ```
 
+또는 Nix를 사용해 이 플레이크를 자신의 플레이크에 추가할 수 있습니다:
+
+```nix
+# flake.nix
+inputs.gitlab-mcp.url = "github:zereight/gitlab-mcp";
+
+# wherever you configure your MCP client:
+command = lib.getExe inputs.gitlab-mcp.packages.${system}.default;
+```
+
+스토어 경로는 lock 파일에 고정되며, `nix flake update gitlab-mcp`로 업데이트합니다.
+
 예시는 기존 `mcp-gitlab`보다 충돌 가능성이 낮은 `zereight-mcp-gitlab` 별칭을 사용합니다. MCP 클라이언트가 찾지 못하면 `which zereight-mcp-gitlab`의 절대 경로를 사용하세요.
 
 전역 설치를 쓰지 않으려면 `npx -y @zereight/mcp-gitlab@2.1.56`처럼 직전 안정 버전(문서가 권장하는 버전)으로 고정하세요. 항상 최신 버전을 원하면 `npx -y @zereight/mcp-gitlab@latest`를 사용하세요. 새 버전이 나오면 서버가 시작 시 stderr로 알려줍니다(`GITLAB_DISABLE_VERSION_CHECK=true`로 비활성화 가능).

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ Or with npm:
 npm install -g @zereight/mcp-gitlab
 ```
 
+Or with Nix, by adding this flake to your own:
+
+```nix
+# flake.nix
+inputs.gitlab-mcp.url = "github:zereight/gitlab-mcp";
+
+# wherever you configure your MCP client:
+command = lib.getExe inputs.gitlab-mcp.packages.${system}.default;
+```
+
+The store path is pinned by your lock file; update it with `nix flake update gitlab-mcp`.
+
 The examples use `zereight-mcp-gitlab`, a less collision-prone alias for the legacy `mcp-gitlab` binary. If your MCP client cannot find it, use the absolute path from `which zereight-mcp-gitlab`.
 
 No global install? Pin `npx` to the previous stable release (the version these docs recommend), for example `npx -y @zereight/mcp-gitlab@2.1.56`. If you always want the newest release, use `npx -y @zereight/mcp-gitlab@latest` instead. The server prints a notice to stderr on startup when a newer version is available (disable with `GITLAB_DISABLE_VERSION_CHECK=true`).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,6 +96,18 @@ brew install zereight/gitlab-mcp/zereight-mcp-gitlab
 npm install -g @zereight/mcp-gitlab
 ```
 
+也可以使用 Nix，把此 flake 添加到你自己的 flake 中：
+
+```nix
+# flake.nix
+inputs.gitlab-mcp.url = "github:zereight/gitlab-mcp";
+
+# wherever you configure your MCP client:
+command = lib.getExe inputs.gitlab-mcp.packages.${system}.default;
+```
+
+存储路径由你的 lock 文件固定，使用 `nix flake update gitlab-mcp` 更新。
+
 示例使用 `zereight-mcp-gitlab`，这是比旧的 `mcp-gitlab` 更不容易冲突的别名。如果 MCP 客户端找不到它，请使用 `which zereight-mcp-gitlab` 输出的绝对路径。
 
 如果不想全局安装，请将 `npx` 固定到上一个稳定版本（即文档推荐的版本），例如 `npx -y @zereight/mcp-gitlab@2.1.56`。如果始终想使用最新版本，请改用 `npx -y @zereight/mcp-gitlab@latest`。有新版本发布时，服务器会在启动时通过 stderr 提示（可用 `GITLAB_DISABLE_VERSION_CHECK=true` 关闭）。

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788316716,
+        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,18 +5,41 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
+  outputs = {nixpkgs, ...}: let
     systems = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+    packageJson = builtins.fromJSON (builtins.readFile ./package.json);
   in {
+    packages = forAllSystems (pkgs: rec {
+      default = gitlab-mcp;
+
+      gitlab-mcp = pkgs.buildNpmPackage {
+        pname = "gitlab-mcp";
+        version = packageJson.version;
+
+        src = ./.;
+
+        nodejs = pkgs.nodejs_22;
+
+        # Bump with `lib.fakeHash` -> build -> copy the reported hash whenever
+        # package-lock.json changes.
+        npmDepsHash = "sha256-3BG3sDzNtn7HfL20b8ZrAkQSV9/dQtYXIGySaWZ0ZDE=";
+
+        meta = {
+          description = packageJson.description;
+          homepage = "https://github.com/zereight/gitlab-mcp";
+          license = pkgs.lib.licenses.mit;
+          mainProgram = "zereight-mcp-gitlab";
+          platforms = systems;
+        };
+      };
+    });
+
     devShells = forAllSystems (pkgs: {
       default = pkgs.mkShell {
         name = "gitlab-mcp";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "GitLab MCP server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+  in {
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        name = "gitlab-mcp";
+
+        packages = [
+          pkgs.nodejs_22
+
+          # Docs site: `make serve` builds a venv from requirements-docs.txt (CI uses 3.12).
+          pkgs.python312
+
+          pkgs.git
+          pkgs.jq
+          pkgs.gh
+        ];
+
+        shellHook = ''
+          export PATH="$PWD/node_modules/.bin:$PATH"
+        '';
+      };
+    });
+  };
+}


### PR DESCRIPTION
Hello, a coworker recommended your MCP. Project seems great. I use NixOS and home-manager to configure claude code. This PR adds a flake.nix file that defines how gitlab-mcp is built. This means, it can be imported in a flake directly and kept up-to-date to this upstream. Happy to answer any questions that might arise