### PR TITLE
fix: defer OAuth token acquisition to first use; no browser on transient refresh errors

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -25,6 +25,10 @@ Optional Netscape cookie file path for cookie-based authentication.
 
 Set to `true` to enable local browser-based OAuth2 authentication.
 
+The token is acquired lazily on the first tool call (not at startup). If no
+stored token exists, the browser opens then; transient refresh failures fail
+that call instead of opening a browser.
+
 ### `GITLAB_OAUTH_CLIENT_ID`
 
 Client ID for local OAuth2 authentication.

--- a/index.ts
+++ b/index.ts
@@ -144,7 +144,7 @@ import { CookieJar, parse as parseCookie } from "tough-cookie";
 import { URL } from "node:url";
 import { z } from "zod";
 
-import { initializeOAuthClient, GitLabOAuth } from "./oauth.js";
+import { createGitLabOAuthClient, ensureOAuthToken, GitLabOAuth } from "./oauth.js";
 import { getPositionalCliCommand } from "./cli-command.js";
 import { runAuthCommandAsync } from "./auth-cli.js";
 import { createGitLabOAuthProvider } from "./oauth-proxy.js";
@@ -1401,15 +1401,10 @@ export function hasStatelessSessionId(req: {
  * This avoids background timers that cause issues with multiple instances.
  */
 async function ensureValidOAuthToken(): Promise<void> {
-  if (!oauthClient) return;
-
-  if (oauthClient.hasValidToken()) return;
-
   try {
-    logger.info("OAuth token expired or missing, refreshing...");
-    const freshToken = await oauthClient.getAccessToken();
-    OAUTH_ACCESS_TOKEN = freshToken;
-    logger.info("OAuth token refreshed successfully");
+    await ensureOAuthToken(oauthClient, OAUTH_ACCESS_TOKEN, token => {
+      OAUTH_ACCESS_TOKEN = token;
+    });
   } catch (error) {
     logger.error({ err: error }, "Failed to refresh OAuth token");
     throw error;
@@ -15697,10 +15692,12 @@ async function runServer() {
       logger.info("Using OAuth authentication...");
       try {
         const gitlabBaseUrl = GITLAB_API_URL.replace(/\/api\/v4$/, "");
-        const oauthResult = await initializeOAuthClient(gitlabBaseUrl);
-        oauthClient = oauthResult.client;
-        OAUTH_ACCESS_TOKEN = oauthResult.accessToken;
-        logger.info("OAuth authentication successful");
+        // Construct the client synchronously (no network). The token is
+        // acquired lazily on the first tool call via ensureValidOAuthToken,
+        // by which point the network is ready. This avoids blocking startup
+        // and avoids opening a browser on transient boot-time network errors.
+        oauthClient = createGitLabOAuthClient(gitlabBaseUrl);
+        logger.info("OAuth enabled; token acquired lazily on first use.");
       } catch (error) {
         logger.error({ err: error }, "OAuth authentication failed");
         process.exit(1);

--- a/oauth.ts
+++ b/oauth.ts
@@ -32,6 +32,29 @@ const pendingAuthRequests = new Map<
   }
 >();
 
+const OAUTH_REFRESH_TIMEOUT_MS = 10000;
+
+/**
+ * Decide whether a failed token-refresh response means the refresh token is
+ * genuinely dead (interactive re-login would fix it) versus a transient or
+ * configuration problem (where opening a browser is wrong).
+ *
+ * Returns true ONLY for a 400/401 whose JSON body has error "invalid_grant"
+ * or "invalid_token". Everything else — config errors (invalid_client,
+ * invalid_request), 5xx, 429, and non-JSON bodies — returns false.
+ */
+export function isAuthInvalidTokenResponse(status: number, bodyText: string): boolean {
+  if (status !== 400 && status !== 401) {
+    return false;
+  }
+  try {
+    const body = JSON.parse(bodyText) as { error?: string };
+    return body.error === "invalid_grant" || body.error === "invalid_token";
+  } catch {
+    return false;
+  }
+}
+
 interface TokenData {
   access_token: string;
   refresh_token?: string;
@@ -228,11 +251,15 @@ export class GitLabOAuth {
         "Content-Type": "application/x-www-form-urlencoded",
       },
       body: params.toString(),
+      signal: AbortSignal.timeout(OAUTH_REFRESH_TIMEOUT_MS),
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Token refresh failed: ${response.status} ${errorText}`);
+      const bodyText = await response.text();
+      const authInvalid = isAuthInvalidTokenResponse(response.status, bodyText);
+      throw Object.assign(new Error(`Token refresh failed: ${response.status} ${bodyText}`), {
+        authInvalid,
+      });
     }
 
     const data = (await response.json()) as {
@@ -640,8 +667,13 @@ export class GitLabOAuth {
           tokenData = await this.refreshAccessToken(tokenData.refresh_token);
           this.saveToken(tokenData);
         } catch (error) {
-          logger.error({ err: error }, "Token refresh failed. Starting new OAuth flow...");
-          tokenData = await this.startOAuthFlow();
+          if ((error as { authInvalid?: boolean }).authInvalid === true) {
+            logger.error({ err: error }, "Refresh token invalid, starting new OAuth flow...");
+            tokenData = await this.startOAuthFlow();
+          } else {
+            logger.error({ err: error }, "Token refresh failed (transient/network), not opening browser.");
+            throw error;
+          }
         }
       } else {
         logger.info("No refresh token available. Starting new OAuth flow...");
@@ -708,11 +740,11 @@ export class GitLabOAuth {
 }
 
 /**
- * Create and initialize a GitLabOAuth client.
- * Performs initial authentication (triggers browser flow if needed).
- * Returns the client instance and the initial access token.
+ * Construct a GitLabOAuth client from environment configuration.
+ * Does NOT perform any network access — no token is acquired here.
+ * Throws if neither GITLAB_OAUTH_CLIENT_ID nor GITLAB_OAUTH_TOKEN_SCRIPT is set.
  */
-export async function initializeOAuthClient(gitlabUrl: string = "https://gitlab.com"): Promise<{ client: GitLabOAuth; accessToken: string }> {
+export function createGitLabOAuthClient(gitlabUrl: string = "https://gitlab.com"): GitLabOAuth {
   const clientId = process.env.GITLAB_OAUTH_CLIENT_ID;
   const clientSecret = process.env.GITLAB_OAUTH_CLIENT_SECRET;
   const redirectUri = process.env.GITLAB_OAUTH_REDIRECT_URI || "http://127.0.0.1:8888/callback";
@@ -725,7 +757,7 @@ export async function initializeOAuthClient(gitlabUrl: string = "https://gitlab.
     );
   }
 
-  const oauth = new GitLabOAuth({
+  return new GitLabOAuth({
     clientId: clientId || "external-token-script",
     clientSecret,
     redirectUri,
@@ -734,6 +766,43 @@ export async function initializeOAuthClient(gitlabUrl: string = "https://gitlab.
     tokenStoragePath,
     tokenScript,
   });
+}
+
+/**
+ * Ensure the caller holds a usable OAuth access token, delivering it via onToken.
+ * Returns cached token without network when still valid.
+ *
+ * NOTE: the fast path requires BOTH a held token and a valid stored token.
+ * Returning early on hasValidToken() alone would skip onToken after lazy
+ * startup (caller holds nothing yet) and leave requests unauthenticated.
+ */
+export async function ensureOAuthToken(
+  client: GitLabOAuth | null | undefined,
+  currentToken: string | null | undefined,
+  onToken: (token: string) => void
+): Promise<void> {
+  if (!client) return;
+
+  // Fast path: token already resolved for this process and still valid.
+  if (currentToken && client.hasValidToken()) return;
+
+  const needsRefresh = !client.hasValidToken();
+  if (needsRefresh) {
+    logger.info("OAuth token expired or missing, refreshing...");
+  }
+  onToken(await client.getAccessToken());
+  if (needsRefresh) {
+    logger.info("OAuth token refreshed successfully");
+  }
+}
+
+/**
+ * Create and initialize a GitLabOAuth client.
+ * Performs initial authentication (triggers browser flow if needed).
+ * Returns the client instance and the initial access token.
+ */
+export async function initializeOAuthClient(gitlabUrl: string = "https://gitlab.com"): Promise<{ client: GitLabOAuth; accessToken: string }> {
+  const oauth = createGitLabOAuthClient(gitlabUrl);
 
   // Single call: triggers browser flow if needed, or reads cached token
   const accessToken = await oauth.getAccessToken();

--- a/scripts/run-mock-tests.sh
+++ b/scripts/run-mock-tests.sh
@@ -35,6 +35,7 @@ run_mock_tests 4 \
   -o -path 'test/stateless/session-id.test.ts' \
   -o -path 'test/stateless/callback-proxy.test.ts' \
   -o -path 'test/stateless/consumed-proxy-code-cache.test.ts' \
+  -o -path 'test/oauth-startup.test.ts' \
   -o -path 'test/oauth-device-flow-tests.ts' \)
 
 # Server-spawning suites — sequential to avoid port races and node:test IPC flakes
@@ -50,6 +51,7 @@ run_mock_tests 1 \
   ! -path 'test/stateless/session-id.test.ts' \
   ! -path 'test/stateless/callback-proxy.test.ts' \
   ! -path 'test/stateless/consumed-proxy-code-cache.test.ts' \
+  ! -path 'test/oauth-startup.test.ts' \
   ! -path 'test/oauth-device-flow-tests.ts'
 
 tsx test/oauth-tests.ts

--- a/test/oauth-startup.test.ts
+++ b/test/oauth-startup.test.ts
@@ -1,0 +1,211 @@
+/**
+ * OAuth startup tests.
+ *
+ * - isAuthInvalidTokenResponse: pure classifier — refresh failures that mean
+ *   "re-login would fix it" vs transient/config errors that must not open a browser.
+ * - ensureOAuthToken: lazy first-use delivery — the caller must receive the
+ *   token even when the on-disk token is still valid (regression: returning
+ *   early on hasValidToken() alone leaves requests unauthenticated).
+ *
+ * Temp token files + a loopback mock for /oauth/token only; no MCP server.
+ * The missing-token and invalid_grant paths start the interactive browser
+ * flow and are deliberately not covered here.
+ */
+
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as http from "node:http";
+import { GitLabOAuth, ensureOAuthToken, isAuthInvalidTokenResponse } from "../oauth.js";
+
+const validTokenFile = {
+  access_token: "cached-access-token",
+  refresh_token: "cached-refresh-token",
+  expires_in: 7200,
+  created_at: Date.now(),
+  token_type: "Bearer",
+};
+
+const expiredTokenFile = {
+  ...validTokenFile,
+  created_at: Date.now() - 10 * 3600 * 1000,
+};
+
+const tmpDirs: string[] = [];
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTokenFile(data: object): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oauth-startup-"));
+  tmpDirs.push(dir);
+  const file = path.join(dir, "token.json");
+  fs.writeFileSync(file, JSON.stringify(data));
+  return file;
+}
+
+function makeClient(tokenStoragePath: string, gitlabUrl: string, extra?: { tokenScript?: string }): GitLabOAuth {
+  return new GitLabOAuth({
+    clientId: "test-client",
+    redirectUri: "http://127.0.0.1:8888/callback",
+    gitlabUrl,
+    scopes: ["api"],
+    tokenStoragePath,
+    ...extra,
+  });
+}
+
+async function startTokenServer(handler: () => { status: number; json: unknown }): Promise<{
+  url: string;
+  bodies: string[];
+}> {
+  const bodies: string[] = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    req.on("end", () => {
+      bodies.push(body);
+      const { status, json } = handler();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(json));
+    });
+  });
+  servers.push(server);
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()));
+  const addr = server.address();
+  assert(addr && typeof addr !== "string");
+  return { url: `http://127.0.0.1:${addr.port}`, bodies };
+}
+
+describe("isAuthInvalidTokenResponse", () => {
+  test("400 invalid_grant is auth-invalid", () => {
+    assert.strictEqual(isAuthInvalidTokenResponse(400, '{"error":"invalid_grant"}'), true);
+  });
+
+  test("400 invalid_token is auth-invalid", () => {
+    assert.strictEqual(isAuthInvalidTokenResponse(400, '{"error":"invalid_token"}'), true);
+  });
+
+  test("401 invalid_grant is auth-invalid", () => {
+    assert.strictEqual(isAuthInvalidTokenResponse(401, '{"error":"invalid_grant"}'), true);
+  });
+
+  test("400 invalid_client is not auth-invalid (config error)", () => {
+    assert.strictEqual(isAuthInvalidTokenResponse(400, '{"error":"invalid_client"}'), false);
+  });
+
+  test("400 invalid_request is not auth-invalid (config error)", () => {
+    assert.strictEqual(isAuthInvalidTokenResponse(400, '{"error":"invalid_request"}'), false);
+  });
+
+  test("500 server_error is not auth-invalid (transient)", () => {
+    assert.strictEqual(isAuthInvalidTokenResponse(500, '{"error":"server_error"}'), false);
+  });
+
+  test("429 is not auth-invalid (rate limited)", () => {
+    assert.strictEqual(isAuthInvalidTokenResponse(429, '{"error":"invalid_grant"}'), false);
+  });
+
+  test("non-JSON body is not auth-invalid", () => {
+    assert.strictEqual(isAuthInvalidTokenResponse(400, "gateway timeout"), false);
+  });
+});
+
+describe("ensureOAuthToken", () => {
+  test("null client is a no-op", async () => {
+    const delivered: string[] = [];
+    await ensureOAuthToken(null, null, t => {
+      delivered.push(t);
+    });
+    await ensureOAuthToken(undefined, undefined, t => {
+      delivered.push(t);
+    });
+    assert.deepStrictEqual(delivered, []);
+  });
+
+  test("first call with valid cached token delivers it without network", async () => {
+    // Closed port: any fetch attempt fails, proving the cached path is network-free.
+    const client = makeClient(makeTokenFile(validTokenFile), "http://127.0.0.1:9");
+    const delivered: string[] = [];
+    await ensureOAuthToken(client, null, t => {
+      delivered.push(t);
+    });
+    assert.deepStrictEqual(delivered, ["cached-access-token"]);
+  });
+
+  test("already-held valid token is not re-delivered", async () => {
+    const client = makeClient(makeTokenFile(validTokenFile), "http://127.0.0.1:9");
+    const delivered: string[] = [];
+    await ensureOAuthToken(client, "cached-access-token", t => {
+      delivered.push(t);
+    });
+    assert.deepStrictEqual(delivered, []);
+  });
+
+  test("expired token refreshes via /oauth/token and persists", async () => {
+    const { url, bodies } = await startTokenServer(() => ({
+      status: 200,
+      json: {
+        access_token: "fresh-token",
+        refresh_token: "fresh-refresh",
+        expires_in: 7200,
+        token_type: "Bearer",
+      },
+    }));
+    const file = makeTokenFile(expiredTokenFile);
+    const client = makeClient(file, url);
+    const delivered: string[] = [];
+    await ensureOAuthToken(client, null, t => {
+      delivered.push(t);
+    });
+    assert.deepStrictEqual(delivered, ["fresh-token"]);
+    assert.strictEqual(bodies.length, 1);
+    assert.match(bodies[0], /grant_type=refresh_token/);
+    assert.match(bodies[0], /refresh_token=cached-refresh-token/);
+    const saved = JSON.parse(fs.readFileSync(file, "utf8")) as { access_token: string };
+    assert.strictEqual(saved.access_token, "fresh-token");
+  });
+
+  test("transient refresh failure propagates without opening a browser", async () => {
+    const { url } = await startTokenServer(() => ({ status: 500, json: { error: "server_error" } }));
+    const client = makeClient(makeTokenFile(expiredTokenFile), url);
+    const delivered: string[] = [];
+    // Rejection (not a browser popup) proves the no-browser path.
+    await assert.rejects(
+      () =>
+        ensureOAuthToken(client, null, t => {
+          delivered.push(t);
+        }),
+      /Token refresh failed: 500/
+    );
+    assert.deepStrictEqual(delivered, []);
+  });
+
+  test("token script resolves once, then fast path holds", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oauth-startup-"));
+    tmpDirs.push(dir);
+    const client = makeClient(path.join(dir, "token.json"), "http://127.0.0.1:9", {
+      tokenScript: "echo script-token-1",
+    });
+    const delivered: string[] = [];
+    await ensureOAuthToken(client, null, t => {
+      delivered.push(t);
+    });
+    assert.deepStrictEqual(delivered, ["script-token-1"]);
+    await ensureOAuthToken(client, delivered[0], t => {
+      delivered.push(t);
+    });
+    assert.deepStrictEqual(delivered, ["script-token-1"]);
+  });
+});


### PR DESCRIPTION
## Problem

When `GITLAB_USE_OAUTH=true`, the server acquires the OAuth token **eagerly and synchronously at startup** (`runServer` → `initializeOAuthClient` → `getAccessToken`), blocking the MCP handshake on a network call to GitLab.

For a self-hosted GitLab (often behind a VPN), the network frequently isn't ready at the instant the MCP client spawns the server. The refresh `fetch` then hangs past the client's connection timeout, and on *any* refresh error the code falls through to the interactive `startOAuthFlow()` — **opening a browser on every cold start**.

## Fix

- **Defer token acquisition.** Construct the OAuth client synchronously at startup (no network) via a new `createGitLabOAuthClient`. The token resolves lazily on the first tool call (every call already passes through `ensureValidOAuthToken`), by which point the network is ready. `initializeOAuthClient` is kept and now delegates.
- **Always deliver the token (fixes #495 review feedback).** New testable helper `ensureOAuthToken(client, currentToken, onToken)`: the fast path requires a held token AND a valid stored token, so the first call after lazy startup populates the token even when the on-disk token is still valid. Token-script setups resolve exactly once.
- **Fast-fail refresh.** 10s `AbortSignal.timeout` on the refresh request.
- **Browser only when warranted.** `isAuthInvalidTokenResponse(status, body)` returns true only for 400/401 with `invalid_grant`/`invalid_token`. Transient and config errors propagate to the caller without a popup.

## Tests

- New `test/oauth-startup.test.ts` (14 cases): 8 classifier cases + 6 `ensureOAuthToken` cases (valid-cache delivery without network via closed-port URL, no re-delivery fast path, refresh + persist against a loopback `/oauth/token` mock, transient-failure propagation, token-script single resolution). Wired into the pure-unit group in `scripts/run-mock-tests.sh`.
- `npm run build` clean; full `npm run test:mock` green; `test-auth-retry` 19/19 and `oauth-device-flow` 22/22 still green.

## Behavior change

First tool call (instead of startup) opens the browser when no stored token exists; a transient refresh failure fails that call instead of popping a browser. Documented in `docs/configuration/environment-variables.md`.

---

Supersedes #495. Thanks to @medyas for the original fix — this PR carries it forward with the cached-token fix and regression tests from the review.
