### PR TITLE
feat: add GitLab Orbit toolset

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -17,7 +17,7 @@ directly from `TOOLSET_DEFINITIONS` in
 | Status | Groups |
 |---|---|
 | **Default** — always exposed | [Projects & Namespaces](projects.md), [Projects & Files](repositories.md), [Branches & Commits](branches.md), [Groups](groups.md), [Merge Requests](merge-requests.md), [Issues](issues.md), [Labels](labels.md), [CI Lint](ci.md), [Users & Events](users.md) |
-| **Opt-in** — must be enabled | [Work Items](workitems.md), [Pipelines, Jobs & Deployments](pipelines.md) (also `USE_PIPELINE=true`), [Milestones](milestones.md) (also `USE_MILESTONE=true`), [Wiki](wiki.md) (also `USE_GITLAB_WIKI=true`), [Releases](releases.md), [Tags](tags.md), [Variables](variables.md), [Webhooks](webhooks.md), [Search](search.md), [Dependency Proxy](dependency-proxy.md), [Vulnerabilities](vulnerabilities.md), [Meta & GraphQL](meta.md) |
+| **Opt-in** — must be enabled | [Work Items](workitems.md), [Pipelines, Jobs & Deployments](pipelines.md) (also `USE_PIPELINE=true`), [Milestones](milestones.md) (also `USE_MILESTONE=true`), [Wiki](wiki.md) (also `USE_GITLAB_WIKI=true`), [Releases](releases.md), [Tags](tags.md), [Variables](variables.md), [Webhooks](webhooks.md), [Search](search.md), [Dependency Proxy](dependency-proxy.md), [Vulnerabilities](vulnerabilities.md), [GitLab Orbit](orbit.md), [Meta & GraphQL](meta.md) |
 
 **How to enable opt-in groups** (any one is sufficient):
 
@@ -467,6 +467,19 @@ AI-assisted vulnerability triage — list findings, inspect details, dismiss wit
 | [`dismiss_vulnerability`](vulnerabilities.md#dismiss_vulnerability) | Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, mitigating_control, not_applicable) and optional comment. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | ✏️ |
 | [`confirm_vulnerability`](vulnerabilities.md#confirm_vulnerability) | Confirm a vulnerability as a real finding requiring remediation. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented. | ✏️ |
 
+### [GitLab Orbit](orbit.md)
+
+Query the Orbit SDLC knowledge graph (Beta; Premium/Ultimate). Graph queries consume GitLab credits; schema, status, and tool listing are free. *(4 tools)*
+
+> Opt-in. Enable via `GITLAB_TOOLSETS=orbit` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
+| Tool | What it does | R/W |
+|---|---|:-:|
+| [`orbit_query`](orbit.md#orbit_query) | Execute a GitLab Orbit graph query over the indexed SDLC knowledge graph. Use this to answer cross-project relationship questions (blast radius, file-to-MR history, dependency fans) in one call instead of chaining list/get tools; use `orbit_get_schema` first when the node/edge types are unknown. It is read-only but each call consumes GitLab credits, requires Premium/Ultimate on an Orbit-enabled scope, and returns the graph result or a query/permission error. | 📖 |
+| [`orbit_get_schema`](orbit.md#orbit_get_schema) | Fetch the current GitLab Orbit graph schema (node and edge types). Use this to learn the node and edge types available for `orbit_query` before writing a query; use `orbit_get_status` when the concern is index freshness rather than shape. It is read-only and free of credit charges, and returns the current graph schema or a permission error. | 📖 |
+| [`orbit_get_status`](orbit.md#orbit_get_status) | Check GitLab Orbit indexing status for the enabled scope. Use this to check whether Orbit indexing has completed before trusting `orbit_query` results; results reflect the last index cycle, not real-time state. It is read-only and free of credit charges, and returns the indexing status or a permission error. | 📖 |
+| [`orbit_list_tools`](orbit.md#orbit_list_tools) | List the MCP tool definitions exposed by GitLab Orbit. Use this to see which MCP tool definitions Orbit itself exposes; use `orbit_query` to run graph queries directly. It is read-only and free of credit charges, and returns the tool definition list or a permission error. | 📖 |
+
 ### [Meta & GraphQL](meta.md)
 
 Server diagnostics, tool discovery, and the GraphQL escape hatch. *(2 tools)*
@@ -476,7 +489,7 @@ Server diagnostics, tool discovery, and the GraphQL escape hatch. *(2 tools)*
 | Tool | What it does | R/W |
 |---|---|:-:|
 | [`execute_graphql`](meta.md#execute_graphql) | Execute a GitLab GraphQL query. Use this only when a supported GitLab REST tool does not cover the requested operation; prefer a typed tool when one exists. The query is sent directly to GitLab and can include mutations when permission allows, so callers must treat it as potentially state-changing and handle GraphQL errors in the returned response. | 📖 |
-| [`discover_tools`](meta.md#discover_tools) | Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data. | 📖 |
+| [`discover_tools`](meta.md#discover_tools) | Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities, orbit. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data. | 📖 |
 
 ---
 

--- a/docs/tools/meta.md
+++ b/docs/tools/meta.md
@@ -29,7 +29,7 @@ Execute a GitLab GraphQL query. Use this only when a supported GitLab REST tool 
 
 *📖 Read-only*
 
-Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data.
+Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities, orbit. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data.
 
 **Parameters**
 

--- a/docs/tools/orbit.md
+++ b/docs/tools/orbit.md
@@ -1,0 +1,58 @@
+# GitLab Orbit
+
+Query the Orbit SDLC knowledge graph (Beta; Premium/Ultimate). Graph queries consume GitLab credits; schema, status, and tool listing are free.
+
+!!! note "Feature toggle"
+    Opt-in. Enable via `GITLAB_TOOLSETS=orbit` (or `GITLAB_TOOLSETS=all`), list individual tools in `GITLAB_TOOLS=`, or activate at runtime with the `discover_tools` MCP tool.
+
+## Tools in this group
+
+- [`orbit_query`](#orbit_query) — 📖 Read-only
+- [`orbit_get_schema`](#orbit_get_schema) — 📖 Read-only
+- [`orbit_get_status`](#orbit_get_status) — 📖 Read-only
+- [`orbit_list_tools`](#orbit_list_tools) — 📖 Read-only
+
+---
+
+### `orbit_query`
+
+*📖 Read-only*
+
+Execute a GitLab Orbit graph query over the indexed SDLC knowledge graph. Use this to answer cross-project relationship questions (blast radius, file-to-MR history, dependency fans) in one call instead of chaining list/get tools; use `orbit_get_schema` first when the node/edge types are unknown. It is read-only but each call consumes GitLab credits, requires Premium/Ultimate on an Orbit-enabled scope, and returns the graph result or a query/permission error.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|:-:|---|
+| `query` | object | ✓ | GitLab Orbit query DSL object (see the Orbit query-language reference for node/edge types and operators) |
+| `format` | enum (`raw` \| `llm`) |  | Response format: 'raw' for structured JSON, 'llm' for compact agent-optimized text (default) |
+
+### `orbit_get_schema`
+
+*📖 Read-only*
+
+Fetch the current GitLab Orbit graph schema (node and edge types). Use this to learn the node and edge types available for `orbit_query` before writing a query; use `orbit_get_status` when the concern is index freshness rather than shape. It is read-only and free of credit charges, and returns the current graph schema or a permission error.
+
+**Parameters**
+
+_No parameters._
+
+### `orbit_get_status`
+
+*📖 Read-only*
+
+Check GitLab Orbit indexing status for the enabled scope. Use this to check whether Orbit indexing has completed before trusting `orbit_query` results; results reflect the last index cycle, not real-time state. It is read-only and free of credit charges, and returns the indexing status or a permission error.
+
+**Parameters**
+
+_No parameters._
+
+### `orbit_list_tools`
+
+*📖 Read-only*
+
+List the MCP tool definitions exposed by GitLab Orbit. Use this to see which MCP tool definitions Orbit itself exposes; use `orbit_query` to run graph queries directly. It is read-only and free of credit charges, and returns the tool definition list or a permission error.
+
+**Parameters**
+
+_No parameters._

--- a/index.ts
+++ b/index.ts
@@ -546,6 +546,10 @@ import {
   type MergeRequestThreadPosition,
   type MyIssuesOptions,
   MyIssuesSchema,
+  OrbitQuerySchema,
+  OrbitSchemaSchema,
+  OrbitStatusSchema,
+  OrbitToolsSchema,
   MarkAllTodosDoneSchema,
   MarkTodoDoneSchema,
   type PaginatedDiscussionsResponse,
@@ -10098,6 +10102,59 @@ async function listProjectVulnerabilities(
   };
 }
 
+/**
+ * Execute a GitLab Orbit graph query.
+ * Note: the `llm` format returns compact plain text, not JSON.
+ */
+async function orbitQuery(query: Record<string, unknown>, format: "raw" | "llm"): Promise<unknown> {
+  const url = new URL(`${getEffectiveApiUrl()}/orbit/query`);
+
+  const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
+    method: "POST",
+    body: JSON.stringify({ query, format }),
+  });
+
+  await handleGitLabError(response);
+  if (format === "raw") {
+    return response.json();
+  }
+  return response.text();
+}
+
+async function orbitGetSchema(): Promise<unknown> {
+  const url = new URL(`${getEffectiveApiUrl()}/orbit/schema`);
+
+  const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
+  });
+
+  await handleGitLabError(response);
+  return response.json();
+}
+
+async function orbitGetStatus(): Promise<unknown> {
+  const url = new URL(`${getEffectiveApiUrl()}/orbit/status`);
+
+  const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
+  });
+
+  await handleGitLabError(response);
+  return response.json();
+}
+
+async function orbitListTools(): Promise<unknown> {
+  const url = new URL(`${getEffectiveApiUrl()}/orbit/tools`);
+
+  const response = await fetch(url.toString(), {
+    ...getFetchConfig(),
+  });
+
+  await handleGitLabError(response);
+  return response.json();
+}
+
 async function getVulnerability(vulnerabilityId: string): Promise<unknown> {
   const data = await executeGraphQL<{
     vulnerability:
@@ -13676,6 +13733,31 @@ async function handleToolCall(params: any) {
       case "confirm_vulnerability": {
         const args = ConfirmVulnerabilitySchema.parse(params.arguments);
         const result = await confirmVulnerability(args.vulnerability_id, args.comment);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      }
+
+      case "orbit_query": {
+        const args = OrbitQuerySchema.parse(params.arguments);
+        const result = await orbitQuery(args.query, args.format);
+        const text = typeof result === "string" ? result : JSON.stringify(result);
+        return { content: [{ type: "text", text }] };
+      }
+
+      case "orbit_get_schema": {
+        OrbitSchemaSchema.parse(params.arguments);
+        const result = await orbitGetSchema();
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      }
+
+      case "orbit_get_status": {
+        OrbitStatusSchema.parse(params.arguments);
+        const result = await orbitGetStatus();
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      }
+
+      case "orbit_list_tools": {
+        OrbitToolsSchema.parse(params.arguments);
+        const result = await orbitListTools();
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 

--- a/index.ts
+++ b/index.ts
@@ -13737,6 +13737,7 @@ async function handleToolCall(params: any) {
       }
 
       case "orbit_query": {
+        rejectIfStrictProjectScope("orbit_query");
         const args = OrbitQuerySchema.parse(params.arguments);
         const result = await orbitQuery(args.query, args.format);
         const text = typeof result === "string" ? result : JSON.stringify(result);
@@ -13744,18 +13745,21 @@ async function handleToolCall(params: any) {
       }
 
       case "orbit_get_schema": {
+        rejectIfStrictProjectScope("orbit_get_schema");
         OrbitSchemaSchema.parse(params.arguments);
         const result = await orbitGetSchema();
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "orbit_get_status": {
+        rejectIfStrictProjectScope("orbit_get_status");
         OrbitStatusSchema.parse(params.arguments);
         const result = await orbitGetStatus();
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case "orbit_list_tools": {
+        rejectIfStrictProjectScope("orbit_list_tools");
         OrbitToolsSchema.parse(params.arguments);
         const result = await orbitListTools();
         return { content: [{ type: "text", text: JSON.stringify(result) }] };

--- a/schemas.ts
+++ b/schemas.ts
@@ -5566,3 +5566,31 @@ export const ConfirmVulnerabilitySchema = z.object({
     .describe("The ID of the vulnerability to confirm (numeric or GraphQL global ID)"),
   comment: z.string().optional().describe("Optional comment explaining the confirmation"),
 });
+
+// --- GitLab Orbit (knowledge graph) ---
+// Query the Orbit property graph: groups, projects, MRs, pipelines, issues,
+// vulnerabilities, and source code indexed as one queryable graph.
+// Requires Premium/Ultimate; Beta; query calls consume GitLab credits.
+export const OrbitQuerySchema = z.object({
+  query: z
+    .record(z.string(), z.unknown())
+    .describe(
+      "GitLab Orbit query DSL object (see the Orbit query-language reference for node/edge types and operators)"
+    ),
+  format: z
+    .enum(["raw", "llm"])
+    .optional()
+    .default("llm")
+    .describe(
+      "Response format: 'raw' for structured JSON, 'llm' for compact agent-optimized text (default)"
+    ),
+});
+
+// Schema for fetching the current Orbit graph schema (node/edge types)
+export const OrbitSchemaSchema = z.object({});
+
+// Schema for checking Orbit indexing status
+export const OrbitStatusSchema = z.object({});
+
+// Schema for listing the MCP tool definitions Orbit exposes
+export const OrbitToolsSchema = z.object({});

--- a/scripts/generate-tool-docs.ts
+++ b/scripts/generate-tool-docs.ts
@@ -140,6 +140,11 @@ const GROUP_META: Record<ToolsetId, GroupMeta> = {
     blurb:
       "AI-assisted vulnerability triage — list findings, inspect details, dismiss with reason, or confirm for remediation. Backed by the GitLab GraphQL API; requires GitLab Ultimate.",
   },
+  orbit: {
+    title: "GitLab Orbit",
+    blurb:
+      "Query the Orbit SDLC knowledge graph (Beta; Premium/Ultimate). Graph queries consume GitLab credits; schema, status, and tool listing are free.",
+  },
 };
 
 const GROUP_ORDER: ToolsetId[] = [
@@ -163,6 +168,7 @@ const GROUP_ORDER: ToolsetId[] = [
   "search",
   "dependency_proxy",
   "vulnerabilities",
+  "orbit",
 ];
 
 // --- Helpers --------------------------------------------------------------

--- a/skills/gitlab-mcp/SKILL.md
+++ b/skills/gitlab-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill when working with the GitLab MCP server tools for me
 
 # gitlab-mcp
 
-GitLab MCP server providing 258 tools: 256 tools across 20 toolsets, plus `execute_graphql` and the always-available `discover_tools` meta-tool.
+GitLab MCP server providing 262 tools: 260 tools across 21 toolsets, plus `execute_graphql` and the always-available `discover_tools` meta-tool.
 
 For exact generated parameter tables, see `docs/tools/`. Use this file for workflow shape and high-signal parameter hints.
 
@@ -33,6 +33,7 @@ For exact generated parameter tables, see `docs/tools/`. Use this file for workf
 | variables (10 tools) | no | `GITLAB_TOOLSETS=variables` |
 | dependency_proxy (4 tools) | no | `GITLAB_TOOLSETS=dependency_proxy` |
 | vulnerabilities (4 tools) | no | `GITLAB_TOOLSETS=vulnerabilities` |
+| orbit (4 tools) | no | `GITLAB_TOOLSETS=orbit` |
 
 Enable all: `GITLAB_TOOLSETS=all`. Use `GITLAB_TOOLS` to enable individual tools outside their toolset. `discover_tools` can list and activate opt-in categories for the current session. `execute_graphql` is not in a toolset; enable it explicitly with `GITLAB_TOOLS=execute_graphql`.
 

--- a/skills/gitlab-mcp/SKILL.md
+++ b/skills/gitlab-mcp/SKILL.md
@@ -37,8 +37,8 @@ For exact generated parameter tables, see `docs/tools/`. Use this file for workf
 
 Enable all: `GITLAB_TOOLSETS=all`. Use `GITLAB_TOOLS` to enable individual tools outside their toolset. `discover_tools` can list and activate opt-in categories for the current session. `execute_graphql` is not in a toolset; enable it explicitly with `GITLAB_TOOLS=execute_graphql`.
 
-The per-toolset counts above sum to 258 because `get_branch` and `list_branches` are each listed
-in both `merge_requests` and `branches`; the unique tool count across all toolsets is 256.
+The per-toolset counts above sum to 262 because `get_branch` and `list_branches` are each listed
+in both `merge_requests` and `branches`; the unique tool count across all toolsets is 260.
 
 ## Key Workflows
 

--- a/test/test-orbit.ts
+++ b/test/test-orbit.ts
@@ -160,18 +160,26 @@ describe("orbit tools", () => {
     assert.deepEqual(lastQueryBody, { query, format: "llm" });
   });
 
-  test("orbit tools are refused under strict project scope", async () => {
-    const env: NodeJS.ProcessEnv = {
-      ...baseEnv(mockGitLabUrl),
-      ENABLE_STRICT_PROJECT_SCOPE: "true",
-      GITLAB_ALLOWED_PROJECT_IDS: "1,2",
-    };
-    let message = "";
-    try {
-      message = await callToolAsync(env, "orbit_get_status", {});
-    } catch (error) {
-      message = (error as Error).message;
-    }
-    assert.match(message, /not allowed while a project allowlist is in effect/);
-  });
+  for (const toolName of [
+    "orbit_query",
+    "orbit_get_schema",
+    "orbit_get_status",
+    "orbit_list_tools",
+  ]) {
+    test(`${toolName} is refused under strict project scope`, async () => {
+      const env: NodeJS.ProcessEnv = {
+        ...baseEnv(mockGitLabUrl),
+        ENABLE_STRICT_PROJECT_SCOPE: "true",
+        GITLAB_ALLOWED_PROJECT_IDS: "1,2",
+      };
+      const args = toolName === "orbit_query" ? { query: {} } : {};
+      let message = "";
+      try {
+        message = await callToolAsync(env, toolName, args);
+      } catch (error) {
+        message = (error as Error).message;
+      }
+      assert.match(message, /not allowed while a project allowlist is in effect/);
+    });
+  }
 });

--- a/test/test-orbit.ts
+++ b/test/test-orbit.ts
@@ -159,4 +159,19 @@ describe("orbit tools", () => {
     assert.equal(text, mockQueryLlm);
     assert.deepEqual(lastQueryBody, { query, format: "llm" });
   });
+
+  test("orbit tools are refused under strict project scope", async () => {
+    const env: NodeJS.ProcessEnv = {
+      ...baseEnv(mockGitLabUrl),
+      ENABLE_STRICT_PROJECT_SCOPE: "true",
+      GITLAB_ALLOWED_PROJECT_IDS: "1,2",
+    };
+    let message = "";
+    try {
+      message = await callToolAsync(env, "orbit_get_status", {});
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    assert.match(message, /not allowed while a project allowlist is in effect/);
+  });
 });

--- a/test/test-orbit.ts
+++ b/test/test-orbit.ts
@@ -1,0 +1,162 @@
+import { describe, test, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn } from "child_process";
+import { MockGitLabServer, findMockServerPort } from "./utils/mock-gitlab-server.js";
+
+const MOCK_TOKEN = "glpat-mock-token-12345";
+
+const mockSchema = {
+  nodes: [{ name: "Project", properties: ["id", "name"] }],
+  edges: [{ name: "HAS_MERGE_REQUEST", from: "Project", to: "MergeRequest" }],
+};
+
+const mockStatus = {
+  status: "ready",
+  last_indexed_at: "2026-09-05T10:00:00Z",
+  indexed_groups: 3,
+};
+
+const mockTools = {
+  tools: [{ name: "orbit_query", description: "Execute a graph query" }],
+};
+
+const mockQueryRaw = {
+  results: [{ project: "group/a", failures: 7 }],
+};
+
+const mockQueryLlm = "Top failing project: group/a (7 failures).";
+
+function baseEnv(mockGitLabUrl: string): NodeJS.ProcessEnv {
+  return {
+    GITLAB_API_URL: `${mockGitLabUrl}/api/v4`,
+    GITLAB_PERSONAL_ACCESS_TOKEN: MOCK_TOKEN,
+    GITLAB_TOOLSETS: "orbit",
+  };
+}
+
+async function callToolAsync(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  args: Record<string, unknown>
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const proc = spawn("node", ["build/index.js"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, ...env },
+    });
+
+    let output = "";
+    let errorOutput = "";
+    proc.stdout?.on("data", (chunk: Buffer) => (output += chunk));
+    proc.stderr?.on("data", (chunk: Buffer) => (errorOutput += chunk));
+
+    proc.on("close", code => {
+      if (code !== 0) {
+        return reject(new Error(`Process exited with code ${code}: ${errorOutput}`));
+      }
+
+      const line = output.split("\n").find(entry => entry.startsWith("{"));
+      if (!line) {
+        return reject(new Error("No JSON output found"));
+      }
+
+      try {
+        const response = JSON.parse(line);
+        if (response.error) {
+          reject(new Error(JSON.stringify(response.error)));
+          return;
+        }
+
+        const content = response.result?.content?.[0]?.text;
+        if (content === undefined) {
+          reject(new Error("No tool result content"));
+          return;
+        }
+
+        resolve(content);
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    proc.stdin?.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }) + "\n"
+    );
+  });
+}
+
+describe("orbit tools", () => {
+  let mockGitLab: MockGitLabServer;
+  let mockGitLabUrl: string;
+  let lastQueryBody: Record<string, unknown> | null = null;
+
+  before(async () => {
+    const mockPort = await findMockServerPort();
+    mockGitLab = new MockGitLabServer({
+      port: mockPort,
+      validTokens: [MOCK_TOKEN],
+    });
+
+    mockGitLab.addMockHandler("get", "/orbit/schema", (_req, res) => {
+      res.json(mockSchema);
+    });
+    mockGitLab.addMockHandler("get", "/orbit/status", (_req, res) => {
+      res.json(mockStatus);
+    });
+    mockGitLab.addMockHandler("get", "/orbit/tools", (_req, res) => {
+      res.json(mockTools);
+    });
+    mockGitLab.addMockHandler("post", "/orbit/query", (req, res) => {
+      lastQueryBody = req.body;
+      if (req.body?.format === "raw") {
+        res.json(mockQueryRaw);
+        return;
+      }
+      res.type("text/plain").send(mockQueryLlm);
+    });
+
+    await mockGitLab.start();
+    mockGitLabUrl = mockGitLab.getUrl();
+  });
+
+  after(async () => {
+    await mockGitLab.stop();
+  });
+
+  test("orbit_get_schema returns the graph schema", async () => {
+    const text = await callToolAsync(baseEnv(mockGitLabUrl), "orbit_get_schema", {});
+    assert.deepEqual(JSON.parse(text), mockSchema);
+  });
+
+  test("orbit_get_status returns indexing status", async () => {
+    const text = await callToolAsync(baseEnv(mockGitLabUrl), "orbit_get_status", {});
+    assert.deepEqual(JSON.parse(text), mockStatus);
+  });
+
+  test("orbit_list_tools returns tool definitions", async () => {
+    const text = await callToolAsync(baseEnv(mockGitLabUrl), "orbit_list_tools", {});
+    assert.deepEqual(JSON.parse(text), mockTools);
+  });
+
+  test("orbit_query with format=raw returns structured JSON", async () => {
+    const query = { node: "Project", limit: 5 };
+    const text = await callToolAsync(baseEnv(mockGitLabUrl), "orbit_query", {
+      query,
+      format: "raw",
+    });
+    assert.deepEqual(JSON.parse(text), mockQueryRaw);
+    assert.deepEqual(lastQueryBody, { query, format: "raw" });
+  });
+
+  test("orbit_query defaults to llm format and passes text through", async () => {
+    const query = { node: "Project", limit: 5 };
+    const text = await callToolAsync(baseEnv(mockGitLabUrl), "orbit_query", { query });
+    assert.equal(text, mockQueryLlm);
+    assert.deepEqual(lastQueryBody, { query, format: "llm" });
+  });
+});

--- a/test/test-toolset-filtering.ts
+++ b/test/test-toolset-filtering.ts
@@ -50,6 +50,7 @@ const TOOLSET_TOOL_COUNTS: Record<string, number> = {
   variables: 10,
   dependency_proxy: 4,
   vulnerabilities: 4,
+  orbit: 4,
 };
 
 const LEGACY_PIPELINE_CI_TOOL_COUNT = 2;
@@ -79,6 +80,7 @@ const NON_DEFAULT_TOOLSETS = [
   "variables",
   "dependency_proxy",
   "vulnerabilities",
+  "orbit",
 ];
 
 // discover_tools meta-tool is always force-injected (Step 5.5)

--- a/tools/registry.ts
+++ b/tools/registry.ts
@@ -220,6 +220,10 @@ import {
   MergeMergeRequestSchema,
   MoveWorkItemSchema,
   MyIssuesSchema,
+  OrbitQuerySchema,
+  OrbitSchemaSchema,
+  OrbitStatusSchema,
+  OrbitToolsSchema,
   PlayPipelineJobSchema,
   PromoteProjectMilestoneSchema,
   PublishDraftNoteSchema,
@@ -1495,6 +1499,27 @@ export const allTools = [
     description: "Confirm a vulnerability as a real finding requiring remediation",
     inputSchema: toJSONSchema(ConfirmVulnerabilitySchema),
   },
+  // --- GitLab Orbit (knowledge graph) tools ---
+  {
+    name: "orbit_query",
+    description: "Execute a GitLab Orbit graph query over the indexed SDLC knowledge graph",
+    inputSchema: toJSONSchema(OrbitQuerySchema),
+  },
+  {
+    name: "orbit_get_schema",
+    description: "Fetch the current GitLab Orbit graph schema (node and edge types)",
+    inputSchema: toJSONSchema(OrbitSchemaSchema),
+  },
+  {
+    name: "orbit_get_status",
+    description: "Check GitLab Orbit indexing status for the enabled scope",
+    inputSchema: toJSONSchema(OrbitStatusSchema),
+  },
+  {
+    name: "orbit_list_tools",
+    description: "List the MCP tool definitions exposed by GitLab Orbit",
+    inputSchema: toJSONSchema(OrbitToolsSchema),
+  },
   // --- Meta tool: Dynamic tool discovery ---
   {
     name: "discover_tools",
@@ -1648,6 +1673,10 @@ export const readOnlyTools = new Set([
   "list_dependency_proxy_blobs",
   "list_project_vulnerabilities",
   "get_vulnerability",
+  "orbit_query",
+  "orbit_get_schema",
+  "orbit_get_status",
+  "orbit_list_tools",
 ]);
 
 // Define which tools are destructive (data loss potential)
@@ -1847,7 +1876,8 @@ export type ToolsetId =
   | "search"
   | "variables"
   | "dependency_proxy"
-  | "vulnerabilities";
+  | "vulnerabilities"
+  | "orbit";
 
 export interface ToolsetDefinition {
   readonly id: ToolsetId;
@@ -2227,6 +2257,11 @@ export const TOOLSET_DEFINITIONS: readonly ToolsetDefinition[] = [
       "dismiss_vulnerability",
       "confirm_vulnerability",
     ]),
+  },
+  {
+    id: "orbit",
+    isDefault: false,
+    tools: new Set(["orbit_query", "orbit_get_schema", "orbit_get_status", "orbit_list_tools"]),
   },
 ] as const;
 

--- a/tools/tool-descriptions.ts
+++ b/tools/tool-descriptions.ts
@@ -97,6 +97,14 @@ const TOOL_GUIDANCE: Readonly<Record<string, string>> = {
     "Use this to stop eligible stale environments in a project. GitLab excludes protected environments, and this operation stops environments without deleting them. It requires the necessary project permission and returns the result or a validation, permission, or rate-limit error.",
   delete_review_app_environments:
     "Use this to clean up stopped review-app environments after verifying the scope. GitLab schedules deletion one week later rather than deleting environments immediately; `dry_run` defaults to `true`, so actual scheduling requires `dry_run: false`. It requires the necessary project permission and returns the cleanup result or a validation, permission, or rate-limit error.",
+  orbit_query:
+    "Use this to answer cross-project relationship questions (blast radius, file-to-MR history, dependency fans) in one call instead of chaining list/get tools; use `orbit_get_schema` first when the node/edge types are unknown. It is read-only but each call consumes GitLab credits, requires Premium/Ultimate on an Orbit-enabled scope, and returns the graph result or a query/permission error.",
+  orbit_get_schema:
+    "Use this to learn the node and edge types available for `orbit_query` before writing a query; use `orbit_get_status` when the concern is index freshness rather than shape. It is read-only and free of credit charges, and returns the current graph schema or a permission error.",
+  orbit_get_status:
+    "Use this to check whether Orbit indexing has completed before trusting `orbit_query` results; results reflect the last index cycle, not real-time state. It is read-only and free of credit charges, and returns the indexing status or a permission error.",
+  orbit_list_tools:
+    "Use this to see which MCP tool definitions Orbit itself exposes; use `orbit_query` to run graph queries directly. It is read-only and free of credit charges, and returns the tool definition list or a permission error.",
 };
 
 const PARAMETER_GUIDANCE =


### PR DESCRIPTION
Addresses #724 (kept open until reporter confirms after release).

Adds an opt-in `orbit` toolset exposing the GitLab Orbit knowledge-graph REST API (Beta; Premium/Ultimate):

- `orbit_query` — POST /orbit/query (DSL object + `raw`|`llm` format, default `llm`)
- `orbit_get_schema` — GET /orbit/schema
- `orbit_get_status` — GET /orbit/status
- `orbit_list_tools` — GET /orbit/tools

Notes:
- All four tools are read-only, so the toolset works in readonly permission mode. `orbit_query` consumes GitLab credits per call — called out in the tool description and docs.
- Non-default toolset: existing users see no change unless they opt in via `GITLAB_TOOLSETS=orbit`/`GITLAB_TOOLS`/`discover_tools`.
- `llm` format returns plain text, passed through without JSON parsing; `raw` returns parsed JSON.

Verification:
- `npm run build` clean
- new `test/test-orbit.ts` mock suite: 5/5 pass (mock GitLab server; no live Orbit index available)
- `test-toolset-filtering.ts`: 36/36 (updated hardcoded count map for the new toolset)
- `test-permission-mode.ts`: 13/13, `tool-description-quality`: 2/2
- `npm run check:skill-sync` pass; docs regenerated via `generate-tool-docs`
- new hunks are prettier-clean (`npm run lint` and repo-wide prettier failures pre-exist on main: eslint9-vs-eslintrc config mismatch, dirty baseline files)