### PR TITLE
ci: sync Docker Hub overview from docker/DOCKERHUB.md

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,8 @@ jobs:
           tags: ${{ github.event_name == 'release' && steps.meta-release.outputs.tags || steps.meta-manual.outputs.tags }}
 
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v5
+        # peter-evans/dockerhub-description@v5 — pin to commit SHA for supply-chain safety
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,8 +55,7 @@ jobs:
           tags: ${{ github.event_name == 'release' && steps.meta-release.outputs.tags || steps.meta-manual.outputs.tags }}
 
       - name: Update Docker Hub description
-        # peter-evans/dockerhub-description@v5 — pin to commit SHA for supply-chain safety
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,3 +53,13 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ github.event_name == 'release' && steps.meta-release.outputs.tags || steps.meta-manual.outputs.tags }}
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: zereight050/gitlab-mcp
+          readme-filepath: ./docker/DOCKERHUB.md
+          short-description: GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more
+          enable-url-completion: true

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -23,8 +23,10 @@ docker run -d --name gitlab-mcp -p 127.0.0.1:3002:3002 \
 ```
 
 With Docker Compose, copy the compose file from the
-[repository](https://github.com/zereight/gitlab-mcp/tree/main/docker) and run
-`docker compose up -d`.
+[repository](https://github.com/zereight/gitlab-mcp/tree/main/docker), set at least
+`GITLAB_PERSONAL_ACCESS_TOKEN`, `STREAMABLE_HTTP=true`, and `HOST=0.0.0.0` in your `.env`
+(or environment), and run `docker compose up -d`. Without `HOST=0.0.0.0` the server binds
+to container loopback and the published port stays unreachable.
 
 ## Environment variables
 

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -1,0 +1,55 @@
+# GitLab MCP Server
+
+Agent-workflow-optimized [GitLab MCP](https://github.com/zereight/gitlab-mcp) server — manage
+projects, merge requests, issues, pipelines, wiki, releases, tags, milestones, and more from
+AI clients such as Claude Code, VS Code, Cursor, and Copilot.
+
+- 232 tools + `discover_tools` for on-demand activation
+- Personal Access Token, OAuth2, read-only mode, and remote authorization
+- stdio, SSE, and Streamable HTTP transports
+- Works with gitlab.com and self-hosted instances
+
+## Quick start
+
+```bash
+docker pull zereight050/gitlab-mcp:latest
+
+docker run -d --name gitlab-mcp -p 127.0.0.1:3002:3002 \
+  -e GITLAB_PERSONAL_ACCESS_TOKEN="<your-token>" \
+  -e GITLAB_API_URL="https://gitlab.com/api/v4" \
+  -e STREAMABLE_HTTP=true \
+  -e HOST=0.0.0.0 \
+  zereight050/gitlab-mcp:latest
+```
+
+With Docker Compose, copy the compose file from the
+[repository](https://github.com/zereight/gitlab-mcp/tree/main/docker) and run
+`docker compose up -d`.
+
+## Environment variables
+
+| Variable                         | Default                      | Description                                        |
+| -------------------------------- | ---------------------------- | -------------------------------------------------- |
+| `GITLAB_PERSONAL_ACCESS_TOKEN`   | —                            | GitLab personal access token (required for PAT)    |
+| `GITLAB_API_URL`                 | `https://gitlab.com/api/v4`  | GitLab API endpoint, self-hosted supported         |
+| `STREAMABLE_HTTP`                | `false`                      | Set `true` for Streamable HTTP transport (port 3002) |
+| `SSE`                            | `false`                      | Set `true` for legacy SSE transport                |
+| `HOST`                           | `127.0.0.1`                  | Set `0.0.0.0` inside containers                    |
+| `PORT`                           | `3002`                       | HTTP port for SSE / Streamable HTTP                |
+| `GITLAB_READ_ONLY_MODE`          | `false`                      | Set `true` to expose read-only tools               |
+| `GITLAB_ALLOWED_PROJECT_IDS`     | —                            | Comma-separated project allowlist                  |
+| `REMOTE_AUTHORIZATION`           | `false`                      | Multi-user mode, each caller sends its own token   |
+
+Full list:
+[environment variables](https://github.com/zereight/gitlab-mcp/blob/main/docs/configuration/environment-variables.md).
+
+## Tags
+
+- `latest` — latest stable release
+- `vX.Y.Z` — pinned releases, e.g. `zereight050/gitlab-mcp:v2.1.59`
+
+## Links
+
+- Source: <https://github.com/zereight/gitlab-mcp>
+- Docs: <https://zereight.github.io/gitlab-mcp/>
+- npm: <https://www.npmjs.com/package/@zereight/mcp-gitlab>

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -15,3 +15,4 @@ services:
       - STREAMABLE_HTTP=${STREAMABLE_HTTP}
       - SSE=${SSE}
       - SSE_AUTH_TOKEN=${SSE_AUTH_TOKEN}
+      - HOST=${HOST}


### PR DESCRIPTION
## Why

https://hub.docker.com/r/zereight050/gitlab-mcp overview shows "No overview available" — `docker-publish.yml` only build-pushes the image, which never updates the Hub description.

## What

- Add `docker/DOCKERHUB.md`: concise Hub overview (quick start, env vars, tags, links)
- Add `peter-evans/dockerhub-description@v5` step to `docker-publish.yml` so every release (or manual dispatch) syncs full + short description

Secrets reused: existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`.

## Verify

- Workflow YAML parses; new step present
- Short description 91 chars (Hub limit 100)
- After merge, run the workflow once (manual dispatch) or wait for next release to populate the overview