### PR TITLE
fix(ci): use bookworm-slim builder to avoid QEMU arm64 SIGILL hang

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    # Fail fast instead of burning the full 6h when a platform leg hangs.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:22.21.1-alpine AS builder
+# bookworm-slim (glibc): node:*-alpine (musl) crashes under QEMU arm64
+# emulation with "uncaught target signal 4 (Illegal instruction)" during npm ci,
+# hanging the multi-platform CI build until the job timeout.
+FROM node:22.21.1-bookworm-slim AS builder
 
 COPY . /app
 COPY tsconfig.json /tsconfig.json


### PR DESCRIPTION
## Problem

The release `Docker Publish` job intermittently hangs for the full 6h and gets cancelled. Affected runs: 32583182216 (v2.1.52), 33406095512 (v2.1.56), 34014243926 (v2.1.59).

Job log (`34014243926`, job `101435176069`) shows the hang point:

```
#24 [linux/arm64 builder 6/6] RUN --mount=type=cache,... npm ci --ignore-scripts --omit-dev
#24 5.313 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
... no output for ~6h ...
##[error]The operation was canceled.
```

The `amd64` leg finishes in seconds; the `arm64` leg (QEMU user-mode emulation on the amd64 runner) crashes with SIGILL during `npm ci` and BuildKit never reports the step failure, so the job sits until the 6h timeout. Alpine/musl + QEMU arm64 is the known trigger (same symptom reported by multiple projects).

## Changes

- `Dockerfile`: builder stage `node:22.21.1-alpine` -> `node:22.21.1-bookworm-slim` (glibc). Runtime stage stays on alpine to keep the image small.
- `.github/workflows/docker-publish.yml`: add `timeout-minutes: 20` so a hung leg fails fast instead of burning 6h.

## Verification

- Workflow YAML parses (`timeout-minutes: 20` confirmed).
- `node:22.21.1-bookworm-slim` tag confirmed on Docker Hub with amd64 + arm64 images.
- Local Docker daemon unavailable (Docker Desktop would not start), so no local `docker build`. The PR `integration-test` job (`docker build` + `ls build/index.js`) covers the Dockerfile change in CI.
- Full multi-arch verification happens on the next release publish (or manual `workflow_dispatch` with a test tag).