### PR TITLE
docs: sync README and skill with tool registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,131 +691,156 @@ Register the skill directory in your AI client to get optimal tool usage guidanc
 106. `get_repository_tree` - Get the repository tree for a GitLab project (list files and directories)
 107. `list_pipelines` - List pipelines in a GitLab project with filtering options
 108. `get_pipeline` - Get details of a specific pipeline in a GitLab project
-109. `list_deployments` - List deployments in a GitLab project with filtering options
-110. `get_deployment` - Get details of a specific deployment in a GitLab project
-111. `list_environments` - List environments in a GitLab project
-112. `get_environment` - Get details of a specific environment in a GitLab project
-113. `list_pipeline_jobs` - List all jobs in a specific pipeline
-114. `list_pipeline_trigger_jobs` - List all trigger jobs (bridges) in a specific pipeline that trigger downstream pipelines
-115. `get_pipeline_job` - Get details of a GitLab pipeline job number
-116. `get_pipeline_job_output` - Get the output/trace of a GitLab pipeline job with optional pagination to limit context window usage
-117. `validate_ci_lint` - Validate provided GitLab CI/CD YAML content for a project
-118. `validate_project_ci_lint` - Validate an existing `.gitlab-ci.yml` configuration for a project
-119. `list_ci_catalog_resources` - List GitLab CI/CD Catalog resources/components visible to the user
-120. `get_ci_catalog_resource` - Get details for a GitLab CI/CD Catalog resource, including versions and components
-121. `create_pipeline` - Create a new pipeline for a branch or tag
-122. `retry_pipeline` - Retry a failed or canceled pipeline
-123. `cancel_pipeline` - Cancel a running pipeline
-124. `list_pipeline_schedules` - List pipeline schedules in a project, optionally filtered to active or inactive
-125. `get_pipeline_schedule` - Get details of a specific pipeline schedule, including its variables and last pipeline
-126. `list_pipeline_schedule_pipelines` - List the pipelines that a pipeline schedule has triggered
-127. `create_pipeline_schedule` - Create a new pipeline schedule for a branch or tag
-128. `update_pipeline_schedule` - Update an existing pipeline schedule
-129. `delete_pipeline_schedule` - Delete a pipeline schedule
-130. `play_pipeline_schedule` - Run a pipeline schedule immediately, without changing its next scheduled run
-131. `take_ownership_pipeline_schedule` - Take ownership of a pipeline schedule
-132. `get_pipeline_schedule_variable` - Get a single variable of a pipeline schedule
-133. `create_pipeline_schedule_variable` - Create a variable for a pipeline schedule
-134. `update_pipeline_schedule_variable` - Update a variable of a pipeline schedule
-135. `delete_pipeline_schedule_variable` - Delete a variable from a pipeline schedule
-136. `play_pipeline_job` - Run a manual pipeline job
-137. `retry_pipeline_job` - Retry a failed or canceled pipeline job
-138. `cancel_pipeline_job` - Cancel a running pipeline job
-139. `list_job_artifacts` - List artifact files in a job's artifacts archive. Returns file names, paths, types, and sizes
-140. `download_job_artifacts` - Download the entire artifact archive (zip) for a job to a local path. Returns the saved file path
-141. `get_job_artifact_file` - Get the content of a single file from a job's artifacts by its path within the archive
-142. `list_merge_requests` - List merge requests globally or in a specific GitLab project with filtering options (project_id is now optional)
-143. `list_group_merge_requests` - List merge requests across all projects of a group and its subgroups with filtering options
-144. `list_milestones` - List milestones in a GitLab project with filtering options
-145. `get_milestone` - Get details of a specific milestone
-146. `create_milestone` - Create a new milestone in a GitLab project
-147. `edit_milestone` - Edit an existing milestone in a GitLab project
-148. `delete_milestone` - Delete a milestone from a GitLab project
-149. `get_milestone_issue` - Get issues associated with a specific milestone
-150. `get_milestone_merge_requests` - Get merge requests associated with a specific milestone
-151. `promote_milestone` - Promote a milestone to the next stage
-152. `get_milestone_burndown_events` - Get burndown events for a specific milestone
-153. `list_group_milestones` - List milestones in a GitLab group with filtering options
-154. `get_group_milestone` - Get details of a specific group milestone
-155. `create_group_milestone` - Create a new milestone in a GitLab group
-156. `edit_group_milestone` - Edit an existing group milestone
-157. `delete_group_milestone` - Delete a milestone from a GitLab group
-158. `get_group_milestone_issue` - Get issues associated with a specific group milestone
-159. `get_group_milestone_merge_requests` - Get merge requests associated with a specific group milestone
-160. `get_group_milestone_burndown_events` - Get burndown events for a specific group milestone
-161. `get_users` - Get GitLab user details by usernames
-162. `get_user` - Get user details by ID
-163. `whoami` - Get current authenticated user details
-164. `list_commits` - List repository commits with filtering options
-165. `get_commit` - Get details of a specific commit
-166. `get_commit_diff` - Get changes/diffs of a specific commit
-167. `get_file_blame` - Get git blame for a file at a given ref. Each entry maps a contiguous range of source lines to the commit that last changed them (id, author, authored_date, message). Use range_start/range_end to limit blame to specific lines.
-168. `list_commit_statuses` - List statuses for a specific commit
-169. `create_commit_status` - Create or update the status of a specific commit
-170. `list_group_iterations` - List group iterations with filtering options
-171. `upload_markdown` - Upload a file to a GitLab project for use in markdown content
-172. `download_attachment` - Download an uploaded file from a GitLab project by secret and filename
-173. `health_check` - Verify server status and authentication; when authenticated, reports GitLab instance version from `/api/v4/version` (`version`, `revision`, `enterprise`)
-174. `list_events` - List all events for the currently authenticated user
-175. `get_project_events` - List all visible events for a specified project
-176. `list_releases` - List all releases for a project
-177. `get_release` - Get a release by tag name
-178. `create_release` - Create a new release in a GitLab project
-179. `update_release` - Update an existing release in a GitLab project
-180. `delete_release` - Delete a release from a GitLab project (does not delete the associated tag)
-181. `create_release_evidence` - Create release evidence for an existing release (GitLab Premium/Ultimate only)
-182. `download_release_asset` - Download a release asset file by direct asset path
-183. `list_tags` - List repository tags with filtering and pagination support
-184. `get_tag` - Get details of a specific repository tag
-185. `create_tag` - Create a new tag in the repository
-186. `delete_tag` - Delete a tag from the repository
-187. `get_tag_signature` - Get the signature of a signed tag
-188. `get_work_item` - Get a single work item with full details including status, hierarchy (parent/children), type, labels, assignees, and all widgets
-189. `list_work_items` - List work items in a project with filters (type, state, search, assignees, labels). Returns items with status and hierarchy info
-190. `create_work_item` - Create a new work item (issue, task, incident, test_case, epic, key_result, objective, requirement, ticket). Supports setting title, description, labels, assignees, weight, parent, health status, start/due dates, milestone, and confidentiality
-191. `update_work_item` - Update a work item. Can modify title, description, labels, assignees, weight, state, status, parent hierarchy, children, health status, start/due dates, milestone, confidentiality, linked items, and custom fields
-192. `convert_work_item_type` - Convert a work item to a different type (e.g. issue to task, task to incident)
-193. `list_work_item_statuses` - List available statuses for a work item type in a project. Requires GitLab Premium/Ultimate with configurable statuses
-194. `list_custom_field_definitions` - List available custom field definitions for a work item type in a project. Returns field names, types, and IDs needed for setting custom fields via update_work_item
-195. `move_work_item` - Move a work item (issue, task, etc.) to a different project. Uses GitLab GraphQL issueMove mutation
-196. `list_work_item_notes` - List notes and discussions on a work item. Returns threaded discussions with author, body, timestamps, and system/internal flags
-197. `create_work_item_note` - Add a note/comment to a work item. Supports Markdown, internal notes, and threaded replies
-198. `list_work_item_emoji_reactions` - List all emoji reactions on a work item
-199. `list_work_item_note_emoji_reactions` - List all emoji reactions on a work item note (comment, thread, or thread reply)
-200. `create_work_item_emoji_reaction` - Add an emoji reaction to a work item (e.g. thumbsup, rocket, eyes)
-201. `delete_work_item_emoji_reaction` - Remove an emoji reaction from a work item
-202. `create_work_item_note_emoji_reaction` - Add an emoji reaction to a work item note (comment, thread, or thread reply)
-203. `delete_work_item_note_emoji_reaction` - Remove an emoji reaction from a work item note (comment, thread, or thread reply)
-204. `get_timeline_events` - List timeline events for an incident. Returns chronological events with notes, timestamps, and tags
-205. `create_timeline_event` - Create a timeline event on an incident. Supports tags: 'Start time', 'End time', 'Impact detected', 'Response initiated', 'Impact mitigated', 'Cause identified'
-206. `list_webhooks` - List all configured webhooks for a GitLab project or group. Provide either project_id or group_id
-207. `create_webhook` - Create a webhook on a GitLab project or group
-208. `update_webhook` - Update an existing project or group webhook
-209. `delete_webhook` - Delete a project or group webhook
-210. `list_webhook_events` - List recent webhook events (past 7 days) for a project or group webhook. Use summary mode for overview, then get_webhook_event for full details
-211. `get_webhook_event` - Get full details of a specific webhook event by ID, including request/response payloads
-212. `search_code` - Search for code across all projects on the GitLab instance (requires advanced search or exact code search to be enabled)
-213. `search_project_code` - Search for code within a specific GitLab project (requires advanced search or exact code search to be enabled)
-214. `search_group_code` - Search for code within a specific GitLab group (requires advanced search or exact code search to be enabled)
-215. `list_project_variables` - List CI/CD variables for a project with optional environment scope filter
-216. `get_project_variable` - Get a single CI/CD variable from a project by key, with optional environment scope filter
-217. `create_project_variable` - Create a new CI/CD variable in a project
-218. `update_project_variable` - Update an existing CI/CD variable in a project, with optional filter to disambiguate by environment scope
-219. `delete_project_variable` - Delete a CI/CD variable from a project, with optional filter to disambiguate by environment scope
-220. `list_group_variables` - List CI/CD variables for a group with optional environment scope filter
-221. `get_group_variable` - Get a single CI/CD variable from a group by key, with optional environment scope filter
-222. `create_group_variable` - Create a new CI/CD variable in a group
-223. `update_group_variable` - Update an existing CI/CD variable in a group, with optional filter to disambiguate by environment scope
-224. `delete_group_variable` - Delete a CI/CD variable from a group, with optional filter to disambiguate by environment scope
-225. `get_dependency_proxy_settings` - Get dependency proxy settings for a group (enabled status, blob count, total size, image prefix, TTL policy)
-226. `update_dependency_proxy_settings` - Update dependency proxy settings for a group (enable/disable, credentials for authenticated Docker Hub pulls)
-227. `list_dependency_proxy_blobs` - List cached dependency proxy blobs for a group with cursor-based pagination
-228. `purge_dependency_proxy_cache` - Schedule purge of all cached dependency proxy blobs for a group
-229. `list_project_vulnerabilities` - List vulnerabilities for a project with optional state, severity, and report type filters (GraphQL-backed, cursor pagination)
-230. `get_vulnerability` - Get full details of a specific vulnerability
-231. `dismiss_vulnerability` - Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, mitigating_control, not_applicable) and optional comment
-232. `confirm_vulnerability` - Confirm a vulnerability as a real finding requiring remediation
-233. `discover_tools` - Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response.
+109. `get_pipeline_variables` - Get variables configured for a pipeline
+110. `get_pipeline_test_report` - Get pipeline test report
+111. `get_pipeline_test_report_summary` - Get pipeline test report summary
+112. `delete_pipeline` - Delete a pipeline. Requires the project Owner role, cannot be undone, and does not automatically delete child pipelines.
+113. `update_pipeline_metadata` - Update pipeline metadata
+114. `list_deployments` - List deployments in a GitLab project with filtering options
+115. `get_deployment` - Get details of a specific deployment in a GitLab project
+116. `create_deployment` - Create a deployment
+117. `update_deployment` - Update a deployment status
+118. `delete_deployment` - Delete a deployment
+119. `list_deployment_merge_requests` - List merge requests shipped with a deployment
+120. `approve_deployment` - Approve or reject a protected-environment deployment
+121. `list_environments` - List environments in a GitLab project
+122. `get_environment` - Get details of a specific environment in a GitLab project
+123. `update_environment` - Update an environment
+124. `delete_environment` - Delete a stopped environment
+125. `stop_environment` - Stop an environment
+126. `stop_stale_environments` - Stop eligible stale environments; protected environments are excluded and environments are stopped, not deleted
+127. `delete_review_app_environments` - Schedule deletion of stopped review-app environments one week later; `dry_run` defaults to true and actual scheduling requires `dry_run=false`
+128. `list_pipeline_triggers` - List project pipeline trigger tokens
+129. `get_pipeline_trigger` - Get a project pipeline trigger
+130. `create_pipeline_trigger` - Create a project pipeline trigger
+131. `update_pipeline_trigger` - Update a project pipeline trigger
+132. `delete_pipeline_trigger` - Delete a project pipeline trigger
+133. `trigger_pipeline` - Trigger a pipeline with a pipeline trigger token
+134. `list_pipeline_jobs` - List all jobs in a specific pipeline
+135. `list_pipeline_trigger_jobs` - List all trigger jobs (bridges) in a specific pipeline that trigger downstream pipelines
+136. `get_pipeline_job` - Get details of a GitLab pipeline job number
+137. `get_pipeline_job_output` - Get the output/trace of a GitLab pipeline job with optional pagination to limit context window usage
+138. `validate_ci_lint` - Validate provided GitLab CI/CD YAML content for a project
+139. `validate_project_ci_lint` - Validate an existing `.gitlab-ci.yml` configuration for a project
+140. `list_ci_catalog_resources` - List GitLab CI/CD Catalog resources/components visible to the user
+141. `get_ci_catalog_resource` - Get details for a GitLab CI/CD Catalog resource, including versions and components
+142. `create_pipeline` - Create a new pipeline for a branch or tag
+143. `retry_pipeline` - Retry a failed or canceled pipeline
+144. `cancel_pipeline` - Cancel a running pipeline
+145. `list_pipeline_schedules` - List pipeline schedules in a project, optionally filtered to active or inactive
+146. `get_pipeline_schedule` - Get details of a specific pipeline schedule, including its variables and last pipeline
+147. `list_pipeline_schedule_pipelines` - List the pipelines that a pipeline schedule has triggered
+148. `create_pipeline_schedule` - Create a new pipeline schedule for a branch or tag
+149. `update_pipeline_schedule` - Update an existing pipeline schedule
+150. `delete_pipeline_schedule` - Delete a pipeline schedule
+151. `play_pipeline_schedule` - Run a pipeline schedule immediately, without changing its next scheduled run
+152. `take_ownership_pipeline_schedule` - Take ownership of a pipeline schedule
+153. `get_pipeline_schedule_variable` - Get a single variable of a pipeline schedule
+154. `create_pipeline_schedule_variable` - Create a variable for a pipeline schedule
+155. `update_pipeline_schedule_variable` - Update a variable of a pipeline schedule
+156. `delete_pipeline_schedule_variable` - Delete a variable from a pipeline schedule
+157. `play_pipeline_job` - Run a manual pipeline job
+158. `play_pipeline_jobs` - Play multiple manual pipeline jobs sequentially
+159. `retry_pipeline_job` - Retry a failed or canceled pipeline job
+160. `cancel_pipeline_job` - Cancel a running pipeline job
+161. `erase_pipeline_job` - Erase a pipeline job log and artifacts
+162. `wait_for_pipeline` - Wait for a pipeline to reach a terminal status
+163. `wait_for_job` - Wait for a job to reach a terminal status
+164. `list_job_artifacts` - List artifact files in a job's artifacts archive. Returns file names, paths, types, and sizes
+165. `download_job_artifacts` - Download the entire artifact archive (zip) for a job to a local path. Returns the saved file path
+166. `get_job_artifact_file` - Get the content of a single file from a job's artifacts by its path within the archive
+167. `list_merge_requests` - List merge requests globally or in a specific GitLab project with filtering options (project_id is now optional)
+168. `list_group_merge_requests` - List merge requests across all projects of a group and its subgroups with filtering options
+169. `list_milestones` - List milestones in a GitLab project with filtering options
+170. `get_milestone` - Get details of a specific milestone
+171. `create_milestone` - Create a new milestone in a GitLab project
+172. `edit_milestone` - Edit an existing milestone in a GitLab project
+173. `delete_milestone` - Delete a milestone from a GitLab project
+174. `get_milestone_issue` - Get issues associated with a specific milestone
+175. `get_milestone_merge_requests` - Get merge requests associated with a specific milestone
+176. `promote_milestone` - Promote a milestone to the next stage
+177. `get_milestone_burndown_events` - Get burndown events for a specific milestone
+178. `list_group_milestones` - List milestones in a GitLab group with filtering options
+179. `get_group_milestone` - Get details of a specific group milestone
+180. `create_group_milestone` - Create a new milestone in a GitLab group
+181. `edit_group_milestone` - Edit an existing group milestone
+182. `delete_group_milestone` - Delete a milestone from a GitLab group
+183. `get_group_milestone_issue` - Get issues associated with a specific group milestone
+184. `get_group_milestone_merge_requests` - Get merge requests associated with a specific group milestone
+185. `get_group_milestone_burndown_events` - Get burndown events for a specific group milestone
+186. `get_users` - Get GitLab user details by usernames
+187. `get_user` - Get user details by ID
+188. `whoami` - Get current authenticated user details
+189. `list_commits` - List repository commits with filtering options
+190. `get_commit` - Get details of a specific commit
+191. `get_commit_diff` - Get changes/diffs of a specific commit
+192. `get_file_blame` - Get git blame for a file at a given ref. Each entry maps a contiguous range of source lines to the commit that last changed them (id, author, authored_date, message). Use range_start/range_end to limit blame to specific lines.
+193. `list_commit_statuses` - List statuses for a specific commit
+194. `create_commit_status` - Create or update the status of a specific commit
+195. `list_group_iterations` - List group iterations with filtering options
+196. `upload_markdown` - Upload a file to a GitLab project for use in markdown content
+197. `download_attachment` - Download an uploaded file from a GitLab project by secret and filename
+198. `health_check` - Verify server status and authentication; when authenticated, reports GitLab instance version from `/api/v4/version` (`version`, `revision`, `enterprise`)
+199. `list_events` - List all events for the currently authenticated user
+200. `get_project_events` - List all visible events for a specified project
+201. `list_releases` - List all releases for a project
+202. `get_release` - Get a release by tag name
+203. `create_release` - Create a new release in a GitLab project
+204. `update_release` - Update an existing release in a GitLab project
+205. `delete_release` - Delete a release from a GitLab project (does not delete the associated tag)
+206. `create_release_evidence` - Create release evidence for an existing release (GitLab Premium/Ultimate only)
+207. `download_release_asset` - Download a release asset file by direct asset path
+208. `list_tags` - List repository tags with filtering and pagination support
+209. `get_tag` - Get details of a specific repository tag
+210. `create_tag` - Create a new tag in the repository
+211. `delete_tag` - Delete a tag from the repository
+212. `get_tag_signature` - Get the signature of a signed tag
+213. `get_work_item` - Get a single work item with full details including status, hierarchy (parent/children), type, labels, assignees, and all widgets
+214. `list_work_items` - List work items in a project with filters (type, state, search, assignees, labels). Returns items with status and hierarchy info
+215. `create_work_item` - Create a new work item (issue, task, incident, test_case, epic, key_result, objective, requirement, ticket). Supports setting title, description, labels, assignees, weight, parent, health status, start/due dates, milestone, and confidentiality
+216. `update_work_item` - Update a work item. Can modify title, description, labels, assignees, weight, state, status, parent hierarchy, children, health status, start/due dates, milestone, confidentiality, linked items, and custom fields
+217. `convert_work_item_type` - Convert a work item to a different type (e.g. issue to task, task to incident)
+218. `list_work_item_statuses` - List available statuses for a work item type in a project. Requires GitLab Premium/Ultimate with configurable statuses
+219. `list_custom_field_definitions` - List available custom field definitions for a work item type in a project. Returns field names, types, and IDs needed for setting custom fields via update_work_item
+220. `move_work_item` - Move a work item (issue, task, etc.) to a different project. Uses GitLab GraphQL issueMove mutation
+221. `list_work_item_notes` - List notes and discussions on a work item. Returns threaded discussions with author, body, timestamps, and system/internal flags
+222. `create_work_item_note` - Add a note/comment to a work item. Supports Markdown, internal notes, and threaded replies
+223. `list_work_item_emoji_reactions` - List all emoji reactions on a work item
+224. `list_work_item_note_emoji_reactions` - List all emoji reactions on a work item note (comment, thread, or thread reply)
+225. `create_work_item_emoji_reaction` - Add an emoji reaction to a work item (e.g. thumbsup, rocket, eyes)
+226. `delete_work_item_emoji_reaction` - Remove an emoji reaction from a work item
+227. `create_work_item_note_emoji_reaction` - Add an emoji reaction to a work item note (comment, thread, or thread reply)
+228. `delete_work_item_note_emoji_reaction` - Remove an emoji reaction from a work item note (comment, thread, or thread reply)
+229. `get_timeline_events` - List timeline events for an incident. Returns chronological events with notes, timestamps, and tags
+230. `create_timeline_event` - Create a timeline event on an incident. Supports tags: 'Start time', 'End time', 'Impact detected', 'Response initiated', 'Impact mitigated', 'Cause identified'
+231. `list_webhooks` - List all configured webhooks for a GitLab project or group. Provide either project_id or group_id
+232. `create_webhook` - Create a webhook on a GitLab project or group
+233. `update_webhook` - Update an existing project or group webhook
+234. `delete_webhook` - Delete a project or group webhook
+235. `list_webhook_events` - List recent webhook events (past 7 days) for a project or group webhook. Use summary mode for overview, then get_webhook_event for full details
+236. `get_webhook_event` - Get full details of a specific webhook event by ID, including request/response payloads
+237. `search_code` - Search for code across all projects on the GitLab instance (requires advanced search or exact code search to be enabled)
+238. `search_project_code` - Search for code within a specific GitLab project (requires advanced search or exact code search to be enabled)
+239. `search_group_code` - Search for code within a specific GitLab group (requires advanced search or exact code search to be enabled)
+240. `list_project_variables` - List CI/CD variables for a project with optional environment scope filter
+241. `get_project_variable` - Get a single CI/CD variable from a project by key, with optional environment scope filter
+242. `create_project_variable` - Create a new CI/CD variable in a project
+243. `update_project_variable` - Update an existing CI/CD variable in a project, with optional filter to disambiguate by environment scope
+244. `delete_project_variable` - Delete a CI/CD variable from a project, with optional filter to disambiguate by environment scope
+245. `list_group_variables` - List CI/CD variables for a group with optional environment scope filter
+246. `get_group_variable` - Get a single CI/CD variable from a group by key, with optional environment scope filter
+247. `create_group_variable` - Create a new CI/CD variable in a group
+248. `update_group_variable` - Update an existing CI/CD variable in a group, with optional filter to disambiguate by environment scope
+249. `delete_group_variable` - Delete a CI/CD variable from a group, with optional filter to disambiguate by environment scope
+250. `get_dependency_proxy_settings` - Get dependency proxy settings for a group (enabled status, blob count, total size, image prefix, TTL policy)
+251. `update_dependency_proxy_settings` - Update dependency proxy settings for a group (enable/disable, credentials for authenticated Docker Hub pulls)
+252. `list_dependency_proxy_blobs` - List cached dependency proxy blobs for a group with cursor-based pagination
+253. `purge_dependency_proxy_cache` - Schedule purge of all cached dependency proxy blobs for a group
+254. `list_project_vulnerabilities` - List vulnerabilities for a project with optional state, severity, and report type filters (GraphQL-backed, cursor pagination)
+255. `get_vulnerability` - Get full details of a specific vulnerability
+256. `dismiss_vulnerability` - Dismiss a vulnerability with a reason (acceptable_risk, false_positive, used_in_tests, mitigating_control, not_applicable) and optional comment
+257. `confirm_vulnerability` - Confirm a vulnerability as a real finding requiring remediation
+258. `discover_tools` - Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response.
 
 <!-- TOOLS-END -->
 


### PR DESCRIPTION
## Summary

Sync check of README + skill against `tools/registry.ts` (258 tools, 20 toolsets) on main.

## Checks

1. **Skill sync** — `npm run check:skill-sync` passes on main; no changes to `skills/gitlab-mcp/` needed.
2. **English README tools list** — `README.md` TOOLS-START/TOOLS-END had 233 entries, missing 25 registry tools. Added the missing entries in exact registry order and renumbered to 258:
   - pipeline: `get_pipeline_variables`, `get_pipeline_test_report`, `get_pipeline_test_report_summary`, `delete_pipeline`, `update_pipeline_metadata`
   - deployments: `create_deployment`, `update_deployment`, `delete_deployment`, `list_deployment_merge_requests`, `approve_deployment`
   - environments: `update_environment`, `delete_environment`, `stop_environment`, `stop_stale_environments`, `delete_review_app_environments`
   - triggers: `list_pipeline_triggers`, `get_pipeline_trigger`, `create_pipeline_trigger`, `update_pipeline_trigger`, `delete_pipeline_trigger`, `trigger_pipeline`
   - jobs: `play_pipeline_jobs`, `erase_pipeline_job`, `wait_for_pipeline`, `wait_for_job`
   - Existing 233 descriptions preserved; new entries use registry base descriptions.
3. **ko/zh READMEs** — tool sections correctly link to `./README.md#tools-%EF%B8%8F` and the category summaries match the current toolset; no changes needed.

## Verification

- `npm run check:skill-sync` → in sync
- Regenerated list verified: 258 entries, sequential numbering, order identical to registry
- Prettier: TOOLS section lines are format-clean (remaining README warnings are pre-existing table formatting on main)